### PR TITLE
Feature/945 allow looking up annotation document by user name only

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -79,6 +79,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateTransition;
 import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition;
@@ -256,14 +257,21 @@ public class DocumentServiceImpl
     @Transactional(noRollbackFor = NoResultException.class)
     public AnnotationDocument getAnnotationDocument(SourceDocument aDocument, User aUser)
     {
+        return getAnnotationDocument(aDocument, aUser.getUsername());
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public AnnotationDocument getAnnotationDocument(SourceDocument aDocument, String aUser)
+    {
         return entityManager
                 .createQuery(
                         "FROM AnnotationDocument WHERE document = :document AND " + "user =:user"
                                 + " AND project = :project", AnnotationDocument.class)
-                .setParameter("document", aDocument).setParameter("user", aUser.getUsername())
+                .setParameter("document", aDocument).setParameter("user", aUser)
                 .setParameter("project", aDocument.getProject()).getSingleResult();
     }
-
+    
     @Override
     @Transactional(noRollbackFor = NoResultException.class)
     public SourceDocument getSourceDocument(Project aProject, String aDocumentName)

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -79,7 +79,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateTransition;
 import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition;

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -289,15 +289,28 @@ public interface DocumentService
     /**
      * Get the annotation document.
      *
-     * @param document
+     * @param aDocument
      *            the source document.
-     * @param user
+     * @param aUser
      *            the user.
      * @return the annotation document.
      * @throws NoResultException
      *             if no annotation document exists for the given source/user.
      */
-    AnnotationDocument getAnnotationDocument(SourceDocument document, User user);
+    AnnotationDocument getAnnotationDocument(SourceDocument aDocument, User aUser);
+
+    /**
+     * Get the annotation document.
+     *
+     * @param aDocument
+     *            the source document.
+     * @param aUser
+     *            the user.
+     * @return the annotation document.
+     * @throws NoResultException
+     *             if no annotation document exists for the given source/user.
+     */
+    AnnotationDocument getAnnotationDocument(SourceDocument aDocument, String aUser);
 
     /**
      * Gets the CAS for the given annotation document. Converts it form the source document if

--- a/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
+++ b/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
@@ -241,6 +241,18 @@ public class SourceDocument
         }
         return true;
     }
+    
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        builder.append(name);
+        builder.append("](");
+        builder.append(id);
+        builder.append(")");
+        return builder.toString();
+    }
 
     public static final Comparator<SourceDocument> NAME_COMPARATOR = Comparator
             .comparing(SourceDocument::getName);

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/SuggestionViewPanel.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/SuggestionViewPanel.java
@@ -220,12 +220,16 @@ public class SuggestionViewPanel
             UserAnnotationSegment aCurationUserSegment, JCas aJcas)
             throws AnnotationException, UIMAException, ClassNotFoundException, IOException
     {
-        User user = userRepository.get(aCurationUserSegment.getUsername());
         SourceDocument sourceDocument = aCurationUserSegment.getAnnotatorState().getDocument();
         AnnotationDocument clickedAnnotationDocument = documentService
-                .getAnnotationDocument(sourceDocument, user);
+                .getAnnotationDocument(sourceDocument, aCurationUserSegment.getUsername());
 
-        Integer address = aRequest.getParameterValue(PARAM_ID).toInteger();
+        if (clickedAnnotationDocument == null) {
+            throw new AnnotationException("No annotation document for source document "
+                    + sourceDocument + " for user [" + aCurationUserSegment.getUsername() + "]");
+        }
+        
+        int address = aRequest.getParameterValue(PARAM_ID).toInt();
         String spanType = removePrefix(aRequest.getParameterValue(PARAM_TYPE).toString());
 
         createSpan(spanType, aCurationUserSegment.getAnnotatorState(), aJcas,


### PR DESCRIPTION
- Can avoid an unnecessary a DB query when fetching the annotation document
- Maybe helps tracking down a problem reported on the mailing list where the requested user apparently does not exist in the user management.