### PR TITLE
Adding functionality for Clarin logo and HelpDesk button.

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.html
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.html
@@ -30,6 +30,50 @@
     <div class="pagetitle">
       <img class="pageicon" wicket:message="src:page.icon" />
       <img class="logo" src="assets/logo.png"  />
+      <a href="nothing" id="clarinLink" target="_blank"><img class="logo" id="clarinLogo" alt="Clarin site"/></a>
+      <input type="text" wicket:id="linksPresent" id="linksPresent" style="display:none;">
+      <input type="text" wicket:id="clarinLogoAddress" id="clarinLogoAddress" style="display:none;">
+      <input type="text" wicket:id="clarinSite" id="clarinSite" style="display:none;">
+      <a href="nothing" id="helpDeskLink" target="_blank"><img class="headerbutton" id="helpDeskLogo" alt="HelpDesk site"/></a>
+      <input type="text" wicket:id="linksHelpDeskPresent" id="linksHelpDeskPresent" style="display:none;">
+      <input type="text" wicket:id="helpDeskLogoAddress" id="helpDeskLogoAddress" style="display:none;">
+      <input type="text" wicket:id="helpDeskSite" id="helpDeskSite" style="display:none;">
+	  <script type="text/javascript">
+		document.getElementById('clarinLogo').src = getImage();
+		document.getElementById('clarinLink').href = getAddress();
+		document.getElementById('helpDeskLogo').src = getHelpDeskImage();
+		document.getElementById('helpDeskLink').href = getHelpDeskAddress();
+		
+		if (document.getElementById('linksPresent').value == "false")
+		{
+			document.getElementById('clarinLogo').style.display = 'none';
+		}
+		if (document.getElementById('linksHelpDeskPresent').value == "false")
+		{
+			document.getElementById('helpDeskLogo').style.display = 'none';
+		}
+		
+    	function getImage()
+    	{
+    		var elem = document.getElementById('clarinLogoAddress').value;
+    		return elem;
+    	}
+    	function getAddress()
+    	{
+    		var address = document.getElementById('clarinSite').value;
+    		return address;
+    	}
+    	function getHelpDeskImage()
+    	{
+    		var elem = document.getElementById('helpDeskLogoAddress').value;
+    		return elem;
+    	}
+    	function getHelpDeskAddress()
+    	{
+    		var address = document.getElementById('helpDeskSite').value;
+    		return address;
+    	}
+	  </script>
       <wicket:message key="page.title"></wicket:message>
     </div>
     <div class="menubar">

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -33,9 +33,11 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.link.PopupSettings;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.protocol.http.ClientProperties;
 import org.apache.wicket.protocol.http.WebSession;
@@ -190,6 +192,50 @@ public abstract class ApplicationPageBase
                 new ResourceModel("page.help", "")));
         helpLink.setPopupSettings(new PopupSettings("_blank"));
         helpLink.setVisible(helpAvailable);
+        
+        String areLinksPresent = "true";
+        
+        String imageAddress = settings.getProperty("clarin.logo.address");
+        String clarinLink = settings.getProperty("clarin.website");
+        
+        if (clarinLink == null || imageAddress  == null)
+        {
+        	areLinksPresent = "false";
+        }
+        
+        String areHelpDeskLinksPresent = "true";
+        
+        String imageHelpDeskAddress = settings.getProperty("helpdesk.logo.address");
+        String helpDeskLink = settings.getProperty("helpdesk.website");
+        
+        if (helpDeskLink == null || imageHelpDeskAddress  == null)
+        {
+        	areHelpDeskLinksPresent = "false";
+        }
+        
+        TextField<String> linksPresent = new TextField<String>("linksPresent");
+        add(linksPresent);
+        linksPresent.setModel(Model.of(areLinksPresent));
+        
+        TextField<String> clarinLogoAddress = new TextField<String>("clarinLogoAddress");
+        add(clarinLogoAddress);
+        clarinLogoAddress.setModel(Model.of(imageAddress));
+        
+        TextField<String> clarinSite = new TextField<String>("clarinSite");
+        add(clarinSite);
+        clarinSite.setModel(Model.of(clarinLink));
+        
+        TextField<String> linksHelpDeskPresent = new TextField<String>("linksHelpDeskPresent");
+        add(linksHelpDeskPresent);
+        linksHelpDeskPresent.setModel(Model.of(areHelpDeskLinksPresent));
+        
+        TextField<String> helpDeskLogoAddress = new TextField<String>("helpDeskLogoAddress");
+        add(helpDeskLogoAddress);
+        helpDeskLogoAddress.setModel(Model.of(imageHelpDeskAddress));
+        
+        TextField<String> helpDeskSite = new TextField<String>("helpDeskSite");
+        add(helpDeskSite);
+        helpDeskSite.setModel(Model.of(helpDeskLink));
         
         add(logoutPanel);
         add(feedbackPanel);

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/webanno.css
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/webanno.css
@@ -164,6 +164,14 @@ ul.vcheckboxgroup{
     height:64px;
 }
 
+.headerbutton{
+    margin:2px;
+	margin-left:5px;
+    float:right;
+    vertical-align:middle;
+    height:40px;
+}
+
 #spinner {
   display: none;
   position: fixed;


### PR DESCRIPTION
I have added a Clarin HelpDesk button and the Clarin logo to the page header dependent on the settings file, ie. the code checks for the properties "clarin.logo.address" and "clarin.website" for the Clarin logo, and "helpdesk.logo.address" and "helpdesk.website" for the HelpDesk button. If these are not present, then the HelpDesk button or Clarin logo simply does not show up and the user doesn't notice anything.