### PR TITLE
#411 remove an extra slash from Remote API v1

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
@@ -776,7 +776,7 @@ public class RemoteApiController
      * Test when running in Eclipse: Open your browser, paste following URL with appropriate values:
      *
      * http://USERNAME:PASSWORD@localhost:8080/webanno-webapp/api/projects/{aProjectId}/curationdoc/
-     * { aSourceDocumentId}?format=xmi
+     * {aSourceDocumentId}?format=xmi
      * 
      * @param response
      *            HttpServletResponse.
@@ -790,7 +790,7 @@ public class RemoteApiController
      *             if there was an error.
      */
     @RequestMapping(
-            value = "/"+PROJECTS+"/{"+PARAM_PROJECT_ID+"}/"+CURATION+"/{"+PARAM_DOCUMENT_ID+"}/", 
+            value = "/"+PROJECTS+"/{"+PARAM_PROJECT_ID+"}/"+CURATION+"/{"+PARAM_DOCUMENT_ID+"}", 
             method = RequestMethod.GET)
     public void curationDocumentRead(HttpServletResponse response, 
             @PathVariable(PARAM_PROJECT_ID) long aProjectId,


### PR DESCRIPTION
This is for version 1 of API.

While version 2 is work in progress now, I still wanted to contribute this change, as this extra slash requirement returns an error if test this with CURL without explicitly adding the slash at the end.

It is inconsistent that this particular API endpoint needs the extra slash at the end, while all others don't.