### PR TITLE
#768 - Feature editor labels not aligned

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
@@ -19,9 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
-    <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/>
-    </label>
+    <label wicket:for="value" class="col-sm-3 control-label"><wicket:container wicket:id="feature"/></label>
     <div class="col-sm-9">
       <input wicket:id="value" type="checkbox"/>
     </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
@@ -19,9 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
-    <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/>
-    </label>
+    <label wicket:for="value" class="col-sm-3 control-label"><wicket:container wicket:id="feature"/></label>
     <div class="col-sm-9">
       <input wicket:id="value" type="number"/>
     </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/>&nbsp;<span wicket:id="textIndicator"></span>
+      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <input wicket:id="value"/>


### PR DESCRIPTION
- Remove whitespace
- Add wicket enclosure to control visibility of extra NBSP separating constraints indicator in text feature editor