### PR TITLE
#486 - Refactoring project structure (3.3.0) 

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ChainAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ChainAdapter.java
@@ -23,7 +23,6 @@ import static org.apache.uima.fit.util.CasUtil.selectFS;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringStrategy.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringStrategy.java
@@ -162,7 +162,7 @@ public abstract class ColoringStrategy
                 filtered.add(color);
             }
         }
-        return (String[]) filtered.toArray(new String[filtered.size()]);
+        return filtered.toArray(new String[filtered.size()]);
     }
 
     public static boolean isTooLight(String aColor, int aThreshold)

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -379,14 +379,8 @@ public class LinkFeatureEditor
         List<LinkWithRoleModel> list = (List<LinkWithRoleModel>) LinkFeatureEditor.this
                 .getModelObject().value;
 
-        Iterator<LinkWithRoleModel> existingLinks = list.iterator();
-        while (existingLinks.hasNext()) {
-            LinkWithRoleModel link = existingLinks.next();
-            if (link.autoCreated && link.targetAddr == -1) {
-                // remove it
-                existingLinks.remove();
-            }
-        }
+        // remove it
+        list.removeIf(link -> link.autoCreated && link.targetAddr == -1);
     }
 
     private void autoAddImportantTags(List<Tag> aTagset, List<PossibleValue> aPossibleValues)

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/RelationRenderer.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/RelationRenderer.java
@@ -23,7 +23,6 @@ import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.selectCovered;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VCommentType.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VCommentType.java
@@ -21,5 +21,5 @@ public enum VCommentType
 {
     INFO,
     ERROR,
-    YIELD;
+    YIELD
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
@@ -399,7 +399,7 @@ public class WebAnnoCasUtil
     private static <T extends Annotation> FSIterator<T> seekByAddress(JCas aJcas, Class<T> aType,
             int aAddr)
     {
-        AnnotationIndex<T> idx = (AnnotationIndex) aJcas.getAnnotationIndex(JCasUtil
+        AnnotationIndex<T> idx = aJcas.getAnnotationIndex(JCasUtil
                 .getAnnotationType(aJcas, aType));
         return idx.iterator(selectByAddr(aJcas, aAddr));
     }
@@ -419,7 +419,7 @@ public class WebAnnoCasUtil
     private static <T extends Annotation> FSIterator<T> seekByFs(JCas aJcas, Class<T> aType,
             AnnotationFS aFS)
     {
-        AnnotationIndex<T> idx = (AnnotationIndex) aJcas.getAnnotationIndex(JCasUtil
+        AnnotationIndex<T> idx = aJcas.getAnnotationIndex(JCasUtil
                 .getAnnotationType(aJcas, aType));
         return idx.iterator(aFS);
     }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -864,7 +864,7 @@ public class AnnotationSchemaServiceImpl
     public List<TypeSystemDescription> getProjectTypes(Project aProject)
     {
         // Create a new type system from scratch
-        List<TypeSystemDescription> types = new ArrayList<TypeSystemDescription>();
+        List<TypeSystemDescription> types = new ArrayList<>();
         for (AnnotationLayer type : listAnnotationLayer(aProject)) {
             if (type.getType().equals(SPAN_TYPE) && !type.isBuiltIn()) {
                 TypeSystemDescription tsd = new TypeSystemDescription_impl();

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -817,7 +817,7 @@ public class DocumentServiceImpl
         // Bail out already. HQL doesn't seem to like queries with an empty
         // parameter right of "in"
         if (users.isEmpty()) {
-            return new ArrayList<AnnotationDocument>();
+            return new ArrayList<>();
         }
 
         return entityManager
@@ -878,7 +878,7 @@ public class DocumentServiceImpl
         // check if the username is in the Users database (imported projects
         // might have username
         // in the ProjectPermission entry while it is not in the Users database
-        List<String> notInUsers = new ArrayList<String>();
+        List<String> notInUsers = new ArrayList<>();
         for (String user : users) {
             if (!userRepository.exists(user)) {
                 notInUsers.add(user);

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectServiceImpl.java
@@ -290,7 +290,7 @@ public class ProjectServiceImpl
                                 + "project =:project ORDER BY user ASC", String.class)
                 .setParameter("project", aProject).getResultList();
 
-        List<User> users = new ArrayList<User>();
+        List<User> users = new ArrayList<>();
 
         for (String username : usernames) {
             if (userRepository.exists(username)) {
@@ -310,7 +310,7 @@ public class ProjectServiceImpl
                                 + "project =:project AND level =:level ORDER BY user ASC",
                         String.class).setParameter("project", aProject)
                 .setParameter("level", aPermissionLevel).getResultList();
-        List<User> users = new ArrayList<User>();
+        List<User> users = new ArrayList<>();
         for (String username : usernames) {
             if (userRepository.exists(username)) {
                 users.add(userRepository.get(username));
@@ -399,7 +399,7 @@ public class ProjectServiceImpl
                 .listFiles();
 
         // Name of the guideline files
-        List<String> annotationGuidelineFiles = new ArrayList<String>();
+        List<String> annotationGuidelineFiles = new ArrayList<>();
         if (files != null) {
             for (File file : files) {
                 annotationGuidelineFiles.add(file.getName());
@@ -570,7 +570,7 @@ public class ProjectServiceImpl
     @Override
     public List<Project> listAccessibleProjects(User user)
     {
-        List<Project> allowedProject = new ArrayList<Project>();
+        List<Project> allowedProject = new ArrayList<>();
         List<Project> allProjects = listProjects();
 
         // if global admin, show all projects
@@ -765,7 +765,7 @@ public class ProjectServiceImpl
 
         for (BeanDefinition bd : scanner.findCandidateComponents("de.tudarmstadt.ukp")) {
             try {
-                Class<?> clazz = (Class<?>) Class.forName(bd.getBeanClassName());
+                Class<?> clazz = Class.forName(bd.getBeanClassName());
                 ProjectType pt = clazz.getAnnotation(ProjectType.class);
 
                 if (projectTypes.stream().anyMatch(t -> t.id().equals(pt.id()))) {

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/SettingsServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/SettingsServiceImpl.java
@@ -17,13 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao;
 
-import java.sql.Connection;
-import java.sql.SQLException;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.hibernate.Session;
-import org.hibernate.jdbc.Work;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -410,33 +410,32 @@ public class BratAnnotationEditor
         aResponse.render(JavaScriptHeaderItem.forReference(BratVisualizerUiResourceReference.get()));
         aResponse.render(JavaScriptHeaderItem.forReference(BratAnnotatorUiResourceReference.get()));
         //aResponse.render(JavaScriptHeaderItem.forReference(BratUrlMonitorResourceReference.get()));
-        
-        StringBuilder script = new StringBuilder();
-        // REC 2014-10-18 - For a reason that I do not understand, the dispatcher cannot be a local
+
+	// REC 2014-10-18 - For a reason that I do not understand, the dispatcher cannot be a local
         // variable. If I put a "var" here, then communication fails with messages such as
         // "action 'openSpanDialog' returned result of action 'loadConf'" in the browsers's JS
         // console.
-        script.append("(function() {");
-        script.append("var dispatcher = new Dispatcher();");
-        // Each visualizer talks to its own Wicket component instance
-        script.append("dispatcher.ajaxUrl = '" + requestHandler.getCallbackUrl() + "'; ");
-        // We attach the JSON send back from the server to this HTML element
-        // because we cannot directly pass it from Wicket to the caller in ajax.js.
-        script.append("dispatcher.wicketId = '" + vis.getMarkupId() + "'; ");
-        script.append("var ajax = new Ajax(dispatcher);");
-        script.append("var visualizer = new Visualizer(dispatcher, '" + vis.getMarkupId() + "');");
-        script.append("var visualizerUI = new VisualizerUI(dispatcher, visualizer.svg);");
-        script.append("var annotatorUI = new AnnotatorUI(dispatcher, visualizer.svg);");
-        //script.append("var logger = new AnnotationLog(dispatcher);");
-        script.append("dispatcher.post('init');");
-        script.append("Wicket.$('" + vis.getMarkupId() + "').dispatcher = dispatcher;");
-        script.append("Wicket.$('" + vis.getMarkupId() + "').visualizer = visualizer;");
-        script.append("})();");
+        String script = "(function() {" +
+            "var dispatcher = new Dispatcher();" +
+	    // Each visualizer talks to its own Wicket component instance
+            "dispatcher.ajaxUrl = '" + requestHandler.getCallbackUrl() + "'; " +
+	    // We attach the JSON send back from the server to this HTML element
+	    // because we cannot directly pass it from Wicket to the caller in ajax.js.
+            "dispatcher.wicketId = '" + vis.getMarkupId() + "'; " +
+            "var ajax = new Ajax(dispatcher);" +
+            "var visualizer = new Visualizer(dispatcher, '" + vis.getMarkupId() + "');" +
+            "var visualizerUI = new VisualizerUI(dispatcher, visualizer.svg);" +
+            "var annotatorUI = new AnnotatorUI(dispatcher, visualizer.svg);" +
+	    //script.append("var logger = new AnnotationLog(dispatcher);");
+            "dispatcher.post('init');" +
+            "Wicket.$('" + vis.getMarkupId() + "').dispatcher = dispatcher;" +
+            "Wicket.$('" + vis.getMarkupId() + "').visualizer = visualizer;" +
+            "})();";
 
         // Must be OnDomReader so that this is rendered before all other Javascript that is
         // appended to the same AJAX request which turns the annotator visible after a document
         // has been chosen.
-        aResponse.render(OnDomReadyHeaderItem.forScript(script.toString()));
+        aResponse.render(OnDomReadyHeaderItem.forScript(script));
         
         // If the page is reloaded in the browser and a document was already open, we need
         // to render it. We use the "later" commands here to avoid polluting the Javascript

--- a/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/ConstraintsServiceImpl.java
+++ b/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/ConstraintsServiceImpl.java
@@ -217,17 +217,13 @@ public class ConstraintsServiceImpl
                     if (merged.getImports().containsKey(e.getKey()) && !e.getValue()
                             .equalsIgnoreCase(merged.getImports().get(e.getKey()))) {
                         // If detected, notify user with proper message and abort merging
-                        StringBuilder errorMessage = new StringBuilder();
-                        errorMessage.append("Conflict detected in imports for key \"");
-                        errorMessage.append(e.getKey());
-                        errorMessage.append("\", conflicting values are \"");
-                        errorMessage.append(e.getValue());
-                        errorMessage.append("\" & \"");
-                        errorMessage.append(merged.getImports().get(e.getKey()));
-                        errorMessage.append(
-                                "\". Please contact Project Admin for correcting this. Constraints feature may not work.");
-                        errorMessage.append("\nAborting Constraint rules merge!");
-                        throw new ParseException(errorMessage.toString());
+                        String errorMessage = "Conflict detected in imports for key \"" + e.getKey() +
+                            "\", conflicting values are \"" + e.getValue() +
+                            "\" & \"" + merged.getImports().get(e.getKey()) +
+                            "\". Please contact Project Admin for correcting this." +
+                            "Constraints feature may not work." +
+                            "\nAborting Constraint rules merge!";
+                        throw new ParseException(errorMessage);
                     }
                 }
                 merged.getImports().putAll(constraints.getImports());

--- a/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/evaluator/ValuesGenerator.java
+++ b/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/evaluator/ValuesGenerator.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.constraints.evaluator;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -205,14 +204,7 @@ public class ValuesGenerator
         List<AnnotationFS> covered = CasUtil.selectCovered(aJcas, type, aBegin, aEnd);
 
         // Remove all that do not have the exact same offset
-        Iterator<AnnotationFS> i = covered.iterator();
-        while (i.hasNext()) {
-            AnnotationFS cur = i.next();
-            if (!(cur.getBegin() == aBegin && cur.getEnd() == aEnd)) {
-                i.remove();
-            }
-        }
-
+        covered.removeIf(cur -> !(cur.getBegin() == aBegin && cur.getEnd() == aEnd));
         return covered;
     }
 

--- a/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/FSFPair.java
+++ b/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/FSFPair.java
@@ -86,12 +86,7 @@ public class FSFPair implements Serializable
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
-        builder.append("FSFPair [featureStructure=");
-        builder.append(featureStructure);
-        builder.append(", affectedFeature=");
-        builder.append(affectedFeature);
-        builder.append("]");
-        return builder.toString();
+        return "FSFPair [featureStructure=" + featureStructure +
+            ", affectedFeature=" + affectedFeature + "]";
     }
 }

--- a/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/ParsedConstraints.java
+++ b/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/ParsedConstraints.java
@@ -91,7 +91,7 @@ public class ParsedConstraints
     {
 
         if (scopeMap == null) { // initialize map if not set already
-            scopeMap = new HashMap<String, Scope>();
+            scopeMap = new HashMap<>();
             for (Scope scope : scopes) {
                 scopeMap.put(scope.getScopeName(), scope);
             }

--- a/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ScopeVisitor.java
+++ b/webanno-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ScopeVisitor.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.syntaxtree.ScopedDeclarations;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.visitor.GJVoidDepthFirst;
-import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Condition;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Rule;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Scope;
 /**

--- a/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/ComplexTypeTest.java
+++ b/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/ComplexTypeTest.java
@@ -20,18 +20,15 @@ package de.tudarmstadt.ukp.clarin.webanno.constraints;
 import static org.junit.Assert.*;
 
 import java.io.FileInputStream;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
-import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
-import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.Test;

--- a/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ParserVisitorTest.java
+++ b/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ParserVisitorTest.java
@@ -18,16 +18,12 @@
 package de.tudarmstadt.ukp.clarin.webanno.constraints.visitor;
 
 import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Test;
 
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.ConstraintsGrammar;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.syntaxtree.Parse;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.ParsedConstraints;
-import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Rule;
-import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Scope;
 
 public class ParserVisitorTest
 {

--- a/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ScopeVisitorTest.java
+++ b/webanno-constraints/src/test/java/de/tudarmstadt/ukp/clarin/webanno/constraints/visitor/ScopeVisitorTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.ConstraintsGrammar;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.grammar.syntaxtree.Parse;
-import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Rule;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.Scope;
 
 public class ScopeVisitorTest

--- a/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/agreement/AgreementUtils.java
+++ b/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/agreement/AgreementUtils.java
@@ -633,7 +633,7 @@ public class AgreementUtils
                     .unmodifiableList(new ArrayList<>(aIncompleteByLabel));
             pluralitySets = Collections
                     .unmodifiableList(new ArrayList<>(aPluralitySets));
-            casGroupIds = Collections.unmodifiableList(new ArrayList<String>(aCasGroupIds));
+            casGroupIds = Collections.unmodifiableList(new ArrayList<>(aCasGroupIds));
             excludeIncomplete = aExcludeIncomplete;
         }
         

--- a/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff2.java
+++ b/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff2.java
@@ -848,12 +848,8 @@ public class CasDiff2
         @Override
         public String toMinimalString()
         {
-            StringBuilder builder = new StringBuilder();
-            builder.append("(").append(sourceBegin).append('-').append(sourceEnd).append(')');
-            builder.append('[').append(sourceText).append(']');
-            builder.append(" -> (").append(targetBegin).append('-').append(targetEnd).append(')');
-            builder.append(" [").append(targetText).append(']');
-            return builder.toString();
+            return "(" + sourceBegin + '-' + sourceEnd + ')' + '[' + sourceText + ']' +
+                " -> (" + targetBegin + '-' + targetEnd + ')' + " [" + targetText + ']';
         }
     }
 
@@ -1656,12 +1652,12 @@ public class CasDiff2
         
         public <T extends TOP> SpanDiffAdapter(Class<T> aType, String... aLabelFeatures)
         {
-            this(aType.getName(), new HashSet<String>(asList(aLabelFeatures)));
+            this(aType.getName(), new HashSet<>(asList(aLabelFeatures)));
         }
         
         public SpanDiffAdapter(String aType, String... aLabelFeatures)
         {
-            this(aType, new HashSet<String>(asList(aLabelFeatures)));
+            this(aType, new HashSet<>(asList(aLabelFeatures)));
         }
         
         public SpanDiffAdapter(String aType, Set<String> aLabelFeatures)
@@ -1711,14 +1707,14 @@ public class CasDiff2
         public <T extends TOP> ArcDiffAdapter(Class<T> aType, String aSourceFeature, String aTargetFeature,
                 String... aLabelFeatures)
         {
-            this(aType.getName(), aSourceFeature, aTargetFeature, new HashSet<String>(
-                    asList(aLabelFeatures)));
+            this(aType.getName(), aSourceFeature, aTargetFeature, new HashSet<>(
+                asList(aLabelFeatures)));
         }
         
         public ArcDiffAdapter(String aType, String aSourceFeature, String aTargetFeature,
                 String... aLabelFeatures)
         {
-            this(aType, aSourceFeature, aTargetFeature, new HashSet<String>(asList(aLabelFeatures)));
+            this(aType, aSourceFeature, aTargetFeature, new HashSet<>(asList(aLabelFeatures)));
         }
         
         public ArcDiffAdapter(String aType, String aSourceFeature, String aTargetFeature,

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctor.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctor.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.diag;
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -304,7 +305,7 @@ public class CasDoctor
         Reflections reflections = new Reflections(Check.class.getPackage().getName());
         return reflections.getSubTypesOf(Check.class).stream()
                 .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                .sorted((a,b) -> a.getName().compareTo(b.getName()))
+                .sorted(Comparator.comparing(Class::getName))
                 .collect(Collectors.toList());
     }
 
@@ -313,7 +314,7 @@ public class CasDoctor
         Reflections reflections = new Reflections(Repair.class.getPackage().getName());
         return reflections.getSubTypesOf(Repair.class).stream()
                 .filter(c -> !Modifier.isAbstract(c.getModifiers()))
-                .sorted((a,b) -> a.getName().compareTo(b.getName()))
+                .sorted(Comparator.comparing(Class::getName))
                 .collect(Collectors.toList());
     }
 

--- a/webanno-dkprocore/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/SurfaceForm_Type.java
+++ b/webanno-dkprocore/src/main/java/de/tudarmstadt/ukp/dkpro/core/api/segmentation/type/SurfaceForm_Type.java
@@ -21,7 +21,6 @@ package de.tudarmstadt.ukp.dkpro.core.api.segmentation.type;
 
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.JCasRegistry;
-import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.cas.impl.FSGenerator;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.impl.TypeImpl;

--- a/webanno-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/SourceDocument.java
+++ b/webanno-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/SourceDocument.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
-import de.tudarmstadt.ukp.clarin.webanno.model.TrainDocumentState;
 
 /**
  * Source document information to be exported/imported

--- a/webanno-io-tei/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tei/TeiReader.java
+++ b/webanno-io-tei/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tei/TeiReader.java
@@ -523,7 +523,7 @@ public class TeiReader
         public void characters(char[] aCh, int aStart, int aLength)
             throws SAXException
         {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(aCh, aStart, aLength);
             if (captureText) {
                 if (isSpaceChar && !buffer.toString().isEmpty()) {

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv1Reader.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv1Reader.java
@@ -333,7 +333,7 @@ public class WebannoTsv1Reader
             Map<Integer, String> aTokensMap, Map<String, Token> aJcasTokens)
     {
 
-        Map<Integer, NamedEntity> indexedNeAnnos = new LinkedHashMap<Integer, NamedEntity>();
+        Map<Integer, NamedEntity> indexedNeAnnos = new LinkedHashMap<>();
 
         for (int i = 1; i <= aTokensMap.size(); i++) {
             if (aNamedEntityMap.get(i).equals("O")) {

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv3Reader.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv3Reader.java
@@ -735,7 +735,7 @@ public class WebannoTsv3Reader extends JCasResourceCollectionReader_ImplBase {
 					}
 					if (ft.startsWith(ROLE)) {
 						ft = ft.substring(5);
-						String t = layerTk.nextToken().toString();
+						String t = layerTk.nextToken();
 						columns++;
 						Type tType = CasUtil.getType(aJcas.getCas(), t);
 						String fName = ft.substring(0, ft.indexOf("_"));

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv3Writer.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv3Writer.java
@@ -246,7 +246,7 @@ public class WebannoTsv3Writer
 				annoType = CH;
 			}
 			IOUtils.write("#" + annoType + "=" + type + "|", docOS, encoding);
-			StringBuffer fsb = new StringBuffer();
+			StringBuilder fsb = new StringBuilder();
 			for (String feature : featurePerLayer.get(type)) {
 				if (fsb.length() < 1) {
 					fsb.append(feature);

--- a/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
+++ b/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
@@ -189,5 +189,5 @@ public class SourceDocument
         }
         return true;
     }
-	public static final Comparator<SourceDocument> NAME_COMPARATOR = (aO1, aO2) -> aO1.getName().compareTo(aO2.getName());
+	public static final Comparator<SourceDocument> NAME_COMPARATOR = Comparator.comparing(SourceDocument::getName);
 }

--- a/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/TrainingDocument.java
+++ b/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/TrainingDocument.java
@@ -199,11 +199,5 @@ public class TrainingDocument
 		this.feature = feature;
 	}
 
-	public static final Comparator<TrainingDocument> NAME_COMPARATOR = new Comparator<TrainingDocument>() {
-        @Override
-        public int compare(TrainingDocument aO1, TrainingDocument aO2)
-        {
-            return aO1.getName().compareTo(aO2.getName());
-        }
-    };
+	public static final Comparator<TrainingDocument> NAME_COMPARATOR = Comparator.comparing(TrainingDocument::getName);
 }

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
@@ -270,7 +270,7 @@ public class RemoteApiController
             JSONObject projectJSON = new JSONObject();
 
             for (ProjectPermission p : projectPermissions) {
-                permissionArr.put(p.getLevel().getName().toString());
+                permissionArr.put(p.getLevel().getName());
             }
             projectJSON.put(project.getName(), permissionArr);
             returnJSONObj.put(projectId, projectJSON);
@@ -763,7 +763,7 @@ public class RemoteApiController
             response.setContentType(mimeType);
             response.setContentType("application/force-download");
             response.setHeader("Content-Disposition",
-                    String.format("inline; filename=\"" + downloadableFile.getName() + "\""));
+                "inline; filename=\"" + downloadableFile.getName() + "\"");
             response.setContentLength((int) downloadableFile.length());
             InputStream inputStream = new BufferedInputStream(
                     new FileInputStream(downloadableFile));
@@ -894,8 +894,7 @@ public class RemoteApiController
             // Set response
             response.setContentType(mimeType);
             response.setContentType("application/force-download");
-            response.setHeader("Content-Disposition", String
-                    .format("inline; filename=\"" + downloadableFile.getName() + "\""));
+            response.setHeader("Content-Disposition", "inline; filename=\"" + downloadableFile.getName() + "\"");
             response.setContentLength((int) downloadableFile.length());
             InputStream inputStream = new BufferedInputStream(
                     new FileInputStream(downloadableFile));

--- a/webanno-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/ServerDetector.java
+++ b/webanno-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/ServerDetector.java
@@ -200,7 +200,7 @@ public class ServerDetector
             sd._jBoss = _detect(JBOSS_CLASS);
         }
 
-        return sd._jBoss.booleanValue();
+        return sd._jBoss;
     }
 
     public static boolean isJetty()

--- a/webanno-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialog.java
+++ b/webanno-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialog.java
@@ -21,8 +21,6 @@ import java.awt.EventQueue;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 
 import javax.swing.JDialog;
 import javax.swing.JFrame;

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/StyledComboBox.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/StyledComboBox.java
@@ -66,13 +66,11 @@ public class StyledComboBox<T>
                 // Some docs on how the templates work in Kendo, in case we need
                 // more fancy dropdowns
                 // http://docs.telerik.com/kendo-ui/framework/templates/overview
-                StringBuilder sb = new StringBuilder();
-                sb.append("# if (data.reordered == 'true') { #");
-                sb.append("<div title=\"#: data.description #\"><b>#: data.name #</b></div>\n");
-                sb.append("# } else { #");
-                sb.append("<div title=\"#: data.description #\">#: data.name #</div>\n");
-                sb.append("# } #");
-                return sb.toString();
+                return "# if (data.reordered == 'true') { #" +
+                    "<div title=\"#: data.description #\"><b>#: data.name #</b></div>\n" +
+                    "# } else { #" +
+                    "<div title=\"#: data.description #\">#: data.name #</div>\n" +
+                    "# } #";
             }
 
             @Override

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
@@ -131,7 +131,7 @@ public class PreferencesUtil
         throws FileNotFoundException, IOException
     {
         AnnotationPreference preference = aBModel.getPreferences();
-        ArrayList<Long> layers = new ArrayList<Long>();
+        ArrayList<Long> layers = new ArrayList<>();
 
         for (AnnotationLayer layer : aBModel.getAnnotationLayers()) {
             layers.add(layer.getId());

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/AnnotationPreferencesModalPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/AnnotationPreferencesModalPanel.java
@@ -23,7 +23,6 @@ import org.apache.wicket.extensions.ajax.markup.html.modal.ModalWindow;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotationPreference;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
@@ -91,7 +90,7 @@ public class AnnotationPreferencesModalPanel
                                 protected void onCancel(AjaxRequestTarget aTarget)
                                 {
                                     closeButtonClicked = true;
-                                };
+                                }
                             });
 
                     annotationLayerSelectionModal

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/ExportModalPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/ExportModalPanel.java
@@ -24,7 +24,6 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateImpl;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.dialog.ExportModalWindowPanel;
 

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/AnnotationPreferenceModalPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/AnnotationPreferenceModalPanel.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.dialog;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -136,9 +135,7 @@ public class AnnotationPreferenceModalPanel
            // add(curationWindowSizeField);
 
             List<Pair<String, String>> editorChoices = annotationEditorRegistry.getEditorFactories()
-                    .stream().map(f -> {
-                        return Pair.of(f.getBeanName(), f.getDisplayName());
-                    }).collect(Collectors.toList());
+                    .stream().map(f -> Pair.of(f.getBeanName(), f.getDisplayName())).collect(Collectors.toList());
             
             add(new DropDownChoice<Pair<String, String>>("editor", editorChoices,
                     new ChoiceRenderer<>("value"))

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/ExportModalWindowPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/ExportModalWindowPanel.java
@@ -249,7 +249,7 @@ public class ExportModalWindowPanel
 
     enum SELECTEXPORT
     {
-        AUTOMATED, ANNOTATED;
+        AUTOMATED, ANNOTATED
     }
 
 }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/OpenDocumentDialog.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/OpenDocumentDialog.java
@@ -72,7 +72,7 @@ public abstract class OpenDocumentDialog
             protected void onCancel(AjaxRequestTarget aInnerTarget)
             {
                 closeButtonClicked = true;
-            };
+            }
         });
         
         setWindowClosedCallback(new ModalWindow.WindowClosedCallback()

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
@@ -239,8 +239,8 @@ public class AutomationPage
 
         sidebarCell.add(detailEditor = createDetailEditor());
 
-        annotationEditor = new BratAnnotationEditor("mergeView", getModel(), detailEditor, 
-                () -> { return getEditorCas(); });
+        annotationEditor = new BratAnnotationEditor("mergeView", getModel(), detailEditor,
+            this::getEditorCas);
         annotationViewCell.add(annotationEditor);
 
         curationContainer = new CurationContainer();

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/project/ProjectMiraTemplatePanel.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/project/ProjectMiraTemplatePanel.java
@@ -63,7 +63,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Status;
 import de.tudarmstadt.ukp.clarin.webanno.model.TrainingDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.EntityModel;
-import de.tudarmstadt.ukp.clarin.webanno.ui.automation.util.AutomationException;
 import de.tudarmstadt.ukp.clarin.webanno.ui.automation.util.AutomationUtil;
 import de.tudarmstadt.ukp.clarin.webanno.ui.automation.util.TabSepDocModel;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanel;
@@ -216,13 +215,13 @@ public class ProjectMiraTemplatePanel
                 @Override
                 public void onSelectionChanged(AnnotationFeature aNewSelection)
                 {
-                    selectedFeature = (AnnotationFeature) aNewSelection;
+                    selectedFeature = aNewSelection;
                     if (automationService.existsMiraTemplate(selectedFeature)) {
                         template = automationService.getMiraTemplate(selectedFeature);
                     }
                     else {
                         template = new MiraTemplate();
-                        template.setTrainFeature((AnnotationFeature) aNewSelection);
+                        template.setTrainFeature(aNewSelection);
                     }
                     featureModel.setObject(selectedFeature);
                     miraTemplateDetailForm.setModelObject(template);
@@ -248,11 +247,11 @@ public class ProjectMiraTemplatePanel
 
         public TargetLaerDetailForm(String id)
         {
-            super(id, new CompoundPropertyModel<MiraTemplate>(new EntityModel<MiraTemplate>(
+            super(id, new CompoundPropertyModel<>(new EntityModel<>(
                     new MiraTemplate())));
 
-            List<ITab> tabs = new ArrayList<ITab>();
-            tabs.add(new AbstractTab(new Model<String>("Target layer"))
+            List<ITab> tabs = new ArrayList<>();
+            tabs.add(new AbstractTab(new Model<>("Target layer"))
             {
                 private static final long serialVersionUID = 6703144434578403272L;
 
@@ -263,7 +262,7 @@ public class ProjectMiraTemplatePanel
                 }
             });
 
-            tabs.add(new AbstractTab(new Model<String>("TAB-SEP target"))
+            tabs.add(new AbstractTab(new Model<>("TAB-SEP target"))
             {
                 private static final long serialVersionUID = 6703144434578403272L;
 
@@ -273,7 +272,7 @@ public class ProjectMiraTemplatePanel
                     return new FreeTabSepAsTargetDocumentsPanel(panelId);
                 }
             });
-            tabs.add(new AbstractTab(new Model<String>("Other layers"))
+            tabs.add(new AbstractTab(new Model<>("Other layers"))
             {
                 private static final long serialVersionUID = 6703144434578403272L;
 
@@ -284,7 +283,7 @@ public class ProjectMiraTemplatePanel
                 }
             });
 
-            tabs.add(new AbstractTab(new Model<String>("TAB-SEP feature"))
+            tabs.add(new AbstractTab(new Model<>("TAB-SEP feature"))
             {
                 private static final long serialVersionUID = 6703144434578403272L;
 
@@ -295,7 +294,7 @@ public class ProjectMiraTemplatePanel
                 }
             });
 
-            add(autoTabs = (AjaxTabbedPanel) new AjaxTabbedPanel<ITab>("autoTabs", tabs)
+            add(autoTabs = (AjaxTabbedPanel) new AjaxTabbedPanel<>("autoTabs", tabs)
                     .setOutputMarkupPlaceholderTag(true));
         }
     }
@@ -322,7 +321,7 @@ public class ProjectMiraTemplatePanel
 
             add(targetLayerTarinDocumentsPanel = new ProjectTrainingDocumentsPanel(
                     "targetLayerTarinDocumentsPanel", ProjectMiraTemplatePanel.this.getModel(),
-                    new Model<TabSepDocModel>(new TabSepDocModel(false, false)), featureModel)
+                    new Model<>(new TabSepDocModel(false, false)), featureModel)
             {
 
                 private static final long serialVersionUID = 7698999083009818310L;
@@ -363,7 +362,7 @@ public class ProjectMiraTemplatePanel
 
             add(otherLayerTarinDocumentsPanel = new ProjectTrainingDocumentsPanel(
                     "otherLayerTarinDocumentsPanel", ProjectMiraTemplatePanel.this.getModel(),
-                    new Model<TabSepDocModel>(new TabSepDocModel(false, false)),
+                    new Model<>(new TabSepDocModel(false, false)),
                     Model.of(otherLayerDetailForm.getModelObject().selectedFeatures))
             {
                 private static final long serialVersionUID = -4663938706290521594L;
@@ -388,7 +387,7 @@ public class ProjectMiraTemplatePanel
             super(id);
             add(freeTrainDocumentsPanel = new ProjectTrainingDocumentsPanel(
                     "freeTabSepAsFeatureDocumentsPanel", ProjectMiraTemplatePanel.this.getModel(),
-                    new Model<TabSepDocModel>(new TabSepDocModel(false, true)), featureModel)
+                    new Model<>(new TabSepDocModel(false, true)), featureModel)
             {
                 private static final long serialVersionUID = -4663938706290521594L;
 
@@ -413,7 +412,7 @@ public class ProjectMiraTemplatePanel
             super(id);
             add(freeTrainDocumentsPanel = new ProjectTrainingDocumentsPanel(
                     "freeTabSepAsTargetDocumentsPanel", ProjectMiraTemplatePanel.this.getModel(),
-                    new Model<TabSepDocModel>(new TabSepDocModel(true, true)), featureModel)
+                    new Model<>(new TabSepDocModel(true, true)), featureModel)
             {
                 private static final long serialVersionUID = -4663938706290521594L;
 
@@ -435,7 +434,7 @@ public class ProjectMiraTemplatePanel
 
         public MiraTemplateDetailForm(String id)
         {
-            super(id, new CompoundPropertyModel<MiraTemplate>(new EntityModel<MiraTemplate>(
+            super(id, new CompoundPropertyModel<>(new EntityModel<>(
                     new MiraTemplate())));
 
             add(new CheckBox("annotateAndRepeat"));
@@ -481,7 +480,7 @@ public class ProjectMiraTemplatePanel
 
         public OtherLayerDeatilForm(String id)
         {
-            super(id, new CompoundPropertyModel<SelectionModel>(new SelectionModel()));
+            super(id, new CompoundPropertyModel<>(new SelectionModel()));
 
             add(otherFeatures = new DropDownChoice<AnnotationFeature>("features")
             {
@@ -564,7 +563,7 @@ public class ProjectMiraTemplatePanel
                         @Override
                         protected List<AnnotationFeature> load()
                         {
-                            return new ArrayList<AnnotationFeature>(miraTemplateDetailForm
+                            return new ArrayList<>(miraTemplateDetailForm
                                     .getModelObject().getOtherFeatures());
                         }
                     });
@@ -758,15 +757,7 @@ public class ProjectMiraTemplatePanel
                         automationService.createAutomationStatus(automationStatus);
                         aTarget.appendJavaScript("alert('" + ExceptionUtils.getRootCause(e) + "')");
                     }
-                    catch (ClassNotFoundException e) {
-                        template.setAutomationStarted(false);
-                        automationStatus.setStatus(Status.INTERRUPTED);
-                        automationStatus.setEndTime(new Timestamp(new Date().getTime()));
-                        automationService.createTemplate(template);
-                        automationService.createAutomationStatus(automationStatus);
-                        aTarget.appendJavaScript("alert('" + e.getMessage() + "')");
-                    }
-                    catch (IOException e) {
+                    catch (ClassNotFoundException | IOException e) {
                         template.setAutomationStarted(false);
                         automationStatus.setStatus(Status.INTERRUPTED);
                         automationStatus.setEndTime(new Timestamp(new Date().getTime()));
@@ -775,14 +766,6 @@ public class ProjectMiraTemplatePanel
                         aTarget.appendJavaScript("alert('" + e.getMessage() + "')");
                     }
                     catch (AnnotationException e) {
-                        aTarget.appendJavaScript("alert('" + e.getMessage() + "')");
-                    }
-                    catch (AutomationException e) {
-                        template.setAutomationStarted(false);
-                        automationStatus.setStatus(Status.INTERRUPTED);
-                        automationStatus.setEndTime(new Timestamp(new Date().getTime()));
-                        automationService.createTemplate(template);
-                        automationService.createAutomationStatus(automationStatus);
                         aTarget.appendJavaScript("alert('" + e.getMessage() + "')");
                     }
                     // any other exception such as Memmory heap

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/project/ProjectTrainingDocumentsPanel.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/project/ProjectTrainingDocumentsPanel.java
@@ -83,7 +83,7 @@ public class ProjectTrainingDocumentsPanel
         feature = afeatureModel.getObject();
         if (aTabsDocModel.getObject().isTabSep()) {
             readableFormats = new ArrayList<>(
-                    Arrays.asList(new String[]{WebAnnoConst.TAB_SEP}));
+                    Arrays.asList(WebAnnoConst.TAB_SEP));
             selectedFormat = WebAnnoConst.TAB_SEP;
         }
         else {

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/util/AutomationUtil.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/util/AutomationUtil.java
@@ -37,7 +37,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -447,7 +446,7 @@ public class AutomationUtil
                     for (Sentence sentence : select(jCas, Sentence.class)) {
 
                         if (aFeature.getLayer().isMultipleTokens()) {
-                            annotations.addAll((List<String>) ((SpanAdapter) adapter)
+                            annotations.addAll(((SpanAdapter) adapter)
                                     .getMultipleAnnotation(sentence, aFeature).values());
                         }
                         else {
@@ -467,7 +466,7 @@ public class AutomationUtil
             JCas jCas = aRepository.readAnnotationCas(annodoc);
             for (Sentence sentence : select(jCas, Sentence.class)) {
                 if (aFeature.getLayer().isMultipleTokens()) {
-                    annotations.addAll((List<String>) ((SpanAdapter) adapter)
+                    annotations.addAll(((SpanAdapter) adapter)
                             .getMultipleAnnotation(sentence, aFeature).values());
                 }
                 else {
@@ -719,7 +718,7 @@ public class AutomationUtil
         StringBuffer sb = new StringBuffer();
 
         String tag = "";
-        List<String> annotations = new ArrayList<String>();
+        List<String> annotations = new ArrayList<>();
         Map<Integer, String> multAnno = null;
         if (aLayerFeature != null) {
             if (aLayerFeature.getLayer().isMultipleTokens()) {
@@ -1141,7 +1140,7 @@ public class AutomationUtil
         int beamSize = 0;
         boolean maxPosteriors = false;
         AnnotationFeature layerFeature = aTemplate.getTrainFeature();
-        List<List<String>> predictions = new ArrayList<List<String>>();
+        List<List<String>> predictions = new ArrayList<>();
 
         File miraDir = aAutomationService.getMiraDir(layerFeature);
         Mira mira = new Mira();
@@ -1284,7 +1283,7 @@ public class AutomationUtil
             mira.test(input, stream);
 
             LineIterator it = IOUtils.lineIterator(new FileReader(predcitedFile));
-            List<String> annotations = new ArrayList<String>();
+            List<String> annotations = new ArrayList<>();
 
             while (it.hasNext()) {
                 String line = it.next();
@@ -1337,7 +1336,7 @@ public class AutomationUtil
             }
 
             LineIterator it = IOUtils.lineIterator(new FileReader(predcitedFile));
-            List<String> annotations = new ArrayList<String>();
+            List<String> annotations = new ArrayList<>();
 
             while (it.hasNext()) {
                 String line = it.next();
@@ -1383,7 +1382,7 @@ public class AutomationUtil
 
         File miraDir = aAutomationService.getMiraDir(layerFeature);
         for (SourceDocument document : aRepository.listSourceDocuments(layerFeature.getProject())) {
-            List<List<String>> predictions = new ArrayList<List<String>>();
+            List<List<String>> predictions = new ArrayList<>();
                 File predFtFile = new File(miraDir, document.getId() + ".pred.ft");
                 Mira mira = new Mira();
                 int beamSize = 0;
@@ -1418,7 +1417,7 @@ public class AutomationUtil
         throws IOException
     {
         LineIterator it = IOUtils.lineIterator(new FileReader(aBaseFile));
-        StringBuffer trainBuffer = new StringBuffer();
+        StringBuilder trainBuffer = new StringBuilder();
         int i = 0;
         while (it.hasNext()) {
             String line = it.next();
@@ -1458,7 +1457,7 @@ public class AutomationUtil
         throws IOException
     {
         LineIterator it = IOUtils.lineIterator(new FileReader(apredFt));
-        StringBuffer predBuffer = new StringBuffer();
+        StringBuilder predBuffer = new StringBuilder();
         int i = 0;
         while (it.hasNext()) {
             String line = it.next();
@@ -1634,7 +1633,7 @@ public class AutomationUtil
 
             LOG.info("Prediction is wrtten to a MIRA File. To be done is writing back to the CAS");
             LineIterator it = IOUtils.lineIterator(new FileReader(predcitedFile));
-            List<String> annotations = new ArrayList<String>();
+            List<String> annotations = new ArrayList<>();
 
             while (it.hasNext()) {
                 String line = it.next();
@@ -1676,11 +1675,8 @@ public class AutomationUtil
     public static void clearAnnotations(JCas aJCas, Type aType)
         throws IOException
     {
-        List<AnnotationFS> annotationsToRemove = new ArrayList<AnnotationFS>();
-        for (AnnotationFS a : select(aJCas.getCas(), aType)) {
-            annotationsToRemove.add(a);
-
-        }
+        List<AnnotationFS> annotationsToRemove = new ArrayList<>();
+        annotationsToRemove.addAll(select(aJCas.getCas(), aType));
         for (AnnotationFS annotation : annotationsToRemove) {
             aJCas.removeFsFromIndexes(annotation);
         }

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -112,13 +112,13 @@ public abstract class WicketApplicationBase
                 ApplicationContext ctx = ApplicationContextProvider.getApplicationContext();
                 DocumentService repo = ctx.getBean(DocumentService.class);
                 MDC.put(Logging.KEY_REPOSITORY_PATH, repo.getDir().getAbsolutePath());
-            };
+            }
 
             @Override
             public void onEndRequest(RequestCycle cycle)
             {
                 MDC.remove(Logging.KEY_REPOSITORY_PATH);
-            };
+            }
         });
     }
 

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -26,7 +26,6 @@ import org.apache.wicket.Application;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.RuntimeConfigurationType;
 import org.apache.wicket.Session;
-import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.feedback.IFeedbackMessageFilter;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;

--- a/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
+++ b/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
@@ -235,7 +235,7 @@ public class CorrectionPage
         sidebarCell.add(detailEditor = createDetailEditor());
         
         annotationEditor = new BratAnnotationEditor("mergeView", getModel(), detailEditor,
-                () -> { return getEditorCas(); });
+            this::getEditorCas);
         annotationViewCell.add(annotationEditor);
 
         curationContainer = new CurationContainer();

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.java
@@ -244,7 +244,7 @@ public class CurationPanel
         sidebarCell.add(editor);
     
         annotationEditor = new BratAnnotationEditor("mergeView", new Model<>(bModel), editor,
-                () -> { return getEditorCas(); });
+            this::getEditorCas);
         // reset sentenceAddress and lastSentenceAddress to the orginal once
         annotationViewCell.add(annotationEditor);
     

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/SuggestionViewPanel.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/SuggestionViewPanel.java
@@ -591,15 +591,9 @@ public class SuggestionViewPanel
 
         List<ConfigurationSet> all = new ArrayList<>();
 
-        for (ConfigurationSet a : diff.getConfigurationSets()) {
-            all.add(a);
-        }
-        for (ConfigurationSet cfgSet : d) {
-            all.remove(cfgSet);
-        }
-        for (ConfigurationSet cfgSet : i) {
-            all.remove(cfgSet);
-        }
+        all.addAll(diff.getConfigurationSets());
+        all.removeAll(d);
+        all.removeAll(i);
 
         addSuggestionColor(bModel.getProject(), bModel.getMode(), jCases, annoStates, all, false, true);
 
@@ -631,7 +625,7 @@ public class SuggestionViewPanel
                     colors = new HashMap<>();
                     aSuggestionColors.put(u, colors);
                 }
-                
+
                 for (Configuration c : cs.getConfigurations(u)) {
 
                     FeatureStructure fs = c.getFs(u, aCasMap);
@@ -726,7 +720,7 @@ public class SuggestionViewPanel
                     sourceDocument, user);
             jCases.put(user.getUsername(), documentService.readAnnotationCas(annotationDocument));
             aAnnotationSelectionByUsernameAndAddress.put(CURATION_USER,
-                    new HashMap<Integer, AnnotationSelection>());
+                new HashMap<>());
         }
         else {
             // If this is a true CURATION then we get all the annotation documents from all the
@@ -747,7 +741,7 @@ public class SuggestionViewPanel
 
                     // cleanup annotationSelections
                     aAnnotationSelectionByUsernameAndAddress.put(username,
-                            new HashMap<Integer, AnnotationSelection>());
+                        new HashMap<>());
                 }
             }
         }

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.java
@@ -137,19 +137,18 @@ public class BratSuggestionVisualizer
         //aResponse.render(JavaScriptHeaderItem.forReference(BratUrlMonitorResourceReference.get()));
 	    
         // BRAT call to load the BRAT JSON from our collProvider and docProvider.
-        StringBuilder script = new StringBuilder();
-        script.append("Util.embedByURL(");
-        script.append("  '"+vis.getMarkupId()+"',");
-        script.append("  '"+collProvider.getCallbackUrl()+"', ");
-        script.append("  '"+docProvider.getCallbackUrl()+"', ");
-        script.append("  function(dispatcher) {");
-        script.append("    dispatcher.wicketId = '" + vis.getMarkupId() + "'; ");
-        script.append("    dispatcher.ajaxUrl = '" + controller.getCallbackUrl() + "'; ");
-        script.append("    var ajax = new Ajax(dispatcher);");
-        script.append("    var curation_mod = new CurationMod(dispatcher, '"+vis.getMarkupId()+"');");
-        script.append("    dispatcher.post('clearSVG', []);");
-        script.append("  });");
-        aResponse.render(OnLoadHeaderItem.forScript("\n" + script.toString()));
+        String script = "Util.embedByURL(" +
+            "  '" + vis.getMarkupId() + "'," +
+            "  '" + collProvider.getCallbackUrl() + "', " +
+            "  '" + docProvider.getCallbackUrl() + "', " +
+            "  function(dispatcher) {" +
+            "    dispatcher.wicketId = '" + vis.getMarkupId() + "'; " +
+            "    dispatcher.ajaxUrl = '" + controller.getCallbackUrl() + "'; " +
+            "    var ajax = new Ajax(dispatcher);" +
+            "    var curation_mod = new CurationMod(dispatcher, '" + vis.getMarkupId() + "');" +
+            "    dispatcher.post('clearSVG', []);" +
+            "  });";
+        aResponse.render(OnLoadHeaderItem.forScript("\n" + script));
 	}
 	
     @Override

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCas.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCas.java
@@ -308,8 +308,7 @@ public class MergeCas
         int end = ((AnnotationFS) fs).getEnd();
 
         List<FeatureStructure> fssAtThisPosition = new ArrayList<>();
-        CasUtil.selectCovered(aJCases.get(aUser).getCas(), t, begin, end)
-                .forEach(fssAtThisPosition::add);
+        fssAtThisPosition.addAll(CasUtil.selectCovered(aJCases.get(aUser).getCas(), t, begin, end));
 
         return fssAtThisPosition;
     }

--- a/webanno-ui-curation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCasTest.java
+++ b/webanno-ui-curation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCasTest.java
@@ -283,7 +283,7 @@ public class MergeCasTest {
 	@Test
 	public void simpleSpanNoDiffMultiFeatureTest() throws Exception {
 		TypeSystemDescription customeTypes = DiffUtils.createCustomTypeSystem(SPAN_TYPE, "webanno.custom.Opinion",
-				asList(new String[] { "aspect", "opinion" }), null);
+				asList("aspect", "opinion"), null);
 
 		Map<String, List<JCas>> casByUser = DiffUtils.loadWebAnnoTSV(customeTypes,
 				"mergecas/spanmultifeature/1sentenceNENoFeature.tsv",
@@ -316,7 +316,7 @@ public class MergeCasTest {
 	@Test
 	public void simpleSpanDiffMultiFeatureTest() throws Exception {
 		TypeSystemDescription customeTypes = DiffUtils.createCustomTypeSystem(SPAN_TYPE, "webanno.custom.Opinion",
-				asList(new String[] { "aspect", "opinion" }), null);
+				asList("aspect", "opinion"), null);
 
 		Map<String, List<JCas>> casByUser = DiffUtils.loadWebAnnoTSV(customeTypes,
 				"mergecas/spanmultifeature/1sentenceNEFeatureA.tsv",
@@ -439,10 +439,10 @@ public class MergeCasTest {
 	@Test
 	public void simpleRelGovStackedTest() throws Exception {
 		TypeSystemDescription customeTypesSpan = DiffUtils.createCustomTypeSystem(SPAN_TYPE,
-				"webanno.custom.Multivalspan", asList(new String[] { "f1", "f2" }), null);
+				"webanno.custom.Multivalspan", asList("f1", "f2"), null);
 
 		TypeSystemDescription customeTypesRel = DiffUtils.createCustomTypeSystem(RELATION_TYPE,
-				"webanno.custom.Multivalrel", asList(new String[] { "rel1", "rel2" }), "webanno.custom.Multivalspan");
+				"webanno.custom.Multivalrel", asList("rel1", "rel2"), "webanno.custom.Multivalspan");
 
 		List<TypeSystemDescription> customTypes = new ArrayList<>();
 		customTypes.add(customeTypesSpan);
@@ -480,10 +480,10 @@ public class MergeCasTest {
 	@Test
 	public void relStackedTest() throws Exception {
 		TypeSystemDescription customeTypesSpan = DiffUtils.createCustomTypeSystem(SPAN_TYPE,
-				"webanno.custom.Multivalspan", asList(new String[] { "f1", "f2" }), null);
+				"webanno.custom.Multivalspan", asList("f1", "f2"), null);
 
 		TypeSystemDescription customeTypesRel = DiffUtils.createCustomTypeSystem(RELATION_TYPE,
-				"webanno.custom.Multivalrel", asList(new String[] { "rel1", "rel2" }), "webanno.custom.Multivalspan");
+				"webanno.custom.Multivalrel", asList("rel1", "rel2"), "webanno.custom.Multivalspan");
 
 		List<TypeSystemDescription> customTypes = new ArrayList<>();
 		customTypes.add(customeTypesSpan);

--- a/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementTable.java
+++ b/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementTable.java
@@ -169,31 +169,29 @@ public class AgreementTable
                             else {
                                 label = String.format("%.2f", result.getAgreement());
                             }
-                            
-                            StringBuilder tooltipTitle = new StringBuilder();
-                            tooltipTitle.append(result.getCasGroupIds().get(0));
-                            tooltipTitle.append('/');
-                            tooltipTitle.append(result.getCasGroupIds().get(1));
-                            
-                            StringBuilder tooltipContent = new StringBuilder();
-                            tooltipContent.append("Positions annotated:\n");
-                            tooltipContent.append(String.format("- %s: %d/%d%n",
+
+                            String tooltipTitle = result.getCasGroupIds().get(0) +
+                                '/' +
+                                result.getCasGroupIds().get(1);
+
+                            String tooltipContent = "Positions annotated:\n" +
+                                String.format("- %s: %d/%d%n",
                                     result.getCasGroupIds().get(0),
                                     result.getNonNullCount(result.getCasGroupIds().get(0)),
-                                    result.getStudy().getItemCount()));
-                            tooltipContent.append(String.format("- %s: %d/%d%n",
+                                    result.getStudy().getItemCount()) +
+                                String.format("- %s: %d/%d%n",
                                     result.getCasGroupIds().get(1),
                                     result.getNonNullCount(result.getCasGroupIds().get(1)),
-                                    result.getStudy().getItemCount()));
-                            tooltipContent.append(String.format("Distinct labels used: %d%n",
-                                    result.getStudy().getCategoryCount()));
-                            
+                                    result.getStudy().getItemCount()) +
+                                String.format("Distinct labels used: %d%n",
+                                    result.getStudy().getCategoryCount());
+
                             Label l = new Label("label", Model.of(label)); 
                             cell.add(l);
                             l.add(makeDownloadBehavior(aRowItem.getModelObject(),
                                     aCellItem.getModelObject()));
                             DescriptionTooltipBehavior tooltip = new DescriptionTooltipBehavior(
-                                    tooltipTitle.toString(), tooltipContent.toString());
+                                tooltipTitle, tooltipContent);
                             tooltip.setOption("position", (Object) null);
                             l.add(tooltip);
                             l.add(new AttributeAppender("style", "cursor: pointer", ";"));
@@ -222,7 +220,7 @@ public class AgreementTable
                             
                             Label l = new Label("label", Model.of(label)); 
                             DescriptionTooltipBehavior tooltip = new DescriptionTooltipBehavior(
-                                    tooltipTitle.toString(), tooltipContent.toString());
+                                tooltipTitle, tooltipContent.toString());
                             tooltip.setOption("position", (Object) null);
                             l.add(tooltip);
                             l.add(new AttributeAppender("style", "cursor: help", ";"));

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ImportUtil.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ImportUtil.java
@@ -167,7 +167,7 @@ public class ImportUtil
         if (aImportedProjectSetting.getVersion() == 0) {
             // this is projects prior to version 2.0
             createV0TagSet(aProjecct, importedTagSets, aAnnotationService, user);
-            return new HashMap<String, AnnotationFeature>();
+            return new HashMap<>();
         }
         return createV1Layer(aProjecct, aImportedProjectSetting, aAnnotationService, user);
     }
@@ -177,14 +177,14 @@ public class ImportUtil
             AnnotationSchemaService aAnnotationService, User user)
         throws IOException
     {
-        List<String> posTags = new ArrayList<String>();
-        List<String> depTags = new ArrayList<String>();
-        List<String> neTags = new ArrayList<String>();
-        List<String> posTagDescriptions = new ArrayList<String>();
-        List<String> depTagDescriptions = new ArrayList<String>();
-        List<String> neTagDescriptions = new ArrayList<String>();
-        List<String> corefTypeTags = new ArrayList<String>();
-        List<String> corefRelTags = new ArrayList<String>();
+        List<String> posTags = new ArrayList<>();
+        List<String> depTags = new ArrayList<>();
+        List<String> neTags = new ArrayList<>();
+        List<String> posTagDescriptions = new ArrayList<>();
+        List<String> depTagDescriptions = new ArrayList<>();
+        List<String> neTagDescriptions = new ArrayList<>();
+        List<String> corefTypeTags = new ArrayList<>();
+        List<String> corefRelTags = new ArrayList<>();
         for (de.tudarmstadt.ukp.clarin.webanno.export.model.TagSet tagSet : importedTagSets) {
             switch (tagSet.getTypeName()) {
                 case WebAnnoConst.POS:
@@ -231,8 +231,8 @@ public class ImportUtil
             AnnotationSchemaService aAnnotationService, User aUser)
         throws IOException
     {
-        Map<String, AnnotationFeature> featuresMap = new HashMap<String, AnnotationFeature>();
-        Map<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationLayer, AnnotationLayer> layersMap = new HashMap<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationLayer, AnnotationLayer>();
+        Map<String, AnnotationFeature> featuresMap = new HashMap<>();
+        Map<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationLayer, AnnotationLayer> layersMap = new HashMap<>();
         for (de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationLayer exLayer : aImportedProjectSetting
                 .getLayers()) {
             if (aAnnotationService.existsLayer(exLayer.getName(), exLayer.getType(), aProject)) {
@@ -501,7 +501,7 @@ public class ImportUtil
             template.setCurrentLayer(exTemplate.isCurrentLayer());
             template.setResult("---");
             template.setTrainFeature(aFeatureMaps.get(exTemplate.getTrainFeature().getName()));
-            Set<AnnotationFeature> otherFeatures = new HashSet<AnnotationFeature>();
+            Set<AnnotationFeature> otherFeatures = new HashSet<>();
             if (exTemplate.getOtherFeatures() != null) {
                 for (de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature exOtherFeature : exTemplate
                         .getOtherFeatures()) {
@@ -735,7 +735,7 @@ public class ImportUtil
             aLayerToExLayer.put(aLayer, exLayer);
         }
 
-        List<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature> exFeatures = new ArrayList<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature>();
+        List<de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature> exFeatures = new ArrayList<>();
         for (AnnotationFeature feature : aAnnotationService.listAnnotationFeature(aLayer)) {
             de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature exFeature = new de.tudarmstadt.ukp.clarin.webanno.export.model.AnnotationFeature();
             exFeature.setDescription(feature.getDescription());
@@ -762,7 +762,7 @@ public class ImportUtil
                 exTagSet.setName(tagSet.getName());
                 exTagSet.setCreateTag(tagSet.isCreateTag());
 
-                List<de.tudarmstadt.ukp.clarin.webanno.export.model.Tag> exportedTags = new ArrayList<de.tudarmstadt.ukp.clarin.webanno.export.model.Tag>();
+                List<de.tudarmstadt.ukp.clarin.webanno.export.model.Tag> exportedTags = new ArrayList<>();
                 for (Tag tag : aAnnotationService.listTags(tagSet)) {
                     de.tudarmstadt.ukp.clarin.webanno.export.model.Tag exTag = new de.tudarmstadt.ukp.clarin.webanno.export.model.Tag();
                     exTag.setDescription(tag.getDescription());

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectCasDoctorPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectCasDoctorPanel.java
@@ -76,10 +76,10 @@ public class ProjectCasDoctorPanel
         Form<FormModel> form = new Form<>("casDoctorForm", PropertyModel.of(this, "formModel"));
         add(form);
 
-        form.add(new CheckBoxMultipleChoice<Class<? extends Repair>>("repairs",
-                PropertyModel.of(this, "formModel.repairs"),
-                CasDoctor.scanRepairs(),
-                new ChoiceRenderer<>("simpleName")).setPrefix("<div>").setSuffix("</div>"));
+        form.add(new CheckBoxMultipleChoice<>("repairs",
+            PropertyModel.of(this, "formModel.repairs"),
+            CasDoctor.scanRepairs(),
+            new ChoiceRenderer<>("simpleName")).setPrefix("<div>").setSuffix("</div>"));
         form.add(new LambdaAjaxButton<FormModel>("check", this::actionCheck));
         form.add(new LambdaAjaxButton<FormModel>("repair", this::actionRepair));
         form.add(createMessageSetsView());

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectConstraintsPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectConstraintsPanel.java
@@ -271,7 +271,7 @@ public class ProjectConstraintsPanel
         {
             super(aId);
 
-            add(new FileUploadField("uploads", PropertyModel.<List<FileUpload>> of(this, "uploads")));
+            add(new FileUploadField("uploads", PropertyModel.of(this, "uploads")));
             add(new Button("import", new StringResourceModel("label"))
             {
                 private static final long serialVersionUID = 1L;

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectExportPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectExportPanel.java
@@ -223,13 +223,9 @@ public class ProjectExportPanel
                 @Override
                 protected String load()
                 {
-                    StringBuilder fileName = new StringBuilder();
-                    fileName.append(ProjectExportForm.this.getModelObject().project.getName());
-                    fileName.append("_curated_documents_");
                     SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd_HHmm");
-                    fileName.append(fmt.format(new Date()));
-                    fileName.append(".zip");
-                    return fileName.toString();
+                    return ProjectExportForm.this.getModelObject().project.getName() +
+                        "_curated_documents_" + fmt.format(new Date()) + ".zip";
                 }
             }) {
                 private static final long serialVersionUID = 5630612543039605914L;
@@ -276,7 +272,7 @@ public class ProjectExportPanel
                     name += "_" + fmt.format(new Date()) + ".zip";
                     
                     return name;
-                };
+                }
             };
 
             fileGenerationProgress = new ProgressBar("progress", new ProgressionModel()

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectLayersPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectLayersPanel.java
@@ -449,7 +449,7 @@ public class ProjectLayersPanel
                 {
                     setVisible(StringUtils.isNotBlank(LayerDetailForm.this.getModelObject()
                             .getName()));
-                };
+                }
             });
             
             add(new TextArea<String>("description").setOutputMarkupPlaceholderTag(true));
@@ -492,7 +492,7 @@ public class ProjectLayersPanel
                 }
             });
 
-            attachTypes = (DropDownChoice<AnnotationLayer>) new DropDownChoice<AnnotationLayer>(
+            attachTypes = new DropDownChoice<AnnotationLayer>(
                     "attachType")
             {
                 private static final long serialVersionUID = -6705445053442011120L;
@@ -510,20 +510,20 @@ public class ProjectLayersPanel
 
                             if (LayerDetailForm.this.getModelObject().getId() > 0) {
                                 if (LayerDetailForm.this.getModelObject().getAttachType() == null) {
-                                    return new ArrayList<AnnotationLayer>();
+                                    return new ArrayList<>();
                                 }
 
                                 return Arrays.asList(LayerDetailForm.this.getModelObject()
                                         .getAttachType());
                             }
                             if (!layerType.equals(RELATION_TYPE)) {
-                                return new ArrayList<AnnotationLayer>();
+                                return new ArrayList<>();
                             }
 
-                            List<AnnotationLayer> attachTeypes = new ArrayList<AnnotationLayer>();
+                            List<AnnotationLayer> attachTeypes = new ArrayList<>();
                             // remove a span layer which is already used as attach type for the
                             // other
-                            List<AnnotationLayer> usedLayers = new ArrayList<AnnotationLayer>();
+                            List<AnnotationLayer> usedLayers = new ArrayList<>();
                             for (AnnotationLayer layer : allLayers) {
                                 if (layer.getAttachType() != null) {
                                     usedLayers.add(layer.getAttachType());
@@ -540,7 +540,7 @@ public class ProjectLayersPanel
                             return attachTeypes;
                         }
                     });
-                    setChoiceRenderer(new ChoiceRenderer<AnnotationLayer>("uiName"));
+                    setChoiceRenderer(new ChoiceRenderer<>("uiName"));
                 }
 
                 @Override
@@ -548,7 +548,7 @@ public class ProjectLayersPanel
                 {
                     setEnabled(LayerDetailForm.this.getModelObject().getId() == 0);
                     setNullValid(isVisible());
-                };
+                }
             };
             attachTypes.setOutputMarkupPlaceholderTag(true);
             add(attachTypes);
@@ -969,12 +969,12 @@ public class ProjectLayersPanel
         DropDownChoice<TagSet> tagSet;
         DropDownChoice<String> featureType;
         CheckBox required;
-        List<String> types = new ArrayList<String>();
+        List<String> types = new ArrayList<>();
 
         public FeatureDetailForm(String id)
         {
-            super(id, new CompoundPropertyModel<AnnotationFeature>(
-                    new EntityModel<AnnotationFeature>(new AnnotationFeature())));
+            super(id, new CompoundPropertyModel<>(
+                new EntityModel<>(new AnnotationFeature())));
 
             add(new Label("name")
             {
@@ -985,7 +985,7 @@ public class ProjectLayersPanel
                 {
                     setVisible(StringUtils.isNotBlank(FeatureDetailForm.this.getModelObject()
                             .getName()));
-                };
+                }
             });
             add(new TextField<String>("uiName").setRequired(true));
             add(new TextArea<String>("description").setOutputMarkupPlaceholderTag(true));
@@ -1013,7 +1013,7 @@ public class ProjectLayersPanel
             });
             add(new CheckBox("hideUnconstraintFeature"));
 
-            add(featureType = (DropDownChoice<String>) new DropDownChoice<String>("type")
+            add(featureType = new DropDownChoice<String>("type")
             {
                 private static final long serialVersionUID = 9029205407108101183L;
 
@@ -1039,7 +1039,7 @@ public class ProjectLayersPanel
                 protected void onConfigure()
                 {
                     setEnabled(FeatureDetailForm.this.getModelObject().getId() == 0);
-                };
+                }
             });
             featureType.add(new AjaxFormComponentUpdatingBehavior("change")
             {
@@ -1058,7 +1058,7 @@ public class ProjectLayersPanel
                 {
                     setOutputMarkupPlaceholderTag(true);
                     setOutputMarkupId(true);
-                    setChoiceRenderer(new ChoiceRenderer<TagSet>("name"));
+                    setChoiceRenderer(new ChoiceRenderer<>("name"));
                     setNullValid(true);
                     setChoices(new LoadableDetachableModel<List<TagSet>>()
                     {
@@ -1202,7 +1202,7 @@ public class ProjectLayersPanel
 
         public FeatureSelectionForm(String id)
         {
-            super(id, new CompoundPropertyModel<SelectionModel>(new SelectionModel()));
+            super(id, new CompoundPropertyModel<>(new SelectionModel()));
 
             add(feature = new ListChoice<AnnotationFeature>("feature")
             {
@@ -1280,7 +1280,7 @@ public class ProjectLayersPanel
                             .listAnnotationFeature(layerDetailForm.getModelObject());
                     if (CHAIN_TYPE.equals(layerDetailForm.getModelObject().getType())
                             && !layerDetailForm.getModelObject().isLinkedListBehavior()) {
-                        List<AnnotationFeature> filtered = new ArrayList<AnnotationFeature>();
+                        List<AnnotationFeature> filtered = new ArrayList<>();
                         for (AnnotationFeature f : features) {
                             if (!WebAnnoConst.COREFERENCE_RELATION_FEATURE.equals(f.getName())) {
                                 filtered.add(f);

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectTagSetsPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectTagSetsPanel.java
@@ -234,8 +234,8 @@ public class ProjectTagSetsPanel
             add(fileUpload = new FileUploadField("content", new Model()));
             add(importTagsetFormat = new DropDownChoice<>("importTagsetFormat",
                     new Model<>(selectedExporTagsetFormat),
-                    Arrays.asList(new String[]{ExportedTagSetConstant.JSON_FORMAT,
-                            ExportedTagSetConstant.TAB_FORMAT})));
+                    Arrays.asList(ExportedTagSetConstant.JSON_FORMAT,
+                        ExportedTagSetConstant.TAB_FORMAT)));
             overwriteTagsetFlag = new CheckBox("overwriteTagset", Model.of(Boolean.FALSE));
             add(overwriteTagsetFlag);
             add(new Button("import", new StringResourceModel("label"))

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectUsersPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectUsersPanel.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.project;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.wicket.AttributeModifier;
@@ -33,7 +32,6 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -284,8 +282,8 @@ public class ProjectUsersPanel
                         @Override
                         protected List<PermissionLevel> load()
                         {
-                            return Arrays.asList(new PermissionLevel[] { PermissionLevel.ADMIN,
-                                    PermissionLevel.CURATOR, PermissionLevel.USER });
+                            return Arrays.asList(PermissionLevel.ADMIN,
+                                PermissionLevel.CURATOR, PermissionLevel.USER);
                         }
 
                     });
@@ -357,8 +355,8 @@ public class ProjectUsersPanel
 
         public UserDetailForm(String id)
         {
-            super(id, new CompoundPropertyModel<SelectionModel>(new SelectionModel()));
-            TextField<String> filterText = new TextField<String>("userFilter");
+            super(id, new CompoundPropertyModel<>(new SelectionModel()));
+            TextField<String> filterText = new TextField<>("userFilter");
             
             add(filterText.setOutputMarkupPlaceholderTag(true));
             add(new Button("filterButton")
@@ -372,31 +370,29 @@ public class ProjectUsersPanel
                 }
             });
             
-            add(users = (CheckBoxMultipleChoice<User>) new CheckBoxMultipleChoice<User>("users",
-                    new LoadableDetachableModel<List<User>>()
-                    {
-                        private static final long serialVersionUID = 1L;
+            add(users = (CheckBoxMultipleChoice<User>) new CheckBoxMultipleChoice<>("users",
+                new LoadableDetachableModel<List<User>>()
+                {
+                    private static final long serialVersionUID = 1L;
 
-                        @Override
-                        protected List<User> load()
-                        {
-                            List<User> allUSers = userRepository.list();
-                            List<User> filteredUSers = new ArrayList<User>();
-                            allUSers.removeAll(projectRepository.listProjectUsersWithPermissions(
-                                    ProjectUsersPanel.this.getModelObject()));
-                            
-                            for (User user : allUSers) 
-                            {
-                                User current = user;
-                                if (current.getUsername().contains(filterText.getValue()))
-                            	{
-                                	filteredUSers.add(current);
-                            	}
+                    @Override
+                    protected List<User> load()
+                    {
+                        List<User> allUSers = userRepository.list();
+                        List<User> filteredUSers = new ArrayList<>();
+                        allUSers.removeAll(projectRepository.listProjectUsersWithPermissions(
+                            ProjectUsersPanel.this.getModelObject()));
+
+                        for (User user : allUSers) {
+                            User current = user;
+                            if (current.getUsername().contains(filterText.getValue())) {
+                                filteredUSers.add(current);
                             }
-                            
-                            return filteredUSers;
                         }
-                    }, new ChoiceRenderer<User>("username", "username")));
+
+                        return filteredUSers;
+                    }
+                }, new ChoiceRenderer<>("username", "username")));
             users.setSuffix("<br>");
 
             add(new Button("add")


### PR DESCRIPTION
- Remove unnecessary unboxing
- Collapse redundant catch blocks
- Simplify comperator using Comperator.comparing
- Replace loop with Collection.removeIf()
- Replace anonymous type with lambda
- Replace lambda with method reference
- Remove redundant String.toString()
- Remove redundant String.format()
- Replace StringBuffer with String
- Use bulk operation instead of iteration
- Remove unnecessary array creation
- Remove redundant casts
- Remove explicit type argument
- Remove unnecessary import
- Remove unnecessary semicolon
- Format lines for better readability
- Inline unnecessary variable