### PR TITLE
#752 - New annotation layers start out hidden

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotationPreference.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotationPreference.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +46,11 @@ public class AnnotationPreference
     public static final int SIDEBAR_SIZE_DEFAULT = 20;
     
     // Id of annotation layers, to be stored in the properties file comma separated: 12, 34,....
+    @Deprecated
     private List<Long> annotationLayers;
+    
+    // Id of annotation layers, to be stored in the properties file comma separated: 12, 34,....
+    private List<Long> hiddenAnnotationLayerIds = new ArrayList<>();
 
     private int windowSize;
 
@@ -61,7 +67,7 @@ public class AnnotationPreference
     private boolean staticColor = true; // this is only here to not break previous user settings,
                                         // its not an option that can be set anymore
 
-    private Map<Long, ColoringStrategyType> colorPerLayer;
+    private Map<Long, ColoringStrategyType> colorPerLayer = new HashMap<>();
 
     private ReadonlyColoringBehaviour readonlyLayerColoringBehaviour = 
             ReadonlyColoringBehaviour.LEGACY;
@@ -71,14 +77,35 @@ public class AnnotationPreference
     
     private String editor;
 
+    /**
+     * working with preferred layers is deprecated, use hidden layers instead
+     * @return
+     */
+    @Deprecated
     public List<Long> getAnnotationLayers()
     {
         return annotationLayers;
     }
-
+    
+    /**
+     * working with preferred layers is deprecated, use hidden layers instead 
+     * 
+     * @param aAnnotationLayers
+     */
+    @Deprecated()
     public void setAnnotationLayers(List<Long> aAnnotationLayers)
     {
         annotationLayers = aAnnotationLayers;
+    }
+    
+    public List<Long> getHiddenAnnotationLayerIds()
+    {
+        return hiddenAnnotationLayerIds;
+    }
+    
+    public void setHiddenAnnotationLayerIds(List<Long> aAnnotationLayerIds)
+    {
+        hiddenAnnotationLayerIds = aAnnotationLayerIds;
     }
 
     /**

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
@@ -120,32 +120,22 @@ public class PreferencesUtil
                     .listAnnotationLayer(aBModel.getProject()).stream()
                     .filter(l -> l.isEnabled())// only allow enabled layers
                     .collect(Collectors.toList());
-                        
-            if (preference.getAnnotationLayers() != null) {
-                List<Long> prefferedLayerIds = preference.getAnnotationLayers();
-                enabledLayers = enabledLayers.stream()
-                        .filter(l -> prefferedLayerIds.contains(l.getId()))
-                        .collect(Collectors.toList());
-            } else {
-                preference.setAnnotationLayers(
-                        enabledLayers.stream()
-                        .map(l -> l.getId())
-                        .collect(Collectors.toList()));
-            }
+          
+            List<Long> hiddenLayerIds = preference.getHiddenAnnotationLayerIds();
+            enabledLayers = enabledLayers.stream()
+                    .filter(l -> !hiddenLayerIds.contains(l.getId()))
+                    .collect(Collectors.toList());
+          
             aBModel.setAnnotationLayers(enabledLayers);
             
             // Get color preferences for each layer, init with legacy if not found
             Map<Long, ColoringStrategyType> colorPerLayer = preference.getColorPerLayer();
-            if (colorPerLayer == null) {
-                colorPerLayer = new HashMap<>();
-            }
             for (AnnotationLayer layer : aAnnotationService
                     .listAnnotationLayer(aBModel.getProject())) {
                 if (!colorPerLayer.containsKey(layer.getId())) {
                     colorPerLayer.put(layer.getId(), ColoringStrategyType.LEGACY);
                 }
             }
-            preference.setColorPerLayer(colorPerLayer);
 
         }
         // no preference found
@@ -156,10 +146,6 @@ public class PreferencesUtil
                     .listAnnotationLayer(aBModel.getProject()).stream()
                     .filter(l -> l.isEnabled())// only allow enabled layers
                     .collect(Collectors.toList()); 
-            preference.setAnnotationLayers(
-                        enabledLayers.stream()
-                        .map(l -> l.getId())
-                        .collect(Collectors.toList()));
             aBModel.setAnnotationLayers(enabledLayers);
             
             preference.setWindowSize(aSettingsService.getNumberOfSentences());

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/AnnotationPreferencesDialogContent.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/dialog/AnnotationPreferencesDialogContent.java
@@ -225,10 +225,10 @@ public class AnnotationPreferencesDialogContent
         AnnotationPreference prefs = state.getPreferences();
         Preferences model = form.getModelObject();
 
-        List<Long> preferredLayerIds = state.getPreferences().getAnnotationLayers();
+        List<Long> hiddenLayerIds = state.getPreferences().getHiddenAnnotationLayerIds();
         state.setAnnotationLayers(
                 model.annotationLayers.stream()
-                .filter(l -> preferredLayerIds.contains(l.getId()))
+                .filter(l -> !hiddenLayerIds.contains(l.getId()))
                 .collect(Collectors.toList()));
 
         prefs.setScrollPage(model.scrollPage);
@@ -262,8 +262,8 @@ public class AnnotationPreferencesDialogContent
                 // add checkbox
                 // get initial state
                 AnnotationPreference pref = stateModel.getObject().getPreferences();
-                List<Long> preferredLayers = pref.getAnnotationLayers();
-                boolean isPreferredToShow = preferredLayers.contains(item.getModelObject().getId());
+                List<Long> hiddenLayerIds = pref.getHiddenAnnotationLayerIds();
+                boolean isPreferredToShow = !hiddenLayerIds.contains(item.getModelObject().getId());
                 
                 CheckBox layer_cb = new CheckBox("annotationLayerActive",
                         Model.of(isPreferredToShow));
@@ -276,19 +276,19 @@ public class AnnotationPreferencesDialogContent
                     protected void onEvent(AjaxRequestTarget target)
                     {
                         // check state & live update preferences
-                        List<Long> preferredLayers = stateModel.getObject()
-                                .getPreferences().getAnnotationLayers();
+                        List<Long> hiddenLayerIds = stateModel.getObject()
+                                .getPreferences().getHiddenAnnotationLayerIds();
                         // get and switch state of checkbox
                         boolean isPreferredToShow = layer_cb.getModelObject();
                         layer_cb.setModelObject(!isPreferredToShow);
                         // live update preferences
                         if (isPreferredToShow) {
                             // prefer to deactivate layer
-                            preferredLayers.remove(item.getModelObject().getId());
+                            hiddenLayerIds.add(item.getModelObject().getId());
                         }
                         else {
                             // prefer to activate layer
-                            preferredLayers.add(item.getModelObject().getId());
+                            hiddenLayerIds.remove(item.getModelObject().getId());
                         }
                     }
                 });


### PR DESCRIPTION
 - refactor logic from preferred layers to hidden layers, which resolves the hidden new layers startout hidden issue by assuming no layer is hidden in the beginning
- *NOTE* this is a branch from patch-755 