### PR TITLE
#1049 - NoMultipleIncomingRelationsCheck reports at ERROR level

### DIFF
--- a/webanno-diag/pom.xml
+++ b/webanno-diag/pom.xml
@@ -67,6 +67,10 @@
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.lexmorph-asl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.api.syntax-asl</artifactId>
+    </dependency>
     
     <!-- SPRING -->
     <dependency>
@@ -103,11 +107,6 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.testing-asl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
-      <artifactId>de.tudarmstadt.ukp.dkpro.core.api.syntax-asl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctor.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctor.java
@@ -326,7 +326,7 @@ public class CasDoctor
 
     public enum LogLevel
     {
-        INFO, ERROR
+        INFO, WARN, ERROR
     }
 
     public static class LogMessage

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheck.java
@@ -40,6 +40,7 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogLevel;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor.LogMessage;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 
 public class NoMultipleIncomingRelationsCheck
     implements Check
@@ -58,6 +59,10 @@ public class NoMultipleIncomingRelationsCheck
             for (AnnotationLayer layer : allAnnoLayers) {
 
                 if (!WebAnnoConst.RELATION_TYPE.equals(layer.getType())) {
+                    continue;
+                }
+                
+                if (!Dependency.class.getName().equals(layer.getName())) {
                     continue;
                 }
 
@@ -102,7 +107,7 @@ public class NoMultipleIncomingRelationsCheck
                         }
 
                         if (sentenceNumber.isPresent()) {
-                            aMessages.add(new LogMessage(this, LogLevel.ERROR,
+                            aMessages.add(new LogMessage(this, LogLevel.WARN,
                                     "Sentence %d: Relation [%s] -> [%s] points to span that already has an "
                                             + "incoming relation [%s] -> [%s].",
                                     sentenceNumber.get(), source.getCoveredText(),
@@ -111,13 +116,16 @@ public class NoMultipleIncomingRelationsCheck
                         }
                         else {
 
-                            aMessages.add(new LogMessage(this, LogLevel.ERROR,
+                            aMessages.add(new LogMessage(this, LogLevel.WARN,
                                     "Relation [%s] -> [%s] points to span that already has an "
                                             + "incoming relation [%s] -> [%s].",
                                     source.getCoveredText(), target.getCoveredText(),
                                     existingSource.getCoveredText(), target.getCoveredText()));
                         }
-                        ok = false;
+                        
+                        // This check only logs warnings - it should not fail. Having multiple
+                        // incoming edges is not a serious problem.
+                        // ok = false;
                     }
                     else {
                         incoming.put(target, source);

--- a/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
+++ b/webanno-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/NoMultipleIncomingRelationsCheckTest.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -47,11 +46,13 @@ import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
 
 @RunWith(SpringRunner.class)
-public class NoMultipleIncomingRelationsCheckTest {
+public class NoMultipleIncomingRelationsCheckTest
+{
 
     @Configuration
     @Import({ AnnotationSchemaService.class, NoMultipleIncomingRelationsCheck.class })
-    static class Config {
+    static class Config
+    {
     }
 
     @Rule
@@ -64,7 +65,8 @@ public class NoMultipleIncomingRelationsCheckTest {
     NoMultipleIncomingRelationsCheck check;
 
     @Test
-    public void testFail() throws Exception {
+    public void testFail() throws Exception
+    {
 
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(Dependency.class.getName());
@@ -102,7 +104,7 @@ public class NoMultipleIncomingRelationsCheckTest {
 
         messages.forEach(System.out::println);
 
-        assertFalse(result);
+        assertTrue(result);
 
         // also check the message itself
         assertEquals(1, messages.size());
@@ -113,7 +115,8 @@ public class NoMultipleIncomingRelationsCheckTest {
     }
 
     @Test
-    public void testOK() throws Exception {
+    public void testOK() throws Exception
+    {
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(Dependency.class.getName());
 
@@ -154,7 +157,8 @@ public class NoMultipleIncomingRelationsCheckTest {
     }
 
     @Test
-    public void testOkBecauseCoref() throws Exception {
+    public void testOkBecauseCoref() throws Exception
+    {
 
         AnnotationLayer relationLayer = new AnnotationLayer();
         relationLayer.setName(CoreferenceChain.class.getName());


### PR DESCRIPTION
- Introduce new WARN log level for CAS Doctor checks
- Apply NoMultipleIncomingRelationsCheck only for the DKPro Core Dependency layer
- Demote its log results to WARN and make the check not fail the analysis