### PR TITLE
#842 - Extend forward annotation to a feature without a tagset

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
@@ -28,7 +28,14 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 
 public interface AnnotationActionHandler
 {
+
     void actionCreateOrUpdate(AjaxRequestTarget aTarget, JCas aJCas)
+        throws IOException, AnnotationException;
+
+    /**
+     * Create annotation on the next token for forward annotation
+     */
+    void actionCreateForward(AjaxRequestTarget aTarget, JCas aJCas)
         throws IOException, AnnotationException;
 
     /**

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
@@ -28,7 +28,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 
 public interface AnnotationActionHandler
 {
-
     void actionCreateOrUpdate(AjaxRequestTarget aTarget, JCas aJCas)
         throws IOException, AnnotationException;
 

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -24,17 +24,20 @@
 		// Based on this accepted answer of so
 		// http://stackoverflow.com/questions/2335553/jquery-how-to-catch-enter-key-and-change-event-to-tab
 		function manageEnter() {			
-			$("#annotationFeatureForm :input").keypress(function(e) {
-			    if (e.which == 13) {
+			$("#annotationFeatureForm :input").keyup(function(e) {
+				if (e.which == 13) {
 			        e.preventDefault();
 			        var inputs = $(this).parents("form").eq(0).find(":input");
 	                var idx = inputs.index(this);
-
 	                if (idx == inputs.length - 1) {
 	                    inputs[idx].blur();
 	                } else {
 	                    inputs[idx + 1].focus(); //  handles submit buttons
 	                    inputs[idx + 1].select();
+	                }
+	                // If it is a forward annotation on free text, trigger change even on Enter key up
+	                if($('#annotationFeatureForm :checkbox:checked').length > 0) {
+	                		$(this).trigger("change")
 	                }
 	                return false;
 			    }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -133,7 +133,6 @@ public class AnnotationDetailEditorPanel
                 }
             }
         });
-        
         return annotationFeatureForm;
     }
 
@@ -350,16 +349,10 @@ public class AnnotationDetailEditorPanel
         onChange(aTarget);
     }
 
-
-
-    @Override
-    public void actionCreateForward(AjaxRequestTarget aTarget, JCas aJCas)
-            throws IOException, AnnotationException {
-        actionCreateForward(aTarget, aJCas, false);
-    }
     @Override
     public void actionCreateOrUpdate(AjaxRequestTarget aTarget, JCas aJCas)
-            throws IOException, AnnotationException {
+        throws IOException, AnnotationException
+    {
         LOG.trace("actionAnnotate");
 
         if (isAnnotationFinished()) {
@@ -438,7 +431,7 @@ public class AnnotationDetailEditorPanel
             state.setSelectedAnnotationLayer(
                     annotationFeatureForm.getLayerSelector().getModelObject());
         }
-
+        
         LOG.trace("actionAnnotate() selectedLayer: {}",
                 state.getSelectedAnnotationLayer().getUiName());
         LOG.trace("actionAnnotate() defaultLayer: {}",
@@ -513,25 +506,21 @@ public class AnnotationDetailEditorPanel
         // onAnnotate callback
         LOG.trace("onAnnotate()");
         onAnnotate(aTarget);
-
-        if (state.getPreferences().isScrollPage()) {
-            autoScroll(aJCas, false);
-        }
         
 
-        annotationFeatureForm.getForwardAnnotationText().setModelObject(null);
-
-        LOG.trace("onChange()");
-        onChange(aTarget);
-        // If we created a new annotation, then refresh the available annotation layers in the
-        // detail panel.
-        if (state.getSelection().getAnnotation().isNotSet()) {
-            refresh(state);
-        }
+        internalCompleteAnnotation(aTarget, aJCas);
+    }
+    
+    @Override
+    public void actionCreateForward(AjaxRequestTarget aTarget, JCas aJCas)
+        throws IOException, AnnotationException
+    {
+        actionCreateForward(aTarget, aJCas, false);
     }
 
     private void actionCreateForward(AjaxRequestTarget aTarget, JCas aJCas, boolean aIsForwarded)
-            throws IOException, AnnotationException {
+        throws IOException, AnnotationException 
+    {
         LOG.trace("actionForward(isForwarded: {})", aIsForwarded);
 
         if (isAnnotationFinished()) {
@@ -542,13 +531,12 @@ public class AnnotationDetailEditorPanel
         AnnotatorState state = getModelObject();
         state.getAction().setAnnotate(true);
 
-
         // Re-set the selected layer from the drop-down since it might have changed if we
         // have previously created a relation annotation
         state.setSelectedAnnotationLayer(
                 annotationFeatureForm.getLayerSelector().getModelObject());
 
-
+        
         LOG.trace("actionAnnotate() selectedLayer: {}",
                 state.getSelectedAnnotationLayer().getUiName());
         LOG.trace("actionAnnotate() defaultLayer: {}",
@@ -623,7 +611,7 @@ public class AnnotationDetailEditorPanel
         // onAnnotate callback
         LOG.trace("onAnnotate()");
         onAnnotate(aTarget);
-
+        
         if (featureStates.get(0).value != null && !aIsForwarded) {
             if (state.getSelection().getEnd() >= state.getFirstVisibleUnitEnd()) {
                 autoScroll(aJCas, true);
@@ -652,11 +640,13 @@ public class AnnotationDetailEditorPanel
             }
 
             LOG.info("BEGIN auto-forward annotation for free-text annotation");
+
             if (featureStates.get(0).value == null) {
                 AnnotationFS fs = selectByAddr(aJCas, state.getSelection().getAnnotation().getId());
                 deleteAnnotation(aJCas, state, fs, featureStates.get(0).feature.getLayer(),
                         adapter);
             }
+
             AnnotationFS nextToken = WebAnnoCasUtil.getNextToken(aJCas,
                     state.getSelection().getBegin(), state.getSelection().getEnd());
             if (nextToken != null) {
@@ -672,20 +662,25 @@ public class AnnotationDetailEditorPanel
 
             LOG.info("END auto-forward annotation for free-text annotation"); 
         }
+        
+        aTarget.add(annotationFeatureForm);
+        
+        internalCompleteAnnotation(aTarget, aJCas);
+    }
+    
+    private void internalCompleteAnnotation(AjaxRequestTarget aTarget, JCas aJCas)
+    {
+        AnnotatorState state = getModelObject();
+        
         // Perform auto-scroll if it is enabled
         if (state.getPreferences().isScrollPage()) {
             autoScroll(aJCas, false);
         }
-        
 
         annotationFeatureForm.getForwardAnnotationText().setModelObject(null);
 
         LOG.trace("onChange()");
         onChange(aTarget);
-
-        setDefaultModelObject(state);
-        aTarget.add(annotationFeatureForm);
-
 
         // If we created a new annotation, then refresh the available annotation layers in the
         // detail panel.
@@ -694,7 +689,8 @@ public class AnnotationDetailEditorPanel
         }
     }
 
-    private void refresh(AnnotatorState state) {
+    private void refresh(AnnotatorState state) 
+    {
         // This already happens in loadFeatureEditorModels() above - probably not needed
         // here again
         // annotationFeatureForm.updateLayersDropdown();

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -489,8 +489,9 @@ public class AnnotationDetailEditorPanel
             loadFeatureEditorModels(aJCas, aTarget);
             createNewAnnotation(aTarget, adapter, aJCas);
         }
-        // Update the features of the selected annotation from the values presently in
-        // the feature editors
+        
+        // Update the features of the selected annotation from the values presently in the
+        // feature editors
         writeFeatureEditorModelsToCas(adapter, aJCas);
 
         // Update progress information
@@ -598,8 +599,9 @@ public class AnnotationDetailEditorPanel
             loadFeatureEditorModels(aJCas, aTarget);
             createNewAnnotation(aTarget, adapter, aJCas);
         }
-        // Update the features of the selected annotation from the values presently in
-        // the feature editors
+
+        // Update the features of the selected annotation from the values presently in the
+        // feature editors
         writeFeatureEditorModelsToCas(adapter, aJCas);
 
         // Update progress information

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -464,57 +464,53 @@ public class AnnotationDetailEditorPanel
 
         internalCommitAnnotation(aTarget, aJCas);
 
-        List<FeatureState> featureStates = getModelObject().getFeatureStates();
-        TypeAdapter adapter = annotationService.getAdapter(state.getSelectedAnnotationLayer());
-        if (featureStates.get(0).value != null && !aIsForwarded) {
+        if (!aIsForwarded) {
             if (state.getSelection().getEnd() >= state.getFirstVisibleUnitEnd()) {
                 autoScroll(aJCas, true);
             }
 
-            LOG.info("BEGIN auto-forward annotation for tagset-based annotation");
+            List<FeatureState> featureStates = getModelObject().getFeatureStates();
+            if (featureStates.get(0).value != null) {
+                LOG.info("BEGIN auto-forward annotation for tagset-based annotation");
 
-            AnnotationFS nextToken = WebAnnoCasUtil.getNextToken(aJCas,
-                    state.getSelection().getBegin(), state.getSelection().getEnd());
-            if (nextToken != null) {
-                if (getModelObject().getWindowEndOffset() > nextToken.getBegin()) {
-                    state.getSelection().selectSpan(aJCas, nextToken.getBegin(),
-                            nextToken.getEnd());
-                    actionCreateForward(aTarget, aJCas, true);
+                AnnotationFS nextToken = WebAnnoCasUtil.getNextToken(aJCas,
+                        state.getSelection().getBegin(), state.getSelection().getEnd());
+                if (nextToken != null) {
+                    if (getModelObject().getWindowEndOffset() > nextToken.getBegin()) {
+                        state.getSelection().selectSpan(aJCas, nextToken.getBegin(),
+                                nextToken.getEnd());
+                        actionCreateForward(aTarget, aJCas, true);
+                    }
                 }
+                LOG.info("END auto-forward annotation for tagset-based annotation");
+            }
+            else {
+                LOG.info("BEGIN auto-forward annotation for free-text annotation");
+
+                if (featureStates.get(0).value == null) {
+                    TypeAdapter adapter = annotationService
+                            .getAdapter(state.getSelectedAnnotationLayer());
+                    AnnotationFS fs = selectByAddr(aJCas,
+                            state.getSelection().getAnnotation().getId());
+                    deleteAnnotation(aJCas, state, fs, featureStates.get(0).feature.getLayer(),
+                            adapter);
+                }
+
+                AnnotationFS nextToken = WebAnnoCasUtil.getNextToken(aJCas,
+                        state.getSelection().getBegin(), state.getSelection().getEnd());
+                if (nextToken != null) {
+                    if (getModelObject().getWindowEndOffset() > nextToken.getBegin()) {
+                        state.getSelection().selectSpan(aJCas, nextToken.getBegin(),
+                                nextToken.getEnd());
+                        actionCreateForward(aTarget, aJCas, true);
+                    }
+                }
+                
+                LOG.info("END auto-forward annotation for free-text annotation"); 
             }
 
             LOG.trace("onAutoForward()");
             onAutoForward(aTarget);
-
-            LOG.info("END auto-forward annotation for tagset-based annotation");
-        }
-        else if (!aIsForwarded) {
-            if (state.getSelection().getEnd() >= state.getFirstVisibleUnitEnd()) {
-                autoScroll(aJCas, true);
-            }
-
-            LOG.info("BEGIN auto-forward annotation for free-text annotation");
-
-            if (featureStates.get(0).value == null) {
-                AnnotationFS fs = selectByAddr(aJCas, state.getSelection().getAnnotation().getId());
-                deleteAnnotation(aJCas, state, fs, featureStates.get(0).feature.getLayer(),
-                        adapter);
-            }
-
-            AnnotationFS nextToken = WebAnnoCasUtil.getNextToken(aJCas,
-                    state.getSelection().getBegin(), state.getSelection().getEnd());
-            if (nextToken != null) {
-                if (getModelObject().getWindowEndOffset() > nextToken.getBegin()) {
-                    state.getSelection().selectSpan(aJCas, nextToken.getBegin(),
-                            nextToken.getEnd());
-                    actionCreateForward(aTarget, aJCas, true);
-                }
-            }
-
-            LOG.trace("onAutoForward()");
-            onAutoForward(aTarget);
-
-            LOG.info("END auto-forward annotation for free-text annotation"); 
         }
         
         aTarget.add(annotationFeatureForm);

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -487,6 +487,8 @@ public class AnnotationDetailEditorPanel
             else {
                 LOG.info("BEGIN auto-forward annotation for free-text annotation");
 
+                // If the annotation value was cleared or not filled in by the user, then we
+                // remove the entire annotation.
                 if (featureStates.get(0).value == null) {
                     TypeAdapter adapter = annotationService
                             .getAdapter(state.getSelectedAnnotationLayer());


### PR DESCRIPTION
Extend forward annotation to free-text annotation feature when
1) it is locked-to-token annotation layer
2) There is only one annotation feature which is enabled and visible at a time. If there multiple features, they should be invisibile and disable to allow forward annotation for free-text annotation
How it works
1) enable forward annotation (using the checkbox)
2) type the annotation in the text-field and pres the ENTER KEY
If nothing is typed in the text-field, annotation will be delted and focus will move to the next token