### PR TITLE
Bug when creating a layer with a name from the dropdown

### DIFF
--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectLayersPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectLayersPanel.java
@@ -429,7 +429,7 @@ public class ProjectLayersPanel
 
             final Project project = ProjectLayersPanel.this.getModelObject();
             add(uiName = (TextField<String>) new TextField<String>("uiName").setRequired(true));
-            uiName.add(new AjaxFormComponentUpdatingBehavior("keyup")
+            uiName.add(new AjaxFormComponentUpdatingBehavior("input")
             {
                 private static final long serialVersionUID = -1756244972577094229L;
 


### PR DESCRIPTION
When one wants to create a new layer and clicks in the layer-name-field and selects from the
drop-down-list, which shows the previously typed in layer-names, an exception gets thrown or the application complains that this layer already exists although it doesn't.

The problem is that the the layer-name-field only gets triggered on an keyup-  instead on an input-event.