### PR TITLE
#1114 - Import projects for non-admins

### DIFF
--- a/webanno-api/pom.xml
+++ b/webanno-api/pom.xml
@@ -51,11 +51,6 @@
       <artifactId>uimaj-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
     <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -80,18 +75,6 @@
       <artifactId>wicket-util</artifactId>
     </dependency>
 
-    <!-- Hibernate dependencies -->
-    <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
-    </dependency>
-
-    <!-- LOGGING DEPENDENCIES - SLF4J -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>junit</groupId>

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
@@ -430,6 +430,57 @@ public interface ProjectService
     @Deprecated
     List<Authority> listAuthorities(User user);
     
+    /**
+     * Can the given user access the project setting of <b>some</b> project. 
+     */
+    public boolean managesAnyProject(User user);
+    
+    /**
+     * Determine if the user is allowed to update a project.
+     *
+     * @param aProject
+     *            the project
+     * @param aUser
+     *            the user.
+     * @return if the user may update a project.
+     */
+    boolean isProjectAdmin(Project aProject, User aUser);
+
+    /**
+     * Determine if the User is an admin of a project
+     *
+     * @param aProject
+     *            the project.
+     * @param aUser
+     *            the user.
+     * @return if the user is an admin.
+     */
+    boolean isAdmin(Project aProject, User aUser);
+
+    /**
+     * Determine if the user is a curator or not.
+     *
+     * @param aProject
+     *            the project.
+     * @param aUser
+     *            the user.
+     * @return if the user is a curator.
+     */
+    boolean isCurator(Project aProject, User aUser);
+
+    /**
+     * Determine if the User is member of a project
+     *
+     * @param aProject
+     *            the project.
+     * @param aUser
+     *            the user.
+     * @return if the user is a member.
+     */
+    boolean isAnnotator(Project aProject, User aUser);
+
+    
+    
     // --------------------------------------------------------------------------------------------
     // Methods related to other things
     // --------------------------------------------------------------------------------------------

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/SecurityUtil.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/SecurityUtil.java
@@ -19,24 +19,12 @@ package de.tudarmstadt.ukp.clarin.webanno.api;
 
 import static java.util.Arrays.asList;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.persistence.NoResultException;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.Authority;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.ApplicationContextProvider;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
@@ -46,8 +34,6 @@ import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
  */
 public class SecurityUtil
 {
-    private static final Logger LOG = LoggerFactory.getLogger(SecurityUtil.class);
-
     public static boolean isProfileSelfServiceAllowed()
     {
         // If users are allowed to access their profile information, the also need to access the
@@ -59,209 +45,94 @@ public class SecurityUtil
                         .equals(settings.getProperty(SettingsUtil.CFG_USER_ALLOW_PROFILE_ACCESS));
     }
     
-    public static Set<String> getRoles(ProjectService aProjectRepository, User aUser)
+    /**
+     * @deprecated Use {@link UserDao#getRoles(User)}
+     */
+    @Deprecated
+    public static Set<String> getRoles(UserDao aUserRepository, User aUser)
     {
-        // When looking up roles for the user who is currently logged in, then we look in the
-        // security context - otherwise we ask the database.
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
-        Set<String> roles = new HashSet<>();
-        if (aUser.getUsername().equals(username)) {
-            for (GrantedAuthority ga : SecurityContextHolder.getContext().getAuthentication()
-                    .getAuthorities()) {
-                roles.add(ga.getAuthority());
-            }
-        }
-        else {
-            for (Authority a : aProjectRepository.listAuthorities(aUser)) {
-                roles.add(a.getAuthority());
-            }
-        }
-        return roles;
+        return aUserRepository.getRoles(aUser);
     }
     
     /**
-     * IS user super Admin
-     * 
-     * @param aProjectRepository the repository service.
-     * @param aUser the user.
-     * @return if the user is a global admin.
+     * @deprecated Use {@link UserDao#isAdministrator(User)}
      */
+    @Deprecated
+    public static boolean isSuperAdmin(UserDao aUserRepository, User aUser)
+    {
+        return aUserRepository.isAdministrator(aUser);
+    }
+
+    /**
+     * @deprecated Use {@link UserDao#isAdministrator(User)}
+     */
+    @Deprecated
     public static boolean isSuperAdmin(ProjectService aProjectRepository, User aUser)
     {
-        boolean roleAdmin = false;
-        for (String role : getRoles(aProjectRepository, aUser)) {
-            if (Role.ROLE_ADMIN.name().equals(role)) {
-                roleAdmin = true;
-                break;
-            }
-        }
-        return roleAdmin;
+        return ApplicationContextProvider.getApplicationContext().getBean(UserDao.class)
+                .isAdministrator(aUser);
     }
 
     /**
-     * IS project creator
-     * 
-     * @param aProjectRepository the repository service.
-     * @param aUser the user.
-     * @return if the user is a project creator
+     * @deprecated Use {@link UserDao#isProjectCreator(User)}
      */
-    public static boolean isProjectCreator(ProjectService aProjectRepository, User aUser)
+    @Deprecated
+    public static boolean isProjectCreator(UserDao aUserRepository, User aUser)
     {
-        boolean roleAdmin = false;
-        for (String role : getRoles(aProjectRepository, aUser)) {
-            if (Role.ROLE_PROJECT_CREATOR.name().equals(role)) {
-                roleAdmin = true;
-                break;
-            }
-        }
-        return roleAdmin;
+        return aUserRepository.isProjectCreator(aUser);
     }
 
     /**
-     * Determine if the User is allowed to update a project
-     *
-     * @param aProject the project
-     * @param aProjectRepository the repository service.
-     * @param aUser the user.
-     * @return if the user may update a project.
+     * @deprecated Use {@link ProjectService#isProjectAdmin(Project, User)}
      */
+    @Deprecated
     public static boolean isProjectAdmin(Project aProject, ProjectService aProjectRepository,
             User aUser)
     {
-        boolean projectAdmin = false;
-        try {
-            List<ProjectPermission> permissionLevels = aProjectRepository
-                    .listProjectPermissionLevel(aUser, aProject);
-            for (ProjectPermission permissionLevel : permissionLevels) {
-                if (StringUtils.equalsIgnoreCase(permissionLevel.getLevel().getName(),
-                        PermissionLevel.ADMIN.getName())) {
-                    projectAdmin = true;
-                    break;
-                }
-            }
-        }
-        catch (NoResultException ex) {
-            LOG.info("No permision is given to this user " + ex);
-        }
-
-        return projectAdmin;
+        return aProjectRepository.isProjectAdmin(aProject, aUser);
     }
 
     /**
-     * Determine if the User is a curator or not
-     *
-     * @param aProject the project.
-     * @param aProjectRepository the respository service.
-     * @param aUser the user.
-     * @return if the user is a curator.
+     * @deprecated Use {@link ProjectService#isCurator(Project, User)}
      */
-    public static boolean isCurator(Project aProject, ProjectService aProjectRepository,
-            User aUser)
+    @Deprecated
+    public static boolean isCurator(Project aProject, ProjectService aProjectRepository, User aUser)
     {
-        boolean curator = false;
-        try {
-            List<ProjectPermission> permissionLevels = aProjectRepository
-                    .listProjectPermissionLevel(aUser, aProject);
-            for (ProjectPermission permissionLevel : permissionLevels) {
-                if (StringUtils.equalsIgnoreCase(permissionLevel.getLevel().getName(),
-                        PermissionLevel.CURATOR.getName())) {
-                    curator = true;
-                    break;
-                }
-            }
-        }
-        catch (NoResultException ex) {
-            LOG.info("No permision is given to this user " + ex);
-        }
-
-        return curator;
+        return aProjectRepository.isCurator(aProject, aUser);
     }
 
     /**
-     * Determine if the User is member of a project
-     *
-     * @param aProject the project.
-     * @param aProjectRepository the repository service.
-     * @param aUser the user.
-     * @return if the user is a member.
+     * @deprecated Use {@link ProjectService#isAnnotator(Project, User)}
      */
+    @Deprecated
     public static boolean isAnnotator(Project aProject, ProjectService aProjectRepository,
             User aUser)
     {
-        boolean user = false;
-        try {
-            List<ProjectPermission> permissionLevels = aProjectRepository
-                    .listProjectPermissionLevel(aUser, aProject);
-            for (ProjectPermission permissionLevel : permissionLevels) {
-                if (StringUtils.equalsIgnoreCase(permissionLevel.getLevel().getName(),
-                        PermissionLevel.USER.getName())) {
-                    user = true;
-                    break;
-                }
-            }
-        }
-
-        catch (NoResultException ex) {
-            LOG.info("No permision is given to this user " + ex);
-        }
-
-        return user;
+        return aProjectRepository.isAnnotator(aProject, aUser);
     }
     
     /**
-     * Determine if the User is an admin of a project
-     *
-     * @param aProject the project.
-     * @param aProjectRepository the repository service.
-     * @param aUser the user.
-     * @return if the user is an admin.
+     * @deprecated Use {@link ProjectService#isAdmin(Project, User)}
      */
-    public static boolean isAdmin(Project aProject, ProjectService aProjectRepository,
-            User aUser)
+    @Deprecated
+    public static boolean isAdmin(Project aProject, ProjectService aProjectRepository, User aUser)
     {
-        boolean user = false;
-        try {
-            List<ProjectPermission> permissionLevels = aProjectRepository
-                    .listProjectPermissionLevel(aUser, aProject);
-            for (ProjectPermission permissionLevel : permissionLevels) {
-                if (StringUtils.equalsIgnoreCase(permissionLevel.getLevel().getName(),
-                        PermissionLevel.ADMIN.getName())) {
-                    user = true;
-                    break;
-                }
-            }
-        }
-
-        catch (NoResultException ex) {
-            LOG.info("No permision is given to this user " + ex);
-        }
-
-        return user;
+        return aProjectRepository.isAdmin(aProject, aUser);
     }
     
+    /**
+     * @deprecated Use {@link ProjectService#managesAnyProject(User)}
+     */
+    @Deprecated
     public static boolean projectSettingsEnabeled(ProjectService repository, User user)
     {
-        if (SecurityUtil.isSuperAdmin(repository, user)) {
-            return true;
-        }
-
-        if (SecurityUtil.isProjectCreator(repository, user)) {
-            return true;
-        }
-
-        for (Project project : repository.listProjects()) {
-            if (SecurityUtil.isProjectAdmin(project, repository, user)) {
-                return true;
-            }
-        }
-        
-        return false;
+        return repository.managesAnyProject(user);
     }
 
     public static boolean curationEnabeled(ProjectService repository, User user)
     {
         for (Project project : repository.listProjects()) {
-            if (SecurityUtil.isCurator(project, repository, user)) {
+            if (repository.isCurator(project, user)) {
                 return true;
             }
         }
@@ -272,7 +143,7 @@ public class SecurityUtil
     public static boolean annotationEnabeled(ProjectService aRepository, User aUser, String aMode)
     {
         for (Project project : aRepository.listProjects()) {
-            if (SecurityUtil.isAnnotator(project, aRepository, aUser)
+            if (aRepository.isAnnotator(project, aUser)
                     && aMode.equals(project.getMode())) {
                 return true;
             }
@@ -284,8 +155,8 @@ public class SecurityUtil
     public static boolean monitoringEnabeled(ProjectService repository, User user)
     {
         for (Project project : repository.listProjects()) {
-            if (SecurityUtil.isCurator(project, repository, user)
-                    || SecurityUtil.isProjectAdmin(project, repository, user)) {
+            if (repository.isCurator(project, user)
+                    || repository.isProjectAdmin(project, user)) {
                 return true;
             }
         }

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectImportRequest.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectImportRequest.java
@@ -18,8 +18,11 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.export;
 
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
 public class ProjectImportRequest
     implements Serializable
@@ -30,14 +33,36 @@ public class ProjectImportRequest
 
     public int progress = 0;
 
-    private final Queue<String> messages;
+    private final Queue<String> messages = new ConcurrentLinkedQueue<>();
+    
     private final boolean createMissingUsers;
+    private final boolean importPermissions;
+    private final Optional<User> manager;
 
+    /**
+     * Request the import of a project, optionally creating any users referenced in the project
+     * but missing in the current instance.
+     */
     public ProjectImportRequest(boolean aCreateMissingUsers)
     {
-        progress = 0;
         createMissingUsers = aCreateMissingUsers;
-        messages = new ConcurrentLinkedQueue<>();
+        importPermissions = true;
+        manager = Optional.empty();
+    }
+
+    public ProjectImportRequest(boolean aCreateMissingUsers, boolean aImportPermissions)
+    {
+        createMissingUsers = aCreateMissingUsers;
+        importPermissions = aImportPermissions;
+        manager = Optional.empty();
+    }
+
+    public ProjectImportRequest(boolean aCreateMissingUsers, boolean aImportPermissions,
+            Optional<User> aManager)
+    {
+        createMissingUsers = aCreateMissingUsers;
+        importPermissions = aImportPermissions;
+        manager = aManager;
     }
 
     public void addMessage(String aMessage)
@@ -56,5 +81,15 @@ public class ProjectImportRequest
     public boolean isCreateMissingUsers()
     {
         return createMissingUsers;
+    }
+    
+    public boolean isImportPermissions()
+    {
+        return importPermissions;
+    }
+    
+    public Optional<User> getManager()
+    {
+        return manager;
     }
 }

--- a/webanno-project/pom.xml
+++ b/webanno-project/pom.xml
@@ -29,6 +29,10 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController.java
@@ -57,7 +57,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
@@ -140,8 +139,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectCreator(projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                userRepository.isProjectCreator(user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
@@ -314,8 +313,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -365,8 +364,8 @@ public class RemoteApiController
         
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -430,8 +429,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -511,8 +510,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -582,8 +581,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -681,8 +680,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             response.sendError(HttpStatus.FORBIDDEN.value(), "User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");
@@ -823,8 +822,8 @@ public class RemoteApiController
 
         // Check for the access
         boolean hasAccess = 
-                SecurityUtil.isProjectAdmin(project, projectRepository, user) ||
-                SecurityUtil.isSuperAdmin(projectRepository, user);
+                projectRepository.isProjectAdmin(project, user) ||
+                userRepository.isAdministrator(user);
         if (!hasAccess) {
             response.sendError(HttpStatus.FORBIDDEN.value(), "User [" + username
                     + "] is not allowed to access project [" + aProjectId + "]");

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController2.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController2.java
@@ -17,9 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isProjectAdmin;
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isProjectCreator;
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isSuperAdmin;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.v2.model.RMessageLevel.ERROR;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.v2.model.RMessageLevel.INFO;
 import static org.apache.uima.fit.util.JCasUtil.select;
@@ -228,8 +225,8 @@ public class RemoteApiController2
         assertPermission(
                 "User [" + user.getUsername() + "] is not allowed to access project [" + aProjectId
                         + "]",
-                isProjectAdmin(project, projectService, user)
-                        || isSuperAdmin(projectService, user));
+                projectService.isProjectAdmin(project, user)
+                        || userRepository.isAdministrator(user));
         
         return project;
     }
@@ -316,13 +313,13 @@ public class RemoteApiController2
 
         // Check for the access
         assertPermission("User [" + user.getUsername() + "] is not allowed to create projects",
-                isProjectCreator(projectService, user) || isSuperAdmin(projectService, user));
+                userRepository.isProjectCreator(user) || userRepository.isAdministrator(user));
         
         // Check if the user can create projects for another user
         assertPermission(
                 "User [" + user.getUsername() + "] is not allowed to create projects for user ["
                         + aCreator.orElse("<unspecified>") + "]",
-                isSuperAdmin(projectService, user)
+                userRepository.isAdministrator(user)
                         || (aCreator.isPresent() && aCreator.get().equals(user.getUsername())));
         
         // Existing project
@@ -402,7 +399,7 @@ public class RemoteApiController2
 
         // Check for the access
         assertPermission("User [" + user.getUsername() + "] is not allowed to import projects",
-                isSuperAdmin(projectService, user));
+                userRepository.isAdministrator(user));
         
         Project importedProject;
         File tempFile = File.createTempFile("webanno-training", null);

--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookService.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookService.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.net.ssl.SSLContext;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -37,6 +36,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.TrustStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.ApplicationEvent;
@@ -58,7 +58,7 @@ import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.Document
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.ProjectStateChangeMessage;
 
 @Component
-public class WebhookService
+public class WebhookService implements InitializingBean
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
     
@@ -82,7 +82,12 @@ public class WebhookService
     private @Autowired WebhooksConfiguration configuration;
     private @Autowired RestTemplateBuilder restTemplateBuilder;
     
-    @PostConstruct
+    @Override
+    public void afterPropertiesSet() throws Exception
+    {
+        init();
+    }
+    
     public void init()
     {
         if (!configuration.getGlobalHooks().isEmpty()) {

--- a/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.security;
 
 import java.util.List;
+import java.util.Set;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Authority;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -97,4 +98,15 @@ public interface UserDao
      */
     List<Authority> listAuthorities(User user);
 
+    /**
+     * Check if the user has global administrator permissions.
+     */
+    public boolean isAdministrator(User aUser);
+
+    /**
+     * Check if the user has the permission to create projects.
+     */
+    public boolean isProjectCreator(User aUser);
+
+    public Set<String> getRoles(User aUser);
 }

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
@@ -60,7 +60,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.CorrectionDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectType;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
@@ -313,8 +312,9 @@ public class AutomationPage
                 super.onConfigure();
                 
                 AnnotatorState state = AutomationPage.this.getModelObject();
-                setVisible(state.getProject() != null && (SecurityUtil.isAdmin(state.getProject(),
-                        projectService, state.getUser()) || !state.getProject().isDisableExport()));
+                setVisible(state.getProject() != null
+                        && (projectService.isAdmin(state.getProject(), state.getUser())
+                                || !state.getProject().isDisableExport()));
             }
         });
         
@@ -372,7 +372,7 @@ public class AutomationPage
             User user = userRepository.getCurrentUser();
             List<DecoratedObject<Project>> allowedProject = new ArrayList<>();
             for (Project project : projectService.listProjects()) {
-                if (SecurityUtil.isAnnotator(project, projectService, user)
+                if (projectService.isAnnotator(project, user)
                         && WebAnnoConst.PROJECT_TYPE_AUTOMATION.equals(project.getMode())) {
                     allowedProject.add(DecoratedObject.of(project));
                 }

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -82,6 +82,7 @@ linkedListBehavior=Behave like a linked list
 onClickJavascriptAction=Run Javascript action on click
 
 generateUsers=Create missing users
+importPermissions=Import permissions
 
 selectedFeatures=Selected features
 useOtherLayersAsTrainingFeatures=Use other layers as training features

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/css/theme/bootstrap.less
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/css/theme/bootstrap.less
@@ -46,7 +46,7 @@
 @import "webjars!bootstrap/current/less/close.less";
 
 // Components w/ JavaScript
-// @import "webjars!bootstrap/current/less/modals.less";
+@import "webjars!bootstrap/current/less/modals.less";
 // @import "webjars!bootstrap/current/less/tooltip.less";
 @import "webjars!bootstrap/current/less/popovers.less";
 // @import "webjars!bootstrap/current/less/carousel.less";

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -292,6 +292,6 @@ public class ManageUsersPage
     
     private boolean isAdmin()
     {
-        return SecurityUtil.isSuperAdmin(projectRepository, userRepository.getCurrentUser());
+        return userRepository.isAdministrator(userRepository.getCurrentUser());
     }
 }

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPageMenuItem.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPageMenuItem.java
@@ -21,16 +21,13 @@ import org.apache.wicket.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItem;
 
 @Component
 public class ManageUsersPageMenuItem implements MenuItem
 {
-    private @Autowired UserDao userRepo;
-    private @Autowired ProjectService projectService;
+    private @Autowired UserDao userRepository;
     
     @Override
     public String getPath()
@@ -56,7 +53,7 @@ public class ManageUsersPageMenuItem implements MenuItem
     @Override
     public boolean applies()
     {
-        return SecurityUtil.isSuperAdmin(projectService, userRepo.getCurrentUser());
+        return userRepository.isAdministrator(userRepository.getCurrentUser());
     }
     
     @Override

--- a/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
+++ b/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
@@ -58,7 +58,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.CorrectionDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectType;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
@@ -285,8 +284,9 @@ public class CorrectionPage
                 super.onConfigure();
                 
                 AnnotatorState state = CorrectionPage.this.getModelObject();
-                setVisible(state.getProject() != null && (SecurityUtil.isAdmin(state.getProject(),
-                        projectService, state.getUser()) || !state.getProject().isDisableExport()));
+                setVisible(state.getProject() != null
+                        && (projectService.isAdmin(state.getProject(), state.getUser())
+                                || !state.getProject().isDisableExport()));
             }
         });
 
@@ -351,7 +351,7 @@ public class CorrectionPage
                         SecurityContextHolder.getContext().getAuthentication().getName());
                 List<DecoratedObject<Project>> allowedProject = new ArrayList<>();
                 for (Project project : projectService.listProjects()) {
-                    if (SecurityUtil.isAnnotator(project, projectService, user)
+                    if (projectService.isAnnotator(project, user)
                             && WebAnnoConst.PROJECT_TYPE_CORRECTION.equals(project.getMode())) {
                         allowedProject.add(DecoratedObject.of(project));
                     }

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.curation.page;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isCurator;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_DOCUMENT_ID;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_FOCUS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJECT_ID;
@@ -66,7 +65,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CorrectionDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.SessionMetaData;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -306,8 +304,9 @@ public class CurationPage
                 super.onConfigure();
                 
                 AnnotatorState state = CurationPage.this.getModelObject();
-                setVisible(state.getProject() != null && (SecurityUtil.isAdmin(state.getProject(),
-                        projectService, state.getUser()) || !state.getProject().isDisableExport()));
+                setVisible(state.getProject() != null
+                        && (projectService.isAdmin(state.getProject(), state.getUser())
+                                || !state.getProject().isDisableExport()));
             }
         });
         
@@ -398,7 +397,7 @@ public class CurationPage
                 List<Project> projectsWithFinishedAnnos = projectService
                         .listProjectsWithFinishedAnnos();
                 for (Project project : projectService.listProjects()) {
-                    if (SecurityUtil.isCurator(project, projectService, user)) {
+                    if (projectService.isCurator(project, user)) {
                         DecoratedObject<Project> dp = DecoratedObject.of(project);
                         if (projectsWithFinishedAnnos.contains(project)) {
                             dp.setColor("green");
@@ -792,7 +791,7 @@ public class CurationPage
         
         // Check access to project
         if (project != null
-                && !isCurator(project, projectService, getModelObject().getUser())) {
+                && !projectService.isCurator(project, getModelObject().getUser())) {
             error("You have no permission to access project [" + project.getId() + "]");
             return;
         }

--- a/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.java
+++ b/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.monitoring.page;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isCurator;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJECT_ID;
 import static java.util.Arrays.asList;
 
@@ -71,7 +70,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.components.TooltipConfig
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.curation.agreement.AgreementUtils;
 import de.tudarmstadt.ukp.clarin.webanno.curation.agreement.AgreementUtils.AgreementReportExportFormat;
@@ -137,7 +135,7 @@ public class AgreementPage
         
         if (project.isPresent()) {
             // Check access to project
-            if (project != null && !isCurator(project.get(), projectService, user)) {
+            if (project != null && !projectService.isCurator(project.get(), user)) {
                 error("You have no permission to access project [" + project.get().getId() + "]");
                 setResponsePage(getApplication().getHomePage());
             }
@@ -625,8 +623,8 @@ public class AgreementPage
 
             List<Project> allProjects = projectService.listProjects();
             for (Project project : allProjects) {
-                if (SecurityUtil.isProjectAdmin(project, projectService, user)
-                        || SecurityUtil.isCurator(project, projectService, user)) {
+                if (projectService.isProjectAdmin(project, user)
+                        || projectService.isCurator(project, user)) {
                     allowedProject.add(project);
                 }
             }

--- a/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/MonitoringPage.java
+++ b/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/MonitoringPage.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.monitoring.page;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isCurator;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJECT_ID;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateTransition.ANNOTATION_FINISHED_TO_ANNOTATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateTransition.ANNOTATION_IN_PROGRESS_TO_ANNOTATION_FINISHED;
@@ -97,7 +96,6 @@ import org.wicketstuff.annotation.mount.MountPath;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.automation.model.MiraTemplate;
 import de.tudarmstadt.ukp.clarin.webanno.automation.service.AutomationService;
@@ -211,7 +209,7 @@ public class MonitoringPage
         
         if (project.isPresent()) {
             // Check access to project
-            if (project != null && !isCurator(project.get(), projectService, user)) {
+            if (project != null && !projectService.isCurator(project.get(), user)) {
                 error("You have no permission to access project [" + project.get().getId() + "]");
                 setResponsePage(getApplication().getHomePage());
             }
@@ -350,8 +348,8 @@ public class MonitoringPage
 
                             List<Project> allProjects = projectService.listProjects();
                             for (Project project : allProjects) {
-                                if (SecurityUtil.isProjectAdmin(project, projectService, user)
-                                        || SecurityUtil.isCurator(project, projectService, user)) {
+                                if (projectService.isProjectAdmin(project, user)
+                                        || projectService.isCurator(project, user)) {
                                     allowedProject.add(project);
                                 }
                             }
@@ -568,8 +566,8 @@ public class MonitoringPage
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userRepository.get(username);
         for (Project project : projectService.listProjects()) {
-            if (SecurityUtil.isCurator(project, projectService, user)
-                    || SecurityUtil.isProjectAdmin(project, projectService, user)) {
+            if (projectService.isCurator(project, user)
+                    || projectService.isProjectAdmin(project, user)) {
                 int annoFinished = documentService.listFinishedAnnotationDocuments(project).size();
                 int allAnno = documentService.numberOfExpectedAnnotationDocuments(project);
                 int progress = (int) Math.round((double) (annoFinished * 100) / (allAnno));
@@ -957,7 +955,7 @@ public class MonitoringPage
                     @Override
                     protected void onEvent(AjaxRequestTarget aTarget)
                     {
-                        if (!SecurityUtil.isCurator(project, projectService, user)) {
+                        if (!projectService.isCurator(project, user)) {
                             aTarget.appendJavaScript(
                                     "alert('the state can only be changed explicitly by the curator')");
                             return;

--- a/webanno-ui-project/pom.xml
+++ b/webanno-ui-project/pom.xml
@@ -167,6 +167,10 @@
       <artifactId>wicket-extensions</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-extensions</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.googlecode.wicket-jquery-ui</groupId>
       <artifactId>wicket-jquery-ui-core</artifactId>
     </dependency>

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.html
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.html
@@ -26,18 +26,12 @@
       <form wicket:id="form">
         <div class="panel-body form-horizontal">
           <div class="form-group">
-            <label wicket:for="content" class="col-sm-4 control-label">
-              <wicket:label key="content" />
-            </label>
-            <div class="col-sm-8">
-              <div class="row">
-                <input wicket:id="content" type="file" multiple
-                  class="col-sm-12" />
-              </div>
+            <div class="col-sm-12">
+              <input wicket:id="content" type="file" multiple class="col-sm-12" />
             </div>
           </div>
           <div class="form-group">
-            <div class="col-sm-offset-4 col-sm-8" wicket:enclosure="importPermissions">
+            <div class="col-sm-12" wicket:enclosure="importPermissions">
               <div class="checkbox">
                 <label wicket:for="importPermissions">
                   <input wicket:id="importPermissions" type="checkbox">
@@ -47,7 +41,7 @@
             </div>
           </div>
           <div class="form-group">
-            <div class="col-sm-offset-4 col-sm-8" wicket:enclosure="generateUsers">
+            <div class="col-sm-12" wicket:enclosure="generateUsers">
               <div class="checkbox">
                 <label wicket:for="generateUsers">
                   <input wicket:id="generateUsers" type="checkbox">

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.html
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.html
@@ -24,7 +24,7 @@
         <h3 class="panel-title"><wicket:message key="projects.import.title" /></h3>
       </div>
       <form wicket:id="form">
-        <div class="panel-body">
+        <div class="panel-body form-horizontal">
           <div class="form-group">
             <label wicket:for="content" class="col-sm-4 control-label">
               <wicket:label key="content" />
@@ -36,8 +36,18 @@
               </div>
             </div>
           </div>
-          <div wicket:enclosure="generateUsers">
-            <div class="col-sm-offset-4 col-sm-8">
+          <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8" wicket:enclosure="importPermissions">
+              <div class="checkbox">
+                <label wicket:for="importPermissions">
+                  <input wicket:id="importPermissions" type="checkbox">
+                  <wicket:label key="importPermissions" />
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-offset-4 col-sm-8" wicket:enclosure="generateUsers">
               <div class="checkbox">
                 <label wicket:for="generateUsers">
                   <input wicket:id="generateUsers" type="checkbox">

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.java
@@ -40,7 +40,6 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
-import org.apache.wicket.markup.html.form.upload.FileUploadField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
@@ -50,6 +49,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInputField;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.ImportUtil;
@@ -72,7 +72,7 @@ public class ProjectImportPanel
     
     private IModel<Project> selectedModel;
     private IModel<Preferences> preferences;
-    private FileUploadField fileUpload;
+    private BootstrapFileInputField fileUpload;
 
     public ProjectImportPanel(String aId, IModel<Project> aModel)
     {
@@ -102,7 +102,10 @@ public class ProjectImportPanel
         form.add(importPermissions);
         authorize(importPermissions, Component.RENDER, ROLE_ADMIN.name());
 
-        form.add(fileUpload = new FileUploadField("content", new ListModel<>()));
+        form.add(fileUpload = new BootstrapFileInputField("content", new ListModel<>()));
+        fileUpload.getConfig().showPreview(false);
+        fileUpload.getConfig().showUpload(false);
+        fileUpload.getConfig().showRemove(false);
         fileUpload.setRequired(true);
         
         form.add(new LambdaAjaxButton<>("import", this::actionImport));

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectImportPanel.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.project;
 
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy.authorize;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -25,10 +29,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.CheckBox;
@@ -48,8 +54,11 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.ImportUtil;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 
 public class ProjectImportPanel
     extends Panel
@@ -58,8 +67,8 @@ public class ProjectImportPanel
 
     private static final Logger LOG = LoggerFactory.getLogger(ProjectImportPanel.class);
     
-    //private @SpringBean ImportService importService;
     private @SpringBean ProjectExportService exportService;
+    private @SpringBean UserDao userRepository;
     
     private IModel<Project> selectedModel;
     private IModel<Preferences> preferences;
@@ -73,18 +82,64 @@ public class ProjectImportPanel
         selectedModel = aModel;
         
         Form<Preferences> form = new Form<>("form", CompoundPropertyModel.of(preferences));
-        form.add(new CheckBox("generateUsers"));
+
+        // Only administrators who can access user management can also use the "create missing
+        // users" checkbox. Also, the option is only available when importing permissions in the
+        // first place.
+        CheckBox generateUsers = new CheckBox("generateUsers");
+        generateUsers.setOutputMarkupPlaceholderTag(true);
+        generateUsers.add(visibleWhen(() -> preferences.getObject().importPermissions));
+        form.add(generateUsers);
+        authorize(generateUsers, Component.RENDER, ROLE_ADMIN.name());
+
+        CheckBox importPermissions = new CheckBox("importPermissions");
+        importPermissions.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
+            if (!preferences.getObject().importPermissions) {
+                preferences.getObject().generateUsers = false;
+            }
+            _target.add(generateUsers);
+        }));
+        form.add(importPermissions);
+        authorize(importPermissions, Component.RENDER, ROLE_ADMIN.name());
+
         form.add(fileUpload = new FileUploadField("content", new ListModel<>()));
         fileUpload.setRequired(true);
+        
         form.add(new LambdaAjaxButton<>("import", this::actionImport));
+        
         add(form);
     }
 
     private void actionImport(AjaxRequestTarget aTarget, Form<Preferences> aForm)
     {
         List<FileUpload> exportedProjects = fileUpload.getFileUploads();
-        boolean aGenerateUsers = preferences.getObject().generateUsers;
-        // import multiple projects!
+        
+        User currentUser = userRepository.getCurrentUser();
+        boolean currentUserIsAdministrator = userRepository.isAdministrator(currentUser);
+        boolean currentUserIsProjectCreator = userRepository.isProjectCreator(currentUser);
+        
+        boolean createMissingUsers;
+        boolean importPermissions;
+        
+        // Importing of permissions is only allowed if the importing user is an administrator
+        if (currentUserIsAdministrator) {
+            createMissingUsers = preferences.getObject().generateUsers;
+            importPermissions = preferences.getObject().importPermissions;
+        }
+        // ... otherwise we force-disable importing of permissions so that the only remaining
+        // permission for non-admin users is that they become the managers of projects they import.
+        else {
+            createMissingUsers = false;
+            importPermissions = false;
+        }
+        
+        
+        // If the current user is a project creator then we assume that the user is importing the
+        // project for own use, so we add the user as a project manager. We do not do this if the
+        // user is "just" an administrator but not a project creator.
+        Optional<User> manager = currentUserIsProjectCreator ? Optional.of(currentUser)
+                : Optional.empty();
+
         Project importedProject = null;
         for (FileUpload exportedProject : exportedProjects) {
             try {
@@ -103,8 +158,8 @@ public class ProjectImportPanel
                         throw new IOException("ZIP file is not a WebAnno project archive");
                     }
                     
-                    //importedProject = importService.importProject(tempFile, aGenerateUsers);
-                    ProjectImportRequest request = new ProjectImportRequest(aGenerateUsers);
+                    ProjectImportRequest request = new ProjectImportRequest(createMissingUsers,
+                            importPermissions, manager);
                     importedProject = exportService.importProject(request, new ZipFile(tempFile));
                 }
                 finally {
@@ -128,5 +183,6 @@ public class ProjectImportPanel
     {
         private static final long serialVersionUID = 3821654370145608038L;
         boolean generateUsers;
+        boolean importPermissions = true;
     }
 }

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPage.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPage.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.project;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil.isAdmin;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJECT_ID;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_PROJECT_CREATOR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,7 +111,7 @@ public class ProjectPage
         
         if (project.isPresent()) {
             // Check access to project
-            if (project != null && !isAdmin(project.get(), projectService, user)) {
+            if (project != null && !projectService.isAdmin(project.get(), user)) {
                 error("You have no permission to access project [" + project.get().getId() + "]");
                 setResponsePage(getApplication().getHomePage());
             }
@@ -169,7 +170,8 @@ public class ProjectPage
         importProjectPanel = new ProjectImportPanel("importPanel", selectedProject);
         sidebar.add(importProjectPanel);
         MetaDataRoleAuthorizationStrategy.authorize(importProjectPanel, Component.RENDER,
-                "ROLE_ADMIN");    }
+                String.join(",", ROLE_ADMIN.name(), ROLE_PROJECT_CREATOR.name()));    
+    }
 
     private List<ITab> makeTabs()
     {

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPageMenuItem.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPageMenuItem.java
@@ -23,7 +23,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.SecurityUtil;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItem;
 
@@ -58,7 +57,7 @@ public class ProjectPageMenuItem implements MenuItem
     @Override
     public boolean applies()
     {
-        return SecurityUtil.projectSettingsEnabeled(projectService, userRepo.getCurrentUser());
+        return projectService.managesAnyProject(userRepo.getCurrentUser());
     }
     
     @Override

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.java
@@ -17,7 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
 
-import java.util.Arrays;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.USER;
+import static java.util.Arrays.asList;
+
 import java.util.Collection;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -37,7 +41,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 
 public class UserPermissionsPanel
@@ -75,8 +78,7 @@ public class UserPermissionsPanel
             projectRepository.setProjectPermissionLevels(user.getObject(), project.getObject(),
                     lvls);
         }));
-        levels.setChoices(LambdaModel.of(() -> Arrays.asList(PermissionLevel.ADMIN,
-                    PermissionLevel.CURATOR, PermissionLevel.USER)));
+        levels.setChoices(asList(ADMIN, CURATOR, USER));
         levels.setChoiceRenderer(new ChoiceRenderer<PermissionLevel>("name"));
         form.add(levels);
         

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
 
+import static java.util.stream.Collectors.joining;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -41,7 +43,6 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.ListPanel_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.OverviewListChoice;
 
@@ -71,7 +72,7 @@ class UserSelectionPanel
         overviewList = new OverviewListChoice<>("user");
         overviewList.setChoiceRenderer(makeUserChoiceRenderer());
         overviewList.setModel(userModel);
-        overviewList.setChoices(LambdaModel.of(this::listUsersWithPermissions));
+        overviewList.setChoices(this::listUsersWithPermissions);
         overviewList.add(new LambdaAjaxFormComponentUpdatingBehavior("change", this::onChange));
         add(overviewList);
         
@@ -91,7 +92,7 @@ class UserSelectionPanel
             }
         };
         usersToAdd.setModel(usersToAddModel);
-        usersToAdd.setChoices(LambdaModel.of(this::listUsersWithoutPermissions));
+        usersToAdd.setChoices(this::listUsersWithoutPermissions);
         usersToAdd.setChoiceRenderer(new ChoiceRenderer<>("username"));
         form.add(usersToAdd);
         form.add(new LambdaAjaxButton<>("add", this::actionAdd));
@@ -104,16 +105,14 @@ class UserSelectionPanel
             private static final long serialVersionUID = 4607720784161484145L;
 
             @Override
-            public Object getDisplayValue(User aObject)
+            public Object getDisplayValue(User aUser)
             {
-                List<ProjectPermission> projectPermissions = projectRepository
-                        .listProjectPermissionLevel(aObject, projectModel.getObject());
-                List<String> permissionLevels = new ArrayList<>();
-                for (ProjectPermission projectPermission : projectPermissions) {
-                    permissionLevels.add(projectPermission.getLevel().getName());
-                }
-                return aObject.getUsername() + " " + permissionLevels
-                        + (aObject.isEnabled() ? "" : " (login disabled)");
+                String permissionLevels = projectRepository
+                        .getProjectPermissionLevels(aUser, projectModel.getObject()).stream()
+                        .map(PermissionLevel::getName).collect(joining(", ", "[", "]"));
+                
+                return aUser.getUsername() + " " + permissionLevels
+                        + (aUser.isEnabled() ? "" : " (login disabled)");
             }
         };
     }

--- a/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_export.adoc
+++ b/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_export.adoc
@@ -1,3 +1,4 @@
+[[sect_projects_export]]
 == Export
 
 image::project_export.jpg[align="center"]

--- a/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_import.adoc
+++ b/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_import.adoc
@@ -1,12 +1,23 @@
 == Import
 
-NOTE: This functionality is only available to *administrators*.
+NOTE: This functionality is only available to *administrators* and *project creators*.
 
-Projects are associated with the accounts of users that act as project managers, annotators, or
-curators. When importing a previously exported project, you can choose to automatically *generate
-missing users* (enabled by default). If this option is disabled, projects still maintain their
-association to users by name. If the respective user accounts are created manually after the import,
-the users will start showing up in the projects.
+Here, you can import project archives such as the example projects provided on our website or
+projects exported from the <<sect_projects_export>> tab.
 
-NOTE: Generated users are disabled and have no password. They must be explicitly enabled and a
-      password must be set before the users can log in again.
+When a user with the role *project creator* imports a project, that user automatically becomes a
+*project manager* of the imported project. However, no permissions for the project are imported!
+
+NOTE: If the current instance has users with the same name as those who originally worked on the
+      import project, the manager can add these users to the project and they can access their annotations.
+      Otherwise, only the imported source documents are accessible.
+      
+When a user with the role *administrator* imports a project, the user can choose whether to *import
+the permissions* and whether to *automatically create users* who have permissions on the imported
+project but so far do not exist. If this option to create missing users disabled, but the option to
+import permissions is enabled, then projects still maintain their association to users by name.
+If the respective user accounts are created manually after the import, the users will start showing
+up in the projects.
+
+NOTE: Automatically added users are disabled and have no password. They must be explicitly enabled
+      and a password must be set before the users can log in.


### PR DESCRIPTION
- Allow project creators to import projects but without importing permissions or creating users
- Allow admins to skip the creation of permissions and if they are skipped also skip the creation of users
- Moved several methods out of SecurityUtil and into related services
- Some minor refactoring here and there