### PR TITLE
Add check for multiple ingoing edges

### DIFF
--- a/webanno-diag/pom.xml
+++ b/webanno-diag/pom.xml
@@ -92,7 +92,12 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -103,6 +108,11 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.syntax-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.api.coref-asl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/webanno-diag/pom.xml
+++ b/webanno-diag/pom.xml
@@ -91,6 +91,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.testing-asl</artifactId>
       <scope>test</scope>
@@ -98,6 +103,11 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.syntax-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -99,7 +99,7 @@ public class NoMultipleIncomingRelationsCheck implements Check {
                         if (sentenceNumber.isPresent()) {
                             aMessages.add(new LogMessage(this, LogLevel.ERROR,
                                     "Sentence %d: Relation [%s] -> [%s] points to span that already has an "
-                                            + "incoming relation [%s] ->[%s].",
+                                            + "incoming relation [%s] -> [%s].",
                                     sentenceNumber.get(), source.getCoveredText(),
                                     target.getCoveredText(), existingSource.getCoveredText(),
                                     target.getCoveredText()));
@@ -107,7 +107,7 @@ public class NoMultipleIncomingRelationsCheck implements Check {
 
                             aMessages.add(new LogMessage(this, LogLevel.ERROR,
                                     "Relation [%s] -> [%s] points to span that already has an "
-                                            + "incoming relation [%s] ->[%s].",
+                                            + "incoming relation [%s] -> [%s].",
                                     source.getCoveredText(), target.getCoveredText(),
                                     existingSource.getCoveredText(), target.getCoveredText()));
                         }

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -98,7 +98,7 @@ public class NoMultipleIncomingRelationsCheck implements Check {
 
                         if (sentenceNumber.isPresent()) {
                             aMessages.add(new LogMessage(this, LogLevel.ERROR,
-                                    "Sentence %d: Relation [%s] -> [%s] points to entitity that already has an "
+                                    "Sentence %d: Relation [%s] -> [%s] points to span that already has an "
                                             + "incoming relation [%s] ->[%s].",
                                     sentenceNumber.get(), source.getCoveredText(),
                                     target.getCoveredText(), existingSource.getCoveredText(),
@@ -106,7 +106,7 @@ public class NoMultipleIncomingRelationsCheck implements Check {
                         } else {
 
                             aMessages.add(new LogMessage(this, LogLevel.ERROR,
-                                    "Relation [%s] -> [%s] points to entitity that already has an "
+                                    "Relation [%s] -> [%s] points to span that already has an "
                                             + "incoming relation [%s] ->[%s].",
                                     source.getCoveredText(), target.getCoveredText(),
                                     existingSource.getCoveredText(), target.getCoveredText()));

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -41,7 +41,7 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
-public class NoMultipleIngoingRelationsCheck implements Check {
+public class NoMultipleIncomingRelationsCheck implements Check {
     private @Autowired AnnotationSchemaService annotationService;
 
     @Override

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -91,7 +91,7 @@ public class NoMultipleIncomingRelationsCheck implements Check {
 
                             sentenceNumber = Optional
                                     .of(WebAnnoCasUtil.getSentenceNumber(jcas, target.getBegin()));
-                        } catch (CASException e) {
+                        } catch (CASException | IndexOutOfBoundsException e) {
                             // ignore this error and don't output sentence number
                             sentenceNumber = Optional.empty();
                         }

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -41,13 +41,16 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
-public class NoMultipleIncomingRelationsCheck implements Check {
+public class NoMultipleIncomingRelationsCheck
+    implements Check
+{
     private @Autowired AnnotationSchemaService annotationService;
 
     @Override
-    public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages) {
+    public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages)
+    {
         boolean ok = true;
-        if(annotationService == null) {
+        if (annotationService == null) {
             return ok;
         }
         List<AnnotationLayer> allAnnoLayers = annotationService.listAnnotationLayer(aProject);
@@ -61,7 +64,8 @@ public class NoMultipleIncomingRelationsCheck implements Check {
                 Type type;
                 try {
                     type = getType(aCas, layer.getName());
-                } catch (IllegalArgumentException e) {
+                }
+                catch (IllegalArgumentException e) {
                     // If the type does not exist, the CAS has not been upgraded. In this case, we
                     // can skip checking the layer because there will be no annotations anyway.
                     continue;
@@ -91,7 +95,8 @@ public class NoMultipleIncomingRelationsCheck implements Check {
 
                             sentenceNumber = Optional
                                     .of(WebAnnoCasUtil.getSentenceNumber(jcas, target.getBegin()));
-                        } catch (CASException | IndexOutOfBoundsException e) {
+                        }
+                        catch (CASException | IndexOutOfBoundsException e) {
                             // ignore this error and don't output sentence number
                             sentenceNumber = Optional.empty();
                         }
@@ -103,7 +108,8 @@ public class NoMultipleIncomingRelationsCheck implements Check {
                                     sentenceNumber.get(), source.getCoveredText(),
                                     target.getCoveredText(), existingSource.getCoveredText(),
                                     target.getCoveredText()));
-                        } else {
+                        }
+                        else {
 
                             aMessages.add(new LogMessage(this, LogLevel.ERROR,
                                     "Relation [%s] -> [%s] points to span that already has an "
@@ -112,7 +118,8 @@ public class NoMultipleIncomingRelationsCheck implements Check {
                                     existingSource.getCoveredText(), target.getCoveredText()));
                         }
                         ok = false;
-                    } else {
+                    }
+                    else {
                         incoming.put(target, source);
                     }
                 }
@@ -120,6 +127,5 @@ public class NoMultipleIncomingRelationsCheck implements Check {
         }
 
         return ok;
-    }   
-    
+    }
 }

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -47,71 +47,79 @@ public class NoMultipleIncomingRelationsCheck implements Check {
     @Override
     public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages) {
         boolean ok = true;
-        for (AnnotationLayer layer : annotationService.listAnnotationLayer(aProject)) {
+        if(annotationService == null) {
+            return ok;
+        }
+        List<AnnotationLayer> allAnnoLayers = annotationService.listAnnotationLayer(aProject);
+        if (allAnnoLayers != null) {
+            for (AnnotationLayer layer : allAnnoLayers) {
 
-            if (!WebAnnoConst.RELATION_TYPE.equals(layer.getType())) {
-                continue;
-            }
+                if (!WebAnnoConst.RELATION_TYPE.equals(layer.getType())) {
+                    continue;
+                }
 
-            Type type;
-            try {
-                type = getType(aCas, layer.getName());
-            } catch (IllegalArgumentException e) {
-                // If the type does not exist, the CAS has not been upgraded. In this case, we
-                // can skip checking the layer because there will be no annotations anyway.
-                continue;
-            }
+                Type type;
+                try {
+                    type = getType(aCas, layer.getName());
+                } catch (IllegalArgumentException e) {
+                    // If the type does not exist, the CAS has not been upgraded. In this case, we
+                    // can skip checking the layer because there will be no annotations anyway.
+                    continue;
+                }
 
-            // Remember all nodes that already have a known incoming relation.
-            // Map from the target to the existing source, so the source can be used
-            // to provide a better debugging output.
-            Map<AnnotationFS, AnnotationFS> incoming = new HashMap<>();
+                // Remember all nodes that already have a known incoming relation.
+                // Map from the target to the existing source, so the source can be used
+                // to provide a better debugging output.
+                Map<AnnotationFS, AnnotationFS> incoming = new HashMap<>();
 
-            for (AnnotationFS rel : select(aCas, type)) {
+                for (AnnotationFS rel : select(aCas, type)) {
 
-                AnnotationFS source = getFeature(rel, WebAnnoConst.FEAT_REL_SOURCE,
-                        AnnotationFS.class);
-                AnnotationFS target = getFeature(rel, WebAnnoConst.FEAT_REL_TARGET,
-                        AnnotationFS.class);
+                    AnnotationFS source = getFeature(rel, WebAnnoConst.FEAT_REL_SOURCE,
+                            AnnotationFS.class);
+                    AnnotationFS target = getFeature(rel, WebAnnoConst.FEAT_REL_TARGET,
+                            AnnotationFS.class);
 
-                AnnotationFS existingSource = incoming.get(target);
-                if (existingSource != null) {
+                    AnnotationFS existingSource = incoming.get(target);
+                    if (existingSource != null) {
 
-                    // Debug output should include sentence number to make the orientation easier
-                    Optional<Integer> sentenceNumber = Optional.empty();
-                    try {
-                        JCas jcas;
-                        jcas = target.getCAS().getJCas();
+                        // Debug output should include sentence number to make the orientation
+                        // easier
+                        Optional<Integer> sentenceNumber = Optional.empty();
+                        try {
+                            JCas jcas;
+                            jcas = target.getCAS().getJCas();
 
-                        sentenceNumber = Optional
-                                .of(WebAnnoCasUtil.getSentenceNumber(jcas, target.getBegin()));
-                    } catch (CASException e) {
-                        // ignore this error and don't output sentence number
-                        sentenceNumber = Optional.empty();
-                    }
+                            sentenceNumber = Optional
+                                    .of(WebAnnoCasUtil.getSentenceNumber(jcas, target.getBegin()));
+                        } catch (CASException e) {
+                            // ignore this error and don't output sentence number
+                            sentenceNumber = Optional.empty();
+                        }
 
-                    if (sentenceNumber.isPresent()) {
-                        aMessages.add(new LogMessage(this, LogLevel.ERROR,
-                                "Sentence %d: Relation [%s] -> [%s] points to entitity that already has an "
-                                        + "incoming relation [%s] ->[%s].",
-                                sentenceNumber.get(), source.getCoveredText(),
-                                target.getCoveredText(), existingSource.getCoveredText(),
-                                target.getCoveredText()));
+                        if (sentenceNumber.isPresent()) {
+                            aMessages.add(new LogMessage(this, LogLevel.ERROR,
+                                    "Sentence %d: Relation [%s] -> [%s] points to entitity that already has an "
+                                            + "incoming relation [%s] ->[%s].",
+                                    sentenceNumber.get(), source.getCoveredText(),
+                                    target.getCoveredText(), existingSource.getCoveredText(),
+                                    target.getCoveredText()));
+                        } else {
+
+                            aMessages.add(new LogMessage(this, LogLevel.ERROR,
+                                    "Relation [%s] -> [%s] points to entitity that already has an "
+                                            + "incoming relation [%s] ->[%s].",
+                                    source.getCoveredText(), target.getCoveredText(),
+                                    existingSource.getCoveredText(), target.getCoveredText()));
+                        }
+                        ok = false;
                     } else {
-
-                        aMessages.add(new LogMessage(this, LogLevel.ERROR,
-                                "Relation [%s] -> [%s] points to entitity that already has an "
-                                        + "incoming relation [%s] ->[%s].",
-                                source.getCoveredText(), target.getCoveredText(),
-                                existingSource.getCoveredText(), target.getCoveredText()));
+                        incoming.put(target, source);
                     }
-                    ok = false;
-                } else {
-                    incoming.put(target, source);
                 }
             }
         }
 
         return ok;
-    }
+    }   
+    
 }

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIngoingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIngoingRelationsCheck.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static org.apache.uima.fit.util.CasUtil.getType;
+import static org.apache.uima.fit.util.CasUtil.select;
+import static org.apache.uima.fit.util.CasUtil.selectFS;
+import static org.apache.uima.fit.util.FSUtil.getFeature;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.util.FSUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
+import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogLevel;
+import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+
+public class NoMultipleIngoingRelationsCheck
+    implements Check
+{
+    private @Autowired AnnotationSchemaService annotationService;
+
+    @Override
+    public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages)
+    {
+        boolean ok = true;
+        for (AnnotationLayer layer : annotationService.listAnnotationLayer(aProject)) {
+            
+        	if (!WebAnnoConst.RELATION_TYPE.equals(layer.getType())) {
+                continue;
+            }
+
+            Type type;
+            try {
+                type = getType(aCas, layer.getName());
+            }
+            catch (IllegalArgumentException e) {
+                // If the type does not exist, the CAS has not been upgraded. In this case, we
+                // can skip checking the layer because there will be no annotations anyway.
+                continue;
+            }
+            
+            // Remember all nodes that already have a known incoming relation.
+            // Map from the target to the existing source, so the source can be used
+            // to provide a better debugging output.
+            Map<AnnotationFS, AnnotationFS> incoming = new HashMap<>();
+            
+            for (AnnotationFS rel : select(aCas, type)) {
+            	
+            	AnnotationFS source = getFeature(rel, WebAnnoConst.FEAT_REL_SOURCE,
+                        AnnotationFS.class);
+            	AnnotationFS target = getFeature(rel, WebAnnoConst.FEAT_REL_TARGET,
+                        AnnotationFS.class);
+            	
+            	AnnotationFS existingSource = incoming.get(target);
+            	if(existingSource != null) {
+            		target.getCoveredText();
+            		aMessages.add(new LogMessage(this, LogLevel.ERROR,
+                            "Relation [%s] -> [%s] points to entitity that already has an "
+                            + "incoming relation [%s] ->[%s].",
+                            source.getCoveredText(), target.getCoveredText(), 
+                            existingSource.getCoveredText(), target.getCoveredText()));
+                    ok = false;
+            	} else {
+            		incoming.put(target, source);
+            	}
+            }
+        }
+        
+        return ok;
+    }
+}

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIngoingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIngoingRelationsCheck.java
@@ -19,28 +19,19 @@ package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
 
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
-import static org.apache.uima.fit.util.CasUtil.selectFS;
 import static org.apache.uima.fit.util.FSUtil.getFeature;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.CASException;
-import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.JCas;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;

--- a/webanno-diag/src/main/resources/META-INF/asciidoc/developer-guide/casdoctor.adoc
+++ b/webanno-diag/src/main/resources/META-INF/asciidoc/developer-guide/casdoctor.adoc
@@ -120,6 +120,16 @@ Each chain in a chain layers consist of a *chain* and several *links*. The chain
 points to the first link and each link points to the following link. If the CAS contains any links
 that are not reachable through a chain, then this is likely due to a bug.
 
+[[check_NoMultipleIncomingRelationsCheck]]
+==== No Multiple Incoming Relations
+
+[horizontal]
+ID:: `NoMultipleIncomingRelationsCheck`
+
+Check that nodes have only one in-going dependency relation inside the same annotation layer.
+Since dependency relations form a tree, every node of this tree can only have at most one parent node.
+This check outputs a message that includes the sentence number (useful to jump directly to the problem) and the actual offending dependency edges.
+
 [[check_NoZeroSizeTokensAndSentencesCheck]]
 ==== No Zero-Size Tokens and Sentences
 

--- a/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
+++ b/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
@@ -107,7 +107,7 @@ public class NoMultipleIncomingRelationsCheckTest {
         // also check the message itself
         assertEquals(1, messages.size());
         assertEquals(
-                "[NoMultipleIncomingRelationsCheck] Relation [This] -> [is] points to entitity that already has an incoming relation [a] ->[is].",
+                "[NoMultipleIncomingRelationsCheck] Relation [This] -> [is] points to span that already has an incoming relation [a] -> [is].",
                 messages.get(0).toString());
 
     }

--- a/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
+++ b/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -48,18 +49,17 @@ import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
 @RunWith(SpringRunner.class)
 public class NoMultipleIncomingRelationsCheckTest {
 
-
     @Configuration
-    @Import({AnnotationSchemaService.class, NoMultipleIncomingRelationsCheck.class})
+    @Import({ AnnotationSchemaService.class, NoMultipleIncomingRelationsCheck.class })
     static class Config {
     }
-    
+
     @Rule
     public DkproTestContext testContext = new DkproTestContext();
 
     @MockBean
     private AnnotationSchemaService annotationService;
-    
+
     @Autowired
     NoMultipleIncomingRelationsCheck check;
 
@@ -68,30 +68,30 @@ public class NoMultipleIncomingRelationsCheckTest {
 
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(Dependency.class.getName());
-        
+
         relationLayer.setType(WebAnnoConst.RELATION_TYPE);
         Mockito.when(annotationService.listAnnotationLayer(Mockito.isNull()))
                 .thenReturn(Arrays.asList(relationLayer));
 
         JCas jcas = JCasFactory.createJCas();
-        
+
         jcas.setDocumentText("This is a test.");
 
         Token spanThis = new Token(jcas, 0, 4);
         spanThis.addToIndexes();
 
-        Token spanIs = new Token(jcas, 6, 8);
+        Token spanIs = new Token(jcas, 5, 7);
         spanIs.addToIndexes();
-        
-        Token spanA = new Token(jcas, 9, 10);
+
+        Token spanA = new Token(jcas, 8, 9);
         spanA.addToIndexes();
 
-        Dependency dep1 = new Dependency(jcas, 0, 8);
+        Dependency dep1 = new Dependency(jcas, 0, 7);
         dep1.setGovernor(spanThis);
         dep1.setDependent(spanIs);
         dep1.addToIndexes();
 
-        Dependency dep2 = new Dependency(jcas, 0, 10);
+        Dependency dep2 = new Dependency(jcas, 0, 9);
         dep2.setGovernor(spanA);
         dep2.setDependent(spanIs);
         dep2.addToIndexes();
@@ -103,19 +103,26 @@ public class NoMultipleIncomingRelationsCheckTest {
         messages.forEach(System.out::println);
 
         assertFalse(result);
+
+        // also check the message itself
+        assertEquals(1, messages.size());
+        assertEquals(
+                "[NoMultipleIncomingRelationsCheck] Relation [This] -> [is] points to entitity that already has an incoming relation [a] ->[is].",
+                messages.get(0).toString());
+
     }
 
     @Test
     public void testOK() throws Exception {
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(Dependency.class.getName());
-        
+
         relationLayer.setType(WebAnnoConst.RELATION_TYPE);
         Mockito.when(annotationService.listAnnotationLayer(Mockito.isNull()))
                 .thenReturn(Arrays.asList(relationLayer));
 
         JCas jcas = JCasFactory.createJCas();
-        
+
         jcas.setDocumentText("This is a test.");
 
         Token spanThis = new Token(jcas, 0, 4);
@@ -123,7 +130,7 @@ public class NoMultipleIncomingRelationsCheckTest {
 
         Token spanIs = new Token(jcas, 6, 8);
         spanIs.addToIndexes();
-        
+
         Token spanA = new Token(jcas, 9, 10);
         spanA.addToIndexes();
 
@@ -145,19 +152,19 @@ public class NoMultipleIncomingRelationsCheckTest {
 
         assertTrue(result);
     }
-    
+
     @Test
     public void testOkBecauseCoref() throws Exception {
 
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(CoreferenceChain.class.getName());
-        
+
         relationLayer.setType(WebAnnoConst.CHAIN_TYPE);
         Mockito.when(annotationService.listAnnotationLayer(Mockito.isNull()))
                 .thenReturn(Arrays.asList(relationLayer));
 
         JCas jcas = JCasFactory.createJCas();
-        
+
         jcas.setDocumentText("This is a test.");
 
         Token spanThis = new Token(jcas, 0, 4);
@@ -165,7 +172,7 @@ public class NoMultipleIncomingRelationsCheckTest {
 
         Token spanIs = new Token(jcas, 6, 8);
         spanIs.addToIndexes();
-        
+
         Token spanA = new Token(jcas, 9, 10);
         spanA.addToIndexes();
 

--- a/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
+++ b/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -64,18 +65,23 @@ public class NoMultipleIncomingRelationsCheckTest {
     @Test
     public void testFail() throws Exception {
 
-        AnnotationLayer layer1 = new AnnotationLayer();
+        AnnotationLayer relationLayer = new AnnotationLayer();
+        relationLayer.setName(Dependency.class.getName());
+        
+        relationLayer.setType(WebAnnoConst.RELATION_TYPE);
         Mockito.when(annotationService.listAnnotationLayer(Mockito.isNull()))
-                .thenReturn(Arrays.asList(layer1));
+                .thenReturn(Arrays.asList(relationLayer));
 
         JCas jcas = JCasFactory.createJCas();
-
+        
         jcas.setDocumentText("This is a test.");
 
         Token spanThis = new Token(jcas, 0, 4);
         spanThis.addToIndexes();
 
         Token spanIs = new Token(jcas, 6, 8);
+        spanIs.addToIndexes();
+        
         Token spanA = new Token(jcas, 9, 10);
         spanA.addToIndexes();
 

--- a/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
+++ b/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
+
+@RunWith(SpringRunner.class)
+public class NoMultipleIncomingRelationsCheckTest {
+
+
+    @Configuration
+    @Import({AnnotationSchemaService.class, NoMultipleIncomingRelationsCheck.class})
+    static class Config {
+    }
+    
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+
+    @MockBean
+    private AnnotationSchemaService annotationService;
+    
+    @Autowired
+    NoMultipleIncomingRelationsCheck check;
+
+    @Test
+    public void testFail() throws Exception {
+
+        AnnotationLayer layer1 = new AnnotationLayer();
+        Mockito.when(annotationService.listAnnotationLayer(Mockito.isNull()))
+                .thenReturn(Arrays.asList(layer1));
+
+        JCas jcas = JCasFactory.createJCas();
+
+        jcas.setDocumentText("This is a test.");
+
+        Token spanThis = new Token(jcas, 0, 4);
+        spanThis.addToIndexes();
+
+        Token spanIs = new Token(jcas, 6, 8);
+        Token spanA = new Token(jcas, 9, 10);
+        spanA.addToIndexes();
+
+        Dependency dep1 = new Dependency(jcas, 0, 8);
+        dep1.setGovernor(spanThis);
+        dep1.setDependent(spanIs);
+        dep1.addToIndexes();
+
+        Dependency dep2 = new Dependency(jcas, 0, 10);
+        dep2.setGovernor(spanA);
+        dep2.setDependent(spanIs);
+        dep2.addToIndexes();
+
+        List<LogMessage> messages = new ArrayList<>();
+
+        boolean result = check.check(null, jcas.getCas(), messages);
+
+        messages.forEach(System.out::println);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testOK() throws Exception {
+
+    }
+
+
+}


### PR DESCRIPTION
We have a corpus that was annotated with an older version of WebAnno, where the annotators could accidentally add dependency relations with the same target token. This will fail to export with both the CONLL-2009 and the WebAnnoTSV exporter and we now have to correct all the files manually, since there is no way to output these to any format we can read.

Since which edge should be removed (or reversed) only can decided manually, I added a check to the CAS Doctor that finds all offending instances and outputs a message that includes the sentence number (useful to jump directly to the problem) and the actual offending dependency edges.

![checkoutputexample](https://user-images.githubusercontent.com/2168104/43532106-a27386aa-95b1-11e8-8e0b-386c49251373.png)

I'm fairly new to the data model, if there is anything I should improve in the implementation please let me know.
