### PR TITLE
#1003 - Fire only one AjaxAfterAnnotationUpdateEvent

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
@@ -119,7 +119,7 @@ public class AnnotatorStateImpl
      */
     private int unitCount;
 
-    private List<FeatureState> featureModels = new ArrayList<>();          
+    private final List<FeatureState> featureModels = new ArrayList<>();          
     
     /**
      * Constraints object from rule file

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -633,12 +633,8 @@ public class AnnotationDetailEditorPanel
         // feature editors
         writeFeatureEditorModelsToCas(adapter, aJCas);
 
-        //Send AjaxEvent so that Active Learning sidebar could receive the changes
-        List<Serializable> values = new ArrayList<>();
-        for (FeatureState featureState : featureStates) {
-            send(getPage(), Broadcast.BREADTH, new AjaxAfterAnnotationUpdateEvent(aTarget, state,
-                    featureState.value));
-        }
+        // Notify other UI elements (e.g. sidebars) about the update so that they can react to it
+        send(getPage(), Broadcast.BREADTH, new AjaxAfterAnnotationUpdateEvent(aTarget, state));
 
         // Update progress information
         LOG.trace("actionAnnotate() updating progress information");

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/event/AjaxAfterAnnotationUpdateEvent.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/event/AjaxAfterAnnotationUpdateEvent.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.event;
 
-import java.io.Serializable;
-
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -27,14 +25,11 @@ public class AjaxAfterAnnotationUpdateEvent
 {
     protected AjaxRequestTarget target;
     private AnnotatorState annotatorState;
-    private Serializable value;
 
-    public AjaxAfterAnnotationUpdateEvent(AjaxRequestTarget aTarget, AnnotatorState aState,
-            Serializable aValue)
+    public AjaxAfterAnnotationUpdateEvent(AjaxRequestTarget aTarget, AnnotatorState aState)
     {
         target = aTarget;
         annotatorState = aState;
-        value = aValue;
     }
 
     public AjaxRequestTarget getTarget()
@@ -45,10 +40,5 @@ public class AjaxAfterAnnotationUpdateEvent
     public AnnotatorState getAnnotatorState()
     {
         return annotatorState;
-    }
-
-    public Serializable getValue()
-    {
-        return value;
     }
 }


### PR DESCRIPTION
- Only one overall event instead of one per feature since the even receivers might e.g. use the event to switch to another document which would reset the feature states and cause a concurrency problem