### PR TITLE
#783 - Color of a layer changes depending on how many layers are enabled

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
@@ -117,10 +117,18 @@ public class BratRenderer
         
         // Render visible (custom) layers
         Map<String[], Queue<String>> colorQueues = new HashMap<>();
-        for (AnnotationLayer layer : aVDoc.getAnnotationLayers()) {
+        for (AnnotationLayer layer : aAnnotationService.listAnnotationLayer(aState.getProject())) {
             ColoringStrategy coloringStrategy = aColoringStrategy != null ? aColoringStrategy
                     : ColoringStrategy.getStrategy(aAnnotationService, layer,
                             aState.getPreferences(), colorQueues);
+            
+            // If the layer is not included in the rendering, then we skip here - but only after
+            // we have obtained a coloring strategy for this layer and thus secured the layer
+            // color. This ensures that the layer colors do not change depending on the number
+            // of visible layers.
+            if (!aVDoc.getAnnotationLayers().contains(layer)) {
+                continue;
+            }
 
             TypeAdapter typeAdapter = aAnnotationService.getAdapter(layer);
             


### PR DESCRIPTION
- When rendering iterate over all layers in the project, then get color, then skip if the layer is not visible. This ensures stable colors with regards to layer visibility (not with regards to layers being enabled/disabled, but that is ok).

Fixes #783