### PR TITLE
Morphological features and layer name display optimizations

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/TypeUtil.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/TypeUtil.java
@@ -67,8 +67,10 @@ public final class TypeUtil
             return bratLabelText.toString();
         }
         else {
-            // If there are no label features at all, then use the layer UI name
-            return "(" + aAdapter.getLayer().getUiName() + ")";
+            // If there are no label features at all, then return the empty string. This avoids
+            // NPEs in the coloring strategy, saves a few characters in the brat JSON ("" vs null)
+            // and still causes the brat UI JS to fall back to the layer name.
+            return "";
         }
     }
     

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectInitializer.java
@@ -35,6 +35,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
@@ -100,6 +101,8 @@ class ProjectInitializer
         createSemArgLayer(aProject);
         
         createSemPredLayer(aProject);
+        
+        createMorphologicalFeaturesLayer(aProject);
 
         // Extra tagsets
         JsonImportUtil.importTagSetFromJson(aProject,
@@ -295,6 +298,30 @@ class ProjectInitializer
         annotationSchemaService.createFeature(lemmaFeature);
     }
 
+    private void createMorphologicalFeaturesLayer(Project aProject)
+            throws IOException
+    {
+        AnnotationLayer tokenLayer = annotationSchemaService.getLayer(Token.class.getName(),
+                aProject);
+        AnnotationFeature tokenMorphFeature = createFeature("morph", "morph", aProject, tokenLayer,
+                Lemma.class.getName());
+        tokenMorphFeature.setVisible(true);
+
+        AnnotationLayer morphLayer = new AnnotationLayer(MorphologicalFeatures.class.getName(),
+                "Morphological features", SPAN_TYPE, aProject, true);
+        morphLayer.setAttachType(tokenLayer);
+        morphLayer.setAttachFeature(tokenMorphFeature);
+        annotationSchemaService.createLayer(morphLayer);
+
+        AnnotationFeature valueFeature = new AnnotationFeature();
+        valueFeature.setDescription("Morphological features");
+        valueFeature.setName("value");
+        valueFeature.setType(CAS.TYPE_NAME_STRING);
+        valueFeature.setProject(aProject);
+        valueFeature.setUiName("Features");
+        valueFeature.setLayer(morphLayer);
+        annotationSchemaService.createFeature(valueFeature);
+    }
     private AnnotationLayer createCorefLayer(Project aProject, TagSet aCorefTypeTags,
             TagSet aCorefRelTags)
         throws IOException

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ProjectInitializer.java
@@ -293,7 +293,7 @@ class ProjectInitializer
         lemmaFeature.setName("value");
         lemmaFeature.setType(CAS.TYPE_NAME_STRING);
         lemmaFeature.setProject(aProject);
-        lemmaFeature.setUiName("Lemma value");
+        lemmaFeature.setUiName("Lemma");
         lemmaFeature.setLayer(lemmaLayer);
         annotationSchemaService.createFeature(lemmaFeature);
     }
@@ -320,6 +320,8 @@ class ProjectInitializer
         valueFeature.setProject(aProject);
         valueFeature.setUiName("Features");
         valueFeature.setLayer(morphLayer);
+        valueFeature.setIncludeInHover(true);
+        valueFeature.setVisible(false);
         annotationSchemaService.createFeature(valueFeature);
     }
     private AnnotationLayer createCorefLayer(Project aProject, TagSet aCorefTypeTags,
@@ -354,7 +356,7 @@ class ProjectInitializer
         AnnotationFeature neFeature = createFeature("value", "value", "Named entity type",
                 CAS.TYPE_NAME_STRING, aTagset, aProject);
 
-        AnnotationLayer neLayer = new AnnotationLayer(NamedEntity.class.getName(), "Named Entity",
+        AnnotationLayer neLayer = new AnnotationLayer(NamedEntity.class.getName(), "Named entity",
                 SPAN_TYPE, aProject, true);
         neLayer.setAllowStacking(true);
         neLayer.setMultipleTokens(true);

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
@@ -375,4 +375,34 @@ public class BratRenderer
         }
         return bratTypeName;
     }
+    
+    public static String abbreviate(String aName)
+    {
+        if (aName == null || aName.length() < 3) {
+            return aName;
+        }
+        
+        StringBuilder abbr = new StringBuilder();
+        int ti = 0;
+        boolean capitalizeNext = true;
+        for (int i = 0; i < aName.length(); i++) {
+            int ch = aName.charAt(i);
+            
+            if (Character.isWhitespace(ch)) {
+                capitalizeNext = true;
+                ti = 0;
+            }
+            else {
+                if (ti < 3) {
+                    if (capitalizeNext) {
+                        ch = Character.toTitleCase(ch);
+                        capitalizeNext = false;
+                    }
+                    abbr.append((char) ch);
+                }
+                ti ++;
+            }
+        }
+        return abbr.toString();
+    }
 }

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/EntityType.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/EntityType.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.brat.render.model;
 
-import java.util.Arrays;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.render.BratRenderer.abbreviate;
+import static java.util.Arrays.asList;
+
 import java.util.List;
 
 /**
@@ -67,8 +69,8 @@ public class EntityType
     {
         this(aName /* name */, aType /* type */, true /* unused */, "" /* hotkey */,
                 null /* fgColor */, null /* bgColor */, null /* borderColor */,
-                Arrays.asList(aLabel) /* labels */, null /* children */, null /* attributes */, 
-                null /* arcs */);
+                asList(aLabel, abbreviate(aLabel)) /* labels */, null /* children */,
+                null /* attributes */, null /* arcs */);
     }
     
 //    public EntityType(String aName, String aType, String aFgColor, String aBgColor,

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/RelationType.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/RelationType.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.brat.render.model;
 
-import java.util.Arrays;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.render.BratRenderer.abbreviate;
+import static java.util.Arrays.asList;
+
 import java.util.List;
 
 /**
@@ -66,7 +68,8 @@ public class RelationType
     public RelationType(String aName, String aLabel, String aType, String aTarget, String aColor,
             String aArrowHead, String aDashArray)
     {
-        this(aColor, aArrowHead, Arrays.asList(aLabel), aType, Arrays.asList(aTarget), aDashArray);
+        this(aColor, aArrowHead, asList(aLabel, abbreviate(aLabel)), aType, asList(aTarget),
+                aDashArray);
     }
     
     private RelationType(String aColor, String aArrowHead, List<String> aLabels, String aType,

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer.js
@@ -1084,6 +1084,11 @@ var Visualizer = (function($, window, undefined) {
                 labelIdx++;
               }
             }
+            
+// WEBANNO EXTENSION BEGIN - #709 - Optimize render data size for annotations without labels
+              fragment.labelText = "(" + fragment.labelText + ")";
+// WEBANNO EXTENSION END - #709 - Optimize render data size for annotations without labels
+            
 // WEBANNO EXTENSION BEGIN - #820 - Allow setting label/color individually
             if (fragment.span.labelText) {
             	fragment.labelText = fragment.span.labelText;
@@ -2738,6 +2743,10 @@ Util.profileStart('arcs');
                   labelIdx++;
                 }
               }
+              
+// WEBANNO EXTENSION BEGIN - #709 - Optimize render data size for annotations without labels
+              labelText = "(" + labelText + ")";
+// WEBANNO EXTENSION END - #709 - Optimize render data size for annotations without labels
 
 // WEBANNO EXTENSION BEGIN - #820 - Allow setting label/color individually
               if (arc.eventDescId && data.eventDescs[arc.eventDescId]) {

--- a/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/LayerNameAbbreviationTest.java
+++ b/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/LayerNameAbbreviationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.render.model;
+
+import static de.tudarmstadt.ukp.clarin.webanno.brat.render.BratRenderer.abbreviate;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LayerNameAbbreviationTest
+{
+    @Test
+    public void test()
+    {
+        assertEquals("Dep", abbreviate("Dependency"));
+        assertEquals("MorFea", abbreviate("Morphological features"));
+        assertEquals("SemArg", abbreviate("Semantic argument"));
+        assertEquals("OneTwoThr", abbreviate("One two three"));
+        assertEquals("FooOfLal", abbreviate("Foo of Lala"));
+    }
+}


### PR DESCRIPTION
Includes fixes for:

* #708 - Support morphological features from CoNLL formats
* #709 - Optimize render data size for annotations without labels
* #720 - Automatically abbreviate long layer names in annotations