### PR TITLE
#896 - Handle case where imported XMI file does not contain DocumentMetaData

### DIFF
--- a/webanno-brat/pom.xml
+++ b/webanno-brat/pom.xml
@@ -47,10 +47,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
-      <artifactId>webanno-security</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-support</artifactId>
     </dependency>
 

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/util/BratAnnotatorUtility.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/util/BratAnnotatorUtility.java
@@ -28,15 +28,14 @@ import org.apache.uima.cas.CASException;
 import org.apache.uima.cas.impl.CASCompleteSerializer;
 import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -72,8 +71,7 @@ public class BratAnnotatorUtility
         return finished;
     }
 
-    public static JCas clearJcasAnnotations(JCas aJCas, SourceDocument aSourceDocument, User aUser,
-            DocumentService repository)
+    public static JCas clearJcasAnnotations(JCas aJCas)
         throws IOException
     {
         JCas target;
@@ -100,7 +98,12 @@ public class BratAnnotatorUtility
         target.reset();
         
         // Copy over essential information
-        DocumentMetaData.copy(aJCas, target);
+        if (JCasUtil.exists(aJCas, DocumentMetaData.class)) {
+            DocumentMetaData.copy(aJCas, target);
+        }
+        else {
+            DocumentMetaData.create(aJCas);
+        }
         target.setDocumentLanguage(aJCas.getDocumentLanguage()); // DKPro Core Issue 435
         target.setDocumentText(aJCas.getDocumentText());
         
@@ -114,8 +117,6 @@ public class BratAnnotatorUtility
             new Sentence(target, s.getBegin(), s.getEnd()).addToIndexes();
         }
 
-        
-        repository.writeAnnotationCas(target, aSourceDocument, aUser, false);
         return target;
     }
 }

--- a/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/util/BratAnnotatorUtilityTest.java
+++ b/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/util/BratAnnotatorUtilityTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.util;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.junit.Test;
+
+public class BratAnnotatorUtilityTest
+{
+    @Test
+    public void testClearJCasWithoutDocumentMetadata() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+
+        BratAnnotatorUtility.clearJcasAnnotations(jcas);
+    }
+}

--- a/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
+++ b/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
@@ -557,8 +557,7 @@ public class CorrectionPage
     {
         AnnotatorState state = getModelObject();
         JCas editorCas = documentService.createOrReadInitialCas(state.getDocument());
-        editorCas = BratAnnotatorUtility.clearJcasAnnotations(editorCas, state.getDocument(),
-                state.getUser(), documentService);
+        editorCas = BratAnnotatorUtility.clearJcasAnnotations(editorCas);
         documentService.writeAnnotationCas(editorCas, state.getDocument(), state.getUser(), false);
         actionLoadDocument(aTarget);
     }
@@ -620,8 +619,8 @@ public class CorrectionPage
             }
             else {
                 editorCas = documentService.createOrReadInitialCas(state.getDocument());
-                editorCas = BratAnnotatorUtility.clearJcasAnnotations(editorCas,
-                        state.getDocument(), user, documentService);
+                editorCas = BratAnnotatorUtility.clearJcasAnnotations(editorCas);
+                documentService.writeAnnotationCas(editorCas, state.getDocument(), user, false);
             }
 
             // Update the CASes


### PR DESCRIPTION
- Changed clearJcasAnnotations to not persist the cleared CAS to disk - calling code was changed to do this
- Changed clearJcasAnnotations to create a DocumentMetaData in the target JCas if it was not there
- Added unit test for clearJcasAnnotations