### PR TITLE
#724 - Cross-row selection is jumpy

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -360,6 +360,16 @@ var AnnotatorUI = (function($, window, undefined) {
           startArcDrag(id);
           return false;
         }
+// BEGIN WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
+        // If user starts selecting text, suppress all pointer events on annotations to
+        // avoid the selection jumping around. During selection, we don't need the annotations
+        // to react on mouse events anyway.
+        if (target.attr('data-chunk-id')) {
+          $(svgElement).children('.row, .sentnum').each(function(index, row) {
+            $(row).css('pointer-events', 'none');
+          });
+        }
+// END WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
       };
 
       var onMouseMove = function(evt) {
@@ -1678,6 +1688,15 @@ var AnnotatorUI = (function($, window, undefined) {
       var onMouseUp = function(evt) {
         if (that.user === null) return;
 
+// BEGIN WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
+        // Restore pointer events on annotations
+        if (dragStartedAt && $(dragStartedAt.target).attr('data-chunk-id')) {
+          $(svgElement).children('.row, .sentnum').each(function(index, row) {
+            $(row).css('pointer-events', 'auto');
+          });
+        }
+// END WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
+
         var target = $(evt.target);
 
         // three things that are clickable in SVG
@@ -1791,6 +1810,7 @@ var AnnotatorUI = (function($, window, undefined) {
           }
           
 // BEGIN WEBANNO EXTENSION - #316 Text selection behavior while dragging mouse
+// BEGIN WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
           if (focusNode && anchorNode && focusNode[0] == anchorNode[0] && focusNode.hasClass('spacing')) {
             if (evt.shiftKey) {
               if (anchorOffset == 0) {
@@ -1822,6 +1842,10 @@ var AnnotatorUI = (function($, window, undefined) {
                 anchorOffset = 0;
                 chunkIndexFrom = anchorNode.attr('data-chunk-id');
               }
+              else if (anchorNode.hasClass('row-initial')) {
+                anchorNode = anchorNode.next();
+                anchorOffset = 0;
+              }
               else {
                 anchorNode = anchorNode.prev();
                 anchorOffset = anchorNode.text().length;
@@ -1833,12 +1857,17 @@ var AnnotatorUI = (function($, window, undefined) {
                 focusOffset = 0;
                 chunkIndexTo = focusNode.attr('data-chunk-id');
               }
+              else if (focusNode.hasClass('row-initial')) {
+                focusNode = focusNode.next();
+                focusOffset = 0;
+              }
               else {
                 focusNode = focusNode.prev();
                 focusOffset = focusNode.text().length;
               }
             }
           }
+// END WEBANNO EXTENSION - #724 - Cross-row selection is jumpy
 // END WEBANNO EXTENSION - #316 Text selection behavior while dragging mouse
 
           if (chunkIndexFrom !== undefined && chunkIndexTo !== undefined) {

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/annotator_ui.js
@@ -1747,12 +1747,6 @@ var AnnotatorUI = (function($, window, undefined) {
 /*
           var chunkIndexFrom = sel.anchorNode && $(sel.anchorNode.parentNode).attr('data-chunk-id');
           var chunkIndexTo = sel.focusNode && $(sel.focusNode.parentNode).attr('data-chunk-id');
- */
-          var anchorNode = sel.anchorNode && $(sel.anchorNode).closest('*[data-chunk-id]');
-          var focusNode = sel.focusNode && $(sel.focusNode).closest('*[data-chunk-id]');
-          var chunkIndexFrom = anchorNode && anchorNode.attr('data-chunk-id');
-          var chunkIndexTo = focusNode && focusNode.attr('data-chunk-id');
-// END WEBANNO EXTENSION - #316 Text selection behavior while dragging mouse
           
           // fallback for firefox (at least):
           // it's unclear why, but for firefox the anchor and focus
@@ -1808,6 +1802,36 @@ var AnnotatorUI = (function($, window, undefined) {
             anchorOffset = sel.anchorOffset;
             focusOffset = sel.focusOffset;
           }
+ */
+          // Try getting anchor and focus node via the selection itself. This works in Chrome and
+          // Safari.
+          var anchorNode = sel.anchorNode && $(sel.anchorNode).closest('*[data-chunk-id]');
+          var anchorOffset = sel.anchorOffset;
+          var focusNode = sel.focusNode && $(sel.focusNode).closest('*[data-chunk-id]');
+          var focusOffset = sel.focusOffset;
+          
+          // If using the selection was not successful, try using the ranges instead. This should
+          // work on Firefox.
+          if (!anchorNode[0] || !focusNode[0]) {
+            anchorNode = $(sel.getRangeAt(0).startContainer).closest('*[data-chunk-id]');
+            anchorOffset = sel.getRangeAt(0).startOffset;
+            focusNode = $(sel.getRangeAt(sel.rangeCount - 1).endContainer).closest('*[data-chunk-id]');
+            focusOffset = sel.getRangeAt(sel.rangeCount - 1).endOffset;
+          }
+          
+          // If neither approach worked, give up.
+          if (!anchorNode[0] || !focusNode[0]) {
+            console.error("Unable to locate start/end chunks");
+            clearSelection();
+            stopArcDrag(target);
+            return;
+          }
+          
+          var chunkIndexFrom = anchorNode && anchorNode.attr('data-chunk-id');
+          var chunkIndexTo = focusNode && focusNode.attr('data-chunk-id');
+          
+// END WEBANNO EXTENSION - #316 Text selection behavior while dragging mouse
+          
           
 // BEGIN WEBANNO EXTENSION - #316 Text selection behavior while dragging mouse
 // BEGIN WEBANNO EXTENSION - #724 - Cross-row selection is jumpy


### PR DESCRIPTION
- Add spacers between rows
- Add spacers at beginning and end of rows
- Always render using SVG text elements, even in LTR mode to avoid maintaining two different rendering branches
- Disable pointer events on unrelevant areas during text selection