### PR TITLE
#1170 - Reorganize behavior code

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ArcAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ArcAdapter.java
@@ -25,6 +25,7 @@ import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.selectCovered;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.uima.cas.CAS;
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.ArcCrossedMultipleSentenceException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.MultipleSentenceCoveredException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -54,70 +55,54 @@ public class ArcAdapter
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final long typeId;
-
-    /**
-     * The UIMA type name.
-     */
-    private final String annotationTypeName;
-
     /**
      * The feature of an UIMA annotation containing the label to be used as a governor for arc
      * annotations
      */
     private final String sourceFeatureName;
+
     /**
      * The feature of an UIMA annotation containing the label to be used as a dependent for arc
      * annotations
      */
-
     private final String targetFeatureName;
 
-    /*
-     * The UIMA type name used as for origin/target span annotations, e.g. {@link POS} for
-     * {@link Dependency}
-     */
-    /*
-     * private final String arcSpanType;
-     */
     /**
-     * The feature of an UIMA annotation containing the label to be used as origin/target spans for
-     * arc annotations
+     * @deprecated
+     * @param aAttacheFeatureName argument is ignored and value obtained from layer instead.
+     * @param aAttachType argument is ignored and value obtained from layer instead.
+     * @param aTypeId argument is ignored and value obtained from layer instead.
+     * @param aLayer argument is ignored and value obtained from layer instead.
      */
-    private final String attachFeatureName;
-
-    /**
-     * as Governor and Dependent of Dependency annotation type are based on Token, we need the UIMA
-     * type for token
-     */
-    private final String attachType;
-
-    /**
-     * Allow multiple annotations of the same layer (only when the type value is different)
-     */
-    private boolean allowStacking;
-
-    private boolean crossMultipleSentence;
-
+    @Deprecated
     public ArcAdapter(FeatureSupportRegistry aFeatureSupportRegistry,
             ApplicationEventPublisher aEventPublisher, AnnotationLayer aLayer, long aTypeId,
             String aTypeName, String aTargetFeatureName, String aSourceFeatureName, 
             /* String aArcSpanType, */ String aAttacheFeatureName, String aAttachType, 
             Collection<AnnotationFeature> aFeatures)
     {
+        this(aFeatureSupportRegistry, aEventPublisher, aLayer,
+                aTargetFeatureName, aSourceFeatureName, aFeatures);
+    }
+    
+    public ArcAdapter(FeatureSupportRegistry aFeatureSupportRegistry,
+            ApplicationEventPublisher aEventPublisher, AnnotationLayer aLayer,
+            String aTargetFeatureName, String aSourceFeatureName,
+            Collection<AnnotationFeature> aFeatures)
+    {
         super(aFeatureSupportRegistry, aEventPublisher, aLayer, aFeatures);
         
-        typeId = aTypeId;
-        annotationTypeName = aTypeName;
         sourceFeatureName = aSourceFeatureName;
         targetFeatureName = aTargetFeatureName;
-        attachFeatureName = aAttacheFeatureName;
-        attachType = aAttachType;
     }
 
     /**
      * Update the CAS with new/modification of arc annotations from brat
      *
+     * @param aDocument
+     *            the document to which the CAS belongs
+     * @param aUsername
+     *            the user to which the CAS belongs
      * @param aOriginFs
      *            the origin FS.
      * @param aTargetFs
@@ -132,56 +117,79 @@ public class ArcAdapter
      * @throws AnnotationException
      *             if the annotation could not be created/updated.
      */
-    public AnnotationFS add(AnnotationFS aOriginFs, AnnotationFS aTargetFs, JCas aJCas,
-            int aWindowBegin, int aWindowEnd)
+    public AnnotationFS add(SourceDocument aDocument, String aUsername, AnnotationFS aOriginFs,
+            AnnotationFS aTargetFs, JCas aJCas, int aWindowBegin, int aWindowEnd)
         throws AnnotationException
     {
-        if (crossMultipleSentence
-                || isSameSentence(aJCas, aOriginFs.getBegin(), aTargetFs.getEnd())) {
-            return interalAddToCas(aJCas, aWindowBegin, aWindowEnd, aOriginFs, aTargetFs);
-        }
-        else {
-            throw new ArcCrossedMultipleSentenceException(
-                    "Arc Annotation shouldn't cross sentence boundary");
-        }
+        return add(new CreateRelationAnnotationRequest(aDocument, aUsername, aJCas, aOriginFs,
+                aTargetFs, aWindowBegin, aWindowEnd));
     }
 
-    /**
-     * @param aWindowBegin
-     *            begin offset of the first visible sentence
-     * @param aWindowEnd
-     *            end offset of the last visible sentence
-     */
-    private AnnotationFS interalAddToCas(JCas aJCas, int aWindowBegin, int aWindowEnd,
-            AnnotationFS aOriginFs, AnnotationFS aTargetFs)
+    public AnnotationFS add(CreateRelationAnnotationRequest aRequest)
         throws AnnotationException
     {
-        Type type = getType(aJCas.getCas(), annotationTypeName);
-        Feature dependentFeature = type.getFeatureByBaseName(targetFeatureName);
-        Feature governorFeature = type.getFeatureByBaseName(sourceFeatureName);
+        CreateRelationAnnotationRequest request = aRequest;
+        
+        request = applyCrossSentenceBehavior(request);
+        
+        request = applyStackingBehavior(request);
+        
+        request = applyAttachFeatureBehavior(request);
+        
+        return createRelationAnnotation(request.getJcas().getCas(), request.getOriginFs(),
+                request.getTargetFs());
+    }
 
-        Type spanType = getType(aJCas.getCas(), attachType);
+    private CreateRelationAnnotationRequest applyAttachFeatureBehavior(
+            CreateRelationAnnotationRequest aRequest)
+    {
+        if (getLayer().getAttachFeature() == null) {
+            return aRequest;
+        }
+        
+        final CAS cas = aRequest.getJcas().getCas();
+        final Type spanType = getType(cas, getLayer().getAttachType().getName());
+        AnnotationFS originFS = aRequest.getOriginFs();
+        AnnotationFS targetFS = aRequest.getTargetFs();
+        targetFS = selectCovered(cas, spanType, targetFS.getBegin(), targetFS.getEnd()).get(0);
+        originFS = selectCovered(cas, spanType, originFS.getBegin(), originFS.getEnd()).get(0);
+        return aRequest.changeRelation(originFS, targetFS);
+    }
 
-        AnnotationFS dependentFs = null;
-        AnnotationFS governorFs = null;
-
+    private CreateRelationAnnotationRequest applyStackingBehavior(
+            CreateRelationAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        final JCas jcas = aRequest.getJcas();
+        final int windowBegin = aRequest.getWindowBegin();
+        final int windowEnd = aRequest.getWindowEnd();
+        final AnnotationFS originFS = aRequest.getOriginFs();
+        final AnnotationFS targetFS = aRequest.getTargetFs();
+        final Type type = getType(jcas.getCas(), getLayer().getName());
+        final Feature dependentFeature = type.getFeatureByBaseName(targetFeatureName);
+        final Feature governorFeature = type.getFeatureByBaseName(sourceFeatureName);
+        
         // Locate the governor and dependent annotations - looking at the annotations that are
         // presently visible on screen is sufficient - we don't have to scan the whole CAS.
-        for (AnnotationFS fs : selectCovered(aJCas.getCas(), type, aWindowBegin, aWindowEnd)) {
-
-            if (attachFeatureName != null) {
-                Feature arcSpanFeature = spanType.getFeatureByBaseName(attachFeatureName);
-                dependentFs = (AnnotationFS) fs.getFeatureValue(dependentFeature).getFeatureValue(
-                        arcSpanFeature);
-                governorFs = (AnnotationFS) fs.getFeatureValue(governorFeature).getFeatureValue(
-                        arcSpanFeature);
+        for (AnnotationFS fs : selectCovered(jcas.getCas(), type, windowBegin, windowEnd)) {
+            AnnotationFS existingTargetFS;
+            AnnotationFS existingOriginFS;
+            
+            if (getLayer().getAttachFeature() != null) {
+                final Type spanType = getType(jcas.getCas(), getLayer().getAttachType().getName());
+                Feature arcSpanFeature = spanType
+                        .getFeatureByBaseName(getLayer().getAttachFeature().getName());
+                existingTargetFS = (AnnotationFS) fs.getFeatureValue(dependentFeature)
+                        .getFeatureValue(arcSpanFeature);
+                existingOriginFS = (AnnotationFS) fs.getFeatureValue(governorFeature)
+                        .getFeatureValue(arcSpanFeature);
             }
             else {
-                dependentFs = (AnnotationFS) fs.getFeatureValue(dependentFeature);
-                governorFs = (AnnotationFS) fs.getFeatureValue(governorFeature);
+                existingTargetFS = (AnnotationFS) fs.getFeatureValue(dependentFeature);
+                existingOriginFS = (AnnotationFS) fs.getFeatureValue(governorFeature);
             }
-
-            if (dependentFs == null || governorFs == null) {
+        
+            if (existingTargetFS == null || existingOriginFS == null) {
                 log.warn("Relation [" + getLayer().getName() + "] with id [" + getAddr(fs)
                         + "] has loose ends - ignoring during while checking for duplicates.");
                 continue;
@@ -189,41 +197,52 @@ public class ArcAdapter
 
             // If stacking is not allowed and we would be creating a duplicate arc, then instead
             // update the label of the existing arc
-            if (!allowStacking && isDuplicate(governorFs, aOriginFs, dependentFs, aTargetFs)) {
+            if (!getLayer().isAllowStacking()
+                    && isDuplicate(existingOriginFS, originFS, existingTargetFS, targetFS)) {
                 throw new AnnotationException("Cannot create another annotation of layer ["
                         + getLayer().getUiName() + "] at this location - stacking is not "
                         + "enabled for this layer.");
             }
         }
-
-        // It is new ARC annotation, create it
-        dependentFs = aTargetFs;
-        governorFs = aOriginFs;
-
-        // for POS annotation, since custom span layers do not have attach feature
-        if (attachFeatureName != null) {
-            dependentFs = selectCovered(aJCas.getCas(), spanType, dependentFs.getBegin(),
-                    dependentFs.getEnd()).get(0);
-            governorFs = selectCovered(aJCas.getCas(), spanType, governorFs.getBegin(),
-                    governorFs.getEnd()).get(0);
+        
+        return aRequest;
+    }
+    
+    private CreateRelationAnnotationRequest applyCrossSentenceBehavior(
+            CreateRelationAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        if (!getLayer().isCrossSentence() && !isSameSentence(aRequest.getJcas(),
+                aRequest.getOriginFs().getBegin(), aRequest.getTargetFs().getEnd())) {
+            throw new MultipleSentenceCoveredException("Annotation coveres multiple sentences, "
+                    + "limit your annotation to single sentence!");
         }
 
-        if (dependentFs == null || governorFs == null) {
+        return aRequest;
+    }
+    
+    private AnnotationFS createRelationAnnotation(CAS cas, AnnotationFS originFS,
+            AnnotationFS targetFS)
+        throws AnnotationException
+    {
+        if (targetFS == null || originFS == null) {
             throw new AnnotationException("Relation must have a source and a target!");
         }
 
-        
         // Set the relation offsets in DKPro Core style - the relation recieves the offsets from
         // the dependent
         // If origin and target spans are multiple tokens, dependentFS.getBegin will be the
         // the begin position of the first token and dependentFS.getEnd will be the End
         // position of the last token.
-        AnnotationFS newAnnotation = aJCas.getCas().createAnnotation(type,
-                dependentFs.getBegin(), dependentFs.getEnd());
+        final Type type = getType(cas, getLayer().getName());
+        final Feature dependentFeature = type.getFeatureByBaseName(targetFeatureName);
+        final Feature governorFeature = type.getFeatureByBaseName(sourceFeatureName);
 
-        newAnnotation.setFeatureValue(dependentFeature, dependentFs);
-        newAnnotation.setFeatureValue(governorFeature, governorFs);
-        aJCas.addFsToIndexes(newAnnotation);
+        AnnotationFS newAnnotation = cas.createAnnotation(type, targetFS.getBegin(),
+                targetFS.getEnd());
+        newAnnotation.setFeatureValue(dependentFeature, targetFS);
+        newAnnotation.setFeatureValue(governorFeature, originFS);
+        cas.addFsToIndexes(newAnnotation);
         return newAnnotation;
     }
 
@@ -245,25 +264,27 @@ public class ArcAdapter
     @Override
     public long getTypeId()
     {
-        return typeId;
+        return getLayer().getId();
     }
 
     @Override
     public Type getAnnotationType(CAS cas)
     {
-        return CasUtil.getType(cas, annotationTypeName);
+        return CasUtil.getType(cas, getLayer().getName());
     }
 
     @Override
     public String getAnnotationTypeName()
     {
-        return annotationTypeName;
+        return getLayer().getName();
     }
 
     @Override
     public String getAttachFeatureName()
     {
-        return attachFeatureName;
+        return Optional.ofNullable(getLayer().getAttachFeature())
+                .map(AnnotationFeature::getName)
+                .orElse(null);
     }
 
     public void delete(SourceDocument aDocument, String aUsername, JCas aJCas,
@@ -304,56 +325,12 @@ public class ArcAdapter
         }
     }
 
-    public boolean isCrossMultipleSentence()
-    {
-        return crossMultipleSentence;
-    }
-
-    public void setCrossMultipleSentence(boolean crossMultipleSentence)
-    {
-        this.crossMultipleSentence = crossMultipleSentence;
-    }
-
-    public boolean isAllowStacking()
-    {
-        return allowStacking;
-    }
-
-    public void setAllowStacking(boolean allowStacking)
-    {
-        this.allowStacking = allowStacking;
-    }
-
-    // FIXME this is the version that treats each tag as a separate type in brat - should be removed
-    // public static String getBratTypeName(TypeAdapter aAdapter, AnnotationFS aFs,
-    // List<AnnotationFeature> aFeatures)
-    // {
-    // String annotations = "";
-    // for (AnnotationFeature feature : aFeatures) {
-    // if (!(feature.isEnabled() || feature.isEnabled())) {
-    // continue;
-    // }
-    // Feature labelFeature = aFs.getType().getFeatureByBaseName(feature.getName());
-    // if (annotations.equals("")) {
-    // annotations = aAdapter.getTypeId()
-    // + "_"
-    // + (aFs.getFeatureValueAsString(labelFeature) == null ? " " : aFs
-    // .getFeatureValueAsString(labelFeature));
-    // }
-    // else {
-    // annotations = annotations
-    // + " | "
-    // + (aFs.getFeatureValueAsString(labelFeature) == null ? " " : aFs
-    // .getFeatureValueAsString(labelFeature));
-    // }
-    // }
-    // return annotations;
-    // }
-
     @Override
     public String getAttachTypeName()
     {
-        return attachType;
+        return Optional.ofNullable(getLayer().getAttachType())
+                .map(AnnotationLayer::getName)
+                .orElse(null);
     }
 
     public String getSourceFeatureName()

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/CreateRelationAnnotationRequest.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/CreateRelationAnnotationRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
+
+import java.util.Optional;
+
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public class CreateRelationAnnotationRequest
+{
+    private final SourceDocument document;
+    private final String username;
+    private final JCas jcas;
+    private final AnnotationFS originFs;
+    private final AnnotationFS targetFs;
+    private final CreateRelationAnnotationRequest originalRequest;
+
+    private final int windowBegin;
+    private final int windowEnd;
+
+    public CreateRelationAnnotationRequest(SourceDocument aDocument, String aUsername, JCas aJCas,
+            AnnotationFS aOriginFs, AnnotationFS aTargetF, int aWindowBegin, int aWindowEnd)
+    {
+        this(null, aDocument, aUsername, aJCas, aOriginFs, aTargetF, aWindowBegin, aWindowEnd);
+    }
+
+    public CreateRelationAnnotationRequest(CreateRelationAnnotationRequest aOriginal,
+            SourceDocument aDocument, String aUsername, JCas aJCas, AnnotationFS aOriginFs,
+            AnnotationFS aTargetFs, int aWindowBegin, int aWindowEnd)
+    {
+        originalRequest = aOriginal;
+        document = aDocument;
+        username = aUsername;
+        jcas = aJCas;
+        originFs = aOriginFs;
+        targetFs = aTargetFs;
+
+        windowBegin = aWindowBegin;
+        windowEnd = aWindowEnd;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public JCas getJcas()
+    {
+        return jcas;
+    }
+
+    public AnnotationFS getOriginFs()
+    {
+        return originFs;
+    }
+
+    public AnnotationFS getTargetFs()
+    {
+        return targetFs;
+    }
+
+    public int getWindowBegin()
+    {
+        return windowBegin;
+    }
+
+    public int getWindowEnd()
+    {
+        return windowEnd;
+    }
+
+    public Optional<CreateRelationAnnotationRequest> getOriginalRequest()
+    {
+        return Optional.ofNullable(originalRequest);
+    }
+
+    public CreateRelationAnnotationRequest changeRelation(AnnotationFS aOrigin,
+            AnnotationFS aTarget)
+    {
+        return new CreateRelationAnnotationRequest(this, document, username, jcas, aOrigin, aTarget,
+                windowBegin, windowEnd);
+    }
+}

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/CreateSpanAnnotationRequest.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/CreateSpanAnnotationRequest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
+
+import java.util.Optional;
+
+import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public class CreateSpanAnnotationRequest
+{
+    private final SourceDocument document;
+    private final String username;
+    private final JCas jcas;
+    private final int begin;
+    private final int end;
+    private final CreateSpanAnnotationRequest originalRequest;
+
+    public CreateSpanAnnotationRequest(SourceDocument aDocument, String aUsername, JCas aJCas,
+            int aBegin, int aEnd)
+    {
+        this(null, aDocument, aUsername, aJCas, aBegin, aEnd);
+    }
+
+    private CreateSpanAnnotationRequest(CreateSpanAnnotationRequest aOriginal,
+            SourceDocument aDocument, String aUsername, JCas aJCas, int aBegin, int aEnd)
+    {
+        originalRequest = aOriginal;
+        document = aDocument;
+        username = aUsername;
+        jcas = aJCas;
+        begin = aBegin;
+        end = aEnd;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public JCas getJcas()
+    {
+        return jcas;
+    }
+
+    public int getBegin()
+    {
+        return begin;
+    }
+
+    public int getEnd()
+    {
+        return end;
+    }
+    
+    public Optional<CreateSpanAnnotationRequest> getOriginalRequest()
+    {
+        return Optional.ofNullable(originalRequest);
+    }
+    
+    public CreateSpanAnnotationRequest changeSpan(int aBegin, int aEnd)
+    {
+        return new CreateSpanAnnotationRequest(this, document, username, jcas, aBegin, aEnd);
+    }
+}

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
@@ -136,8 +136,12 @@ public class SpanAdapter
     private CreateSpanAnnotationRequest applyAnchoringMode(CreateSpanAnnotationRequest aRequest)
         throws AnnotationException
     {
-        if (aRequest.getBegin() == aRequest.getEnd()
-                && getLayer().getAnchoringMode().isZeroSpanAllowed()) {
+        if (aRequest.getBegin() == aRequest.getEnd()) {
+            if (!getLayer().getAnchoringMode().isZeroSpanAllowed()) {
+                throw new AnnotationException(
+                        "Cannot create zero-width annotation on layers that lock to token boundaries.");
+            }
+
             return aRequest;
         }
         

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
@@ -39,7 +39,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.SpanDeletedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.MultipleSentenceCoveredException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -58,17 +57,6 @@ public class SpanAdapter
             Collection<AnnotationFeature> aFeatures)
     {
         super(aFeatureSupportRegistry, aEventPublisher, aLayer, aFeatures);
-    }
-
-    /**
-     * @deprecated The UI class {@link AnnotatorState} should not be passed here. Use
-     *             {@link #add(SourceDocument, String, JCas, int, int)} instead.
-     */
-    @Deprecated
-    public Integer add(AnnotatorState aState, JCas aJCas, int aBegin, int aEnd)
-        throws AnnotationException
-    {
-        return add(aState.getDocument(), aState.getUser().getUsername(), aJCas, aBegin, aEnd);
     }
 
     /**
@@ -91,47 +79,103 @@ public class SpanAdapter
     public Integer add(SourceDocument aDocument, String aUsername, JCas aJCas, int aBegin, int aEnd)
         throws AnnotationException
     {
-        // if zero-offset annotation is requested
-        if (aBegin == aEnd) {
-            return createAnnotation(aDocument, aUsername, aJCas.getCas(), aBegin, aEnd);
-        }
-        if (getLayer().isCrossSentence() || isSameSentence(aJCas, aBegin, aEnd)) {
-            switch (getLayer().getAnchoringMode()) {
-            case CHARACTERS: {
-                return createAnnotation(aDocument, aUsername, aJCas.getCas(), aBegin, aEnd);
-            }
-            case SINGLE_TOKEN: {
-                List<Token> tokens = selectOverlapping(aJCas, Token.class, aBegin, aEnd);
-
-                if (tokens.isEmpty()) {
-                    throw new AnnotationException("No token is found to annotate");
+        return perform(new CreateSpanAnnotationRequest(aDocument, aUsername, aJCas, aBegin, aEnd));
+    }
+    
+    public Integer perform(CreateSpanAnnotationRequest aRequest)
+            throws AnnotationException
+    {
+        CreateSpanAnnotationRequest request = aRequest;
+        
+        request = applyCrossSentenceBehavior(request);
+        
+        request = applyAnchoringMode(request);
+        
+        request = applyStackingBehavior(request);
+        
+        return createSpanAnnotation(request.getDocument(), request.getUsername(),
+                request.getJcas().getCas(), request.getBegin(), request.getEnd());
+    }
+    
+    private CreateSpanAnnotationRequest applyStackingBehavior(CreateSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        final CAS aCas = aRequest.getJcas().getCas();
+        final int aBegin = aRequest.getBegin();
+        final int aEnd = aRequest.getEnd();
+        
+        // If stacking is not allowed and there already is an annotation, then return the address
+        // of the existing annotation.
+        Type type = CasUtil.getType(aCas, getAnnotationTypeName());
+        for (AnnotationFS fs : CasUtil.selectCovered(aCas, type, aBegin, aEnd)) {
+            if (fs.getBegin() == aBegin && fs.getEnd() == aEnd) {
+                if (!getLayer().isAllowStacking()) {
+                    throw new AnnotationException("Cannot create another annotation of layer ["
+                            + getLayer().getUiName() + "] at this location - stacking is not "
+                            + "enabled for this layer.");
                 }
-                
-                return createAnnotation(aDocument, aUsername, aJCas.getCas(),
-                        tokens.get(0).getBegin(), tokens.get(0).getEnd());
-            }
-            case TOKENS: {
-                List<Token> tokens = selectOverlapping(aJCas, Token.class, aBegin, aEnd);
-                // update the begin and ends (no sub token selection)
-                aBegin = tokens.get(0).getBegin();
-                aEnd = tokens.get(tokens.size() - 1).getEnd();
-                return createAnnotation(aDocument, aUsername, aJCas.getCas(), aBegin, aEnd);
-            }
-            case SENTENCES: {
-                List<Sentence> sentences = selectOverlapping(aJCas, Sentence.class, aBegin, aEnd);
-                // update the begin and ends (no sub token selection)
-                aBegin = sentences.get(0).getBegin();
-                aEnd = sentences.get(sentences.size() - 1).getEnd();
-                return createAnnotation(aDocument, aUsername, aJCas.getCas(), aBegin, aEnd);
-            }
-            default:
-                throw new IllegalStateException(
-                        "Unsupported anchoring mode: [" + getLayer().getAnchoringMode() + "]");
             }
         }
-        else {
-            throw new MultipleSentenceCoveredException("Annotation coveres multiple sentences, "
+        
+        return aRequest;
+    }
+
+    private CreateSpanAnnotationRequest applyCrossSentenceBehavior(
+            CreateSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        if (!getLayer().isCrossSentence()
+                && !isSameSentence(aRequest.getJcas(), aRequest.getBegin(), aRequest.getEnd())) {
+            throw new MultipleSentenceCoveredException("Annotation covers multiple sentences, "
                     + "limit your annotation to single sentence!");
+        }
+        
+        return aRequest;
+    }
+    
+    private CreateSpanAnnotationRequest applyAnchoringMode(CreateSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        if (aRequest.getBegin() == aRequest.getEnd()
+                && getLayer().getAnchoringMode().isZeroSpanAllowed()) {
+            return aRequest;
+        }
+        
+        switch (getLayer().getAnchoringMode()) {
+        case CHARACTERS: {
+            return aRequest;
+        }
+        case SINGLE_TOKEN: {
+            List<Token> tokens = selectOverlapping(aRequest.getJcas(), Token.class,
+                    aRequest.getBegin(), aRequest.getEnd());
+
+            if (tokens.isEmpty()) {
+                throw new AnnotationException("No token is found to annotate");
+            }
+                        
+            return aRequest.changeSpan(tokens.get(0).getBegin(), tokens.get(0).getEnd());
+        }
+        case TOKENS: {
+            List<Token> tokens = selectOverlapping(aRequest.getJcas(), Token.class,
+                    aRequest.getBegin(), aRequest.getEnd());
+            // update the begin and ends (no sub token selection)
+            int begin = tokens.get(0).getBegin();
+            int end = tokens.get(tokens.size() - 1).getEnd();
+            
+            return aRequest.changeSpan(begin, end);
+        }
+        case SENTENCES: {
+            List<Sentence> sentences = selectOverlapping(aRequest.getJcas(), Sentence.class,
+                    aRequest.getBegin(), aRequest.getEnd());
+            // update the begin and ends (no sub token selection)
+            int begin = sentences.get(0).getBegin();
+            int end = sentences.get(sentences.size() - 1).getEnd();
+            
+            return aRequest.changeSpan(begin, end);
+        }
+        default:
+            throw new IllegalStateException(
+                    "Unsupported anchoring mode: [" + getLayer().getAnchoringMode() + "]");
         }
     }
     
@@ -187,21 +231,11 @@ public class SpanAdapter
     /**
      * A Helper method to add annotation to CAS
      */
-    private Integer createAnnotation(SourceDocument aDocument, String aUsername, CAS aCas,
+    private Integer createSpanAnnotation(SourceDocument aDocument, String aUsername, CAS aCas,
             int aBegin, int aEnd)
         throws AnnotationException
     {
-        // If stacking is not allowed and there already is an annotation, then return the address
-        // of the existing annotation.
         Type type = CasUtil.getType(aCas, getAnnotationTypeName());
-        for (AnnotationFS fs : CasUtil.selectCovered(aCas, type, aBegin, aEnd)) {
-            if (fs.getBegin() == aBegin && fs.getEnd() == aEnd) {
-                if (!getLayer().isAllowStacking()) {
-                    return getAddr(fs);
-                }
-            }
-        }
-        
         AnnotationFS newAnnotation = aCas.createAnnotation(type, aBegin, aEnd);
         
         // If if the layer attaches to a feature, then set the attach-feature to the newly

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/RelationLayerSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/RelationLayerSupport.java
@@ -17,11 +17,14 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_TARGET;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.RELATION_TYPE;
 import static java.util.Arrays.asList;
+import static org.apache.uima.cas.CAS.TYPE_NAME_ANNOTATION;
 
 import java.util.List;
 
-import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.beans.factory.InitializingBean;
@@ -30,7 +33,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.ArcAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
@@ -70,54 +72,47 @@ public class RelationLayerSupport
     {
         layerSupportId = aBeanName;
     }
-    
+
     @Override
     public void afterPropertiesSet() throws Exception
     {
-        types = asList(new LayerType(WebAnnoConst.RELATION_TYPE, "Relation", layerSupportId));
+        types = asList(new LayerType(RELATION_TYPE, "Relation", layerSupportId));
     }
-    
+
     @Override
     public List<LayerType> getSupportedLayerTypes()
     {
         return types;
     }
-    
+
     @Override
     public boolean accepts(AnnotationLayer aLayer)
     {
-        return WebAnnoConst.RELATION_TYPE.equals(aLayer.getType());
+        return RELATION_TYPE.equals(aLayer.getType());
     }
-    
+
     @Override
     public ArcAdapter createAdapter(AnnotationLayer aLayer)
     {
         ArcAdapter adapter = new ArcAdapter(featureSupportRegistry, eventPublisher, aLayer,
-                aLayer.getId(), aLayer.getName(), WebAnnoConst.FEAT_REL_TARGET,
-                WebAnnoConst.FEAT_REL_SOURCE,
-                aLayer.getAttachFeature() == null ? null : aLayer.getAttachFeature().getName(),
-                aLayer.getAttachType().getName(), schemaService.listAnnotationFeature(aLayer));
-
-        adapter.setCrossMultipleSentence(aLayer.isCrossSentence());
-        adapter.setAllowStacking(aLayer.isAllowStacking());
+                FEAT_REL_TARGET, FEAT_REL_SOURCE, schemaService.listAnnotationFeature(aLayer));
 
         return adapter;
     }
-    
+
     @Override
     public void generateTypes(TypeSystemDescription aTsd, AnnotationLayer aLayer)
     {
-        TypeDescription td = aTsd.addType(aLayer.getName(), "", CAS.TYPE_NAME_ANNOTATION);
+        TypeDescription td = aTsd.addType(aLayer.getName(), "", TYPE_NAME_ANNOTATION);
         AnnotationLayer attachType = aLayer.getAttachType();
 
-        td.addFeature(WebAnnoConst.FEAT_REL_TARGET, "", attachType.getName());
-        td.addFeature(WebAnnoConst.FEAT_REL_SOURCE, "", attachType.getName());
+        td.addFeature(FEAT_REL_TARGET, "", attachType.getName());
+        td.addFeature(FEAT_REL_SOURCE, "", attachType.getName());
 
         generateFeatures(aTsd, td, aLayer);
     }
-    
-    void generateFeatures(TypeSystemDescription aTSD, TypeDescription aTD,
-            AnnotationLayer aLayer)
+
+    void generateFeatures(TypeSystemDescription aTSD, TypeDescription aTD, AnnotationLayer aLayer)
     {
         List<AnnotationFeature> features = schemaService.listAnnotationFeature(aLayer);
         for (AnnotationFeature feature : features) {
@@ -125,7 +120,7 @@ public class RelationLayerSupport
             fs.generateFeature(aTSD, aTD, feature);
         }
     }
-    
+
     @Override
     public Renderer getRenderer(AnnotationLayer aLayer)
     {

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -203,8 +203,9 @@ public abstract class AnnotationDetailEditorPanel
         AnnotationFS targetFs = selectByAddr(aJCas, selection.getTarget());
 
         // Creating a relation
-        AnnotationFS arc = aAdapter.add(originFs, targetFs, aJCas, state.getWindowBeginOffset(),
-            state.getWindowEndOffset());
+        AnnotationFS arc = aAdapter.add(state.getDocument(), state.getUser().getUsername(),
+                originFs, targetFs, aJCas, state.getWindowBeginOffset(),
+                state.getWindowEndOffset());
         selection.selectArc(new VID(arc), originFs, targetFs);
     }
 
@@ -860,7 +861,8 @@ public abstract class AnnotationDetailEditorPanel
         TypeAdapter adapter = annotationService.getAdapter(state.getSelectedAnnotationLayer());
         if (adapter instanceof ArcAdapter) {
             // If no features, still create arc #256
-            AnnotationFS arc = ((ArcAdapter) adapter).add(targetFs, originFs, jCas,
+            AnnotationFS arc = ((ArcAdapter) adapter).add(state.getDocument(),
+                    state.getUser().getUsername(), targetFs, originFs, jCas,
                     state.getWindowBeginOffset(), state.getWindowEndOffset());
             state.getSelection().setAnnotation(new VID(getAddr(arc)));
             

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/util/AutomationUtil.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/util/AutomationUtil.java
@@ -168,7 +168,7 @@ public class AutomationUtil
                 governorFs = (AnnotationFS) fs.getFeatureValue(governorFeature);
             }
 
-            if (adapter.isCrossMultipleSentence()) {
+            if (adapter.getLayer().isCrossSentence()) {
                 List<AnnotationFS> mSpanAnnos = new ArrayList<>(
                         getAllAnnoFss(jCas, governorFs.getType()));
                 repeatRelation(aState, 0, jCas.getDocumentText().length() - 1, aFeature, aValue,
@@ -200,7 +200,8 @@ public class AutomationUtil
         for (AnnotationFS fs : aSpanAnnos) {
             if (dCoveredText.equals(fs.getCoveredText())) {
                 if (g != null && isSamAnno(attachSpanType, fs, aDepFS)) {
-                    AnnotationFS arc = adapter.add(g, fs, jCas, aStart, aEnd);
+                    AnnotationFS arc = adapter.add(aState.getDocument(),
+                            aState.getUser().getUsername(), g, fs, jCas, aStart, aEnd);
                     adapter.setFeatureValue(aState.getDocument(), aState.getUser().getUsername(),
                             jCas, getAddr(arc), aFeature, aValue);
                     g = null;
@@ -215,7 +216,8 @@ public class AutomationUtil
             // we don't use else, in case gov and dep are the same
             if (gCoveredText.equals(fs.getCoveredText())  ) {
                 if (d != null && isSamAnno(attachSpanType, fs, aGovFS)) {
-                    AnnotationFS arc = adapter.add(fs, d, jCas, aStart, aEnd);
+                    AnnotationFS arc = adapter.add(aState.getDocument(),
+                            aState.getUser().getUsername(), fs, d, jCas, aStart, aEnd);
                     adapter.setFeatureValue(aState.getDocument(), aState.getUser().getUsername(),
                             jCas, getAddr(arc), aFeature, aValue);
                     g = null;

--- a/webanno-ui-curation/pom.xml
+++ b/webanno-ui-curation/pom.xml
@@ -181,6 +181,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.testing-asl</artifactId>
       <scope>test</scope>

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCas.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/MergeCas.java
@@ -622,7 +622,7 @@ public class MergeCas
     {
         if (MergeCas.existsSameAnnoOnPosition(aFSClicked, aMergeJCas)) {
             throw new AnnotationException(
-                    "Same Annotation exists on the mergeview. Please add it manually.");
+                    "Same annotation already exists on the mergeview. Please add it manually.");
         }
 
         // a) if stacking allowed add this new annotation to the mergeview

--- a/webanno-ui-curation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/CopyAnnotationTest.java
+++ b/webanno-ui-curation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/util/CopyAnnotationTest.java
@@ -17,8 +17,17 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.curation.util;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_TARGET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.JCasFactory.createJCas;
+import static org.apache.uima.fit.util.CasUtil.selectCovered;
+import static org.apache.uima.fit.util.JCasUtil.selectCovered;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -34,13 +43,11 @@ import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.jcas.JCas;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
@@ -54,7 +61,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff2;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
@@ -62,6 +68,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import mockit.Mock;
@@ -77,6 +84,8 @@ public class CopyAnnotationTest
     private AnnotationFeature tokenPosFeature;
     private AnnotationLayer posLayer;
     private AnnotationFeature posFeature;
+    private AnnotationLayer neLayer;
+    private AnnotationFeature neFeature;
     private AnnotationLayer slotLayer;
     private AnnotationFeature slotFeature;
     private AnnotationFeature stringFeature;
@@ -86,8 +95,8 @@ public class CopyAnnotationTest
     {
         project = new Project();
         
-        tokenLayer = new AnnotationLayer(Token.class.getName(), "Token",
-                SPAN_TYPE, null, true, AnchoringMode.SINGLE_TOKEN);
+        tokenLayer = new AnnotationLayer(Token.class.getName(), "Token", SPAN_TYPE, null, true,
+                SINGLE_TOKEN);
         
         tokenPosFeature = new AnnotationFeature();
         tokenPosFeature.setName("pos");
@@ -98,8 +107,8 @@ public class CopyAnnotationTest
         tokenPosFeature.setProject(project);
         tokenPosFeature.setVisible(true);
         
-        posLayer = new AnnotationLayer(POS.class.getName(), "POS",
-                SPAN_TYPE, project, true, AnchoringMode.SINGLE_TOKEN);
+        posLayer = new AnnotationLayer(POS.class.getName(), "POS", SPAN_TYPE, project, true,
+                SINGLE_TOKEN);
         posLayer.setAttachType(tokenLayer);
         posLayer.setAttachFeature(tokenPosFeature);
         
@@ -112,8 +121,20 @@ public class CopyAnnotationTest
         posFeature.setProject(project);
         posFeature.setVisible(true);
         
-        slotLayer = new AnnotationLayer(DiffUtils.HOST_TYPE, DiffUtils.HOST_TYPE,
-                SPAN_TYPE, project, false, AnchoringMode.SINGLE_TOKEN);
+        neLayer = new AnnotationLayer(NamedEntity.class.getName(), "Named Entity", SPAN_TYPE,
+                project, true, TOKENS);
+        
+        neFeature = new AnnotationFeature();
+        neFeature.setName("value");
+        neFeature.setEnabled(true);
+        neFeature.setType(CAS.TYPE_NAME_STRING);
+        neFeature.setUiName("value");
+        neFeature.setLayer(neLayer);
+        neFeature.setProject(project);
+        neFeature.setVisible(true);
+        
+        slotLayer = new AnnotationLayer(DiffUtils.HOST_TYPE, DiffUtils.HOST_TYPE, SPAN_TYPE,
+                project, false, SINGLE_TOKEN);
         slotFeature = new AnnotationFeature();
         slotFeature.setName("links");
         slotFeature.setEnabled(true);
@@ -139,6 +160,9 @@ public class CopyAnnotationTest
             {
                 if (type.getName().equals(POS.class.getName())) {
                     return asList(posFeature);
+                }
+                if (type.getName().equals(NamedEntity.class.getName())) {
+                    return asList(neFeature);
                 }
                 if (type.getName().equals(DiffUtils.HOST_TYPE)) {
                     return asList(slotFeature, stringFeature);
@@ -170,26 +194,37 @@ public class CopyAnnotationTest
     public void simpleCopyToEmptyTest()
         throws Exception
     {
-        AnnotatorState state = new AnnotatorStateImpl(Mode.CURATION);
+        AnnotatorState state = new AnnotatorStateImpl(CURATION);
         state.setUser(new User());
         
-        JCas jcas = JCasFactory.createJCas();
-        Type type = jcas.getTypeSystem().getType(POS.class.getTypeName());
-        AnnotationFS clickedFs = createPOSAnno(jcas, type, "NN", 0, 0);
+        JCas jcas = createJCas();
+        AnnotationFS clickedFs = createNEAnno(jcas, "NN", 0, 0);
 
-        JCas mergeCAs = JCasFactory.createJCas();
-        createTokenAnno(mergeCAs, 0, 0);
+        JCas mergeCas = createJCas();
+        createTokenAnno(mergeCas, 0, 0);
 
         MergeCas.addSpanAnnotation(state, annotationSchemaService,
-                posLayer, mergeCAs, clickedFs, false);
+                neLayer, mergeCas, clickedFs, false);
 
-        assertEquals(1, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 0).size());
+        assertEquals(1, selectCovered(mergeCas, NamedEntity.class, 0, 0).size());
     }
 
-    private AnnotationFS createPOSAnno(JCas aJCas, Type aType, String aValue, int aBegin, int aEnd)
+    private AnnotationFS createNEAnno(JCas aJCas, String aValue, int aBegin, int aEnd)
     {
-        AnnotationFS clickedFs = aJCas.getCas().createAnnotation(aType, aBegin, aEnd);
-        Feature posValue = aType.getFeatureByBaseName("PosValue");
+        Type type = aJCas.getTypeSystem().getType(NamedEntity.class.getTypeName());
+        AnnotationFS clickedFs = aJCas.getCas().createAnnotation(type, aBegin, aEnd);
+        Feature value = type.getFeatureByBaseName("value");
+        clickedFs.setStringValue(value, aValue);
+        aJCas.addFsToIndexes(clickedFs);
+        return clickedFs;
+    }
+
+    private AnnotationFS createPOSAnno(JCas aJCas, String aValue, int aBegin, int aEnd)
+    {
+        Type type = aJCas.getTypeSystem().getType(POS.class.getTypeName());
+        
+        AnnotationFS clickedFs = aJCas.getCas().createAnnotation(type, aBegin, aEnd);
+        Feature posValue = type.getFeatureByBaseName("PosValue");
         clickedFs.setStringValue(posValue, aValue);
         aJCas.addFsToIndexes(clickedFs);
         return clickedFs;
@@ -207,36 +242,37 @@ public class CopyAnnotationTest
     public void simpleCopyToSameExistingAnnoTest()
         throws Exception
     {
-        JCas jcas = JCasFactory.createJCas();
+        JCas jcas = createJCas();
         Type type = jcas.getTypeSystem().getType(POS.class.getTypeName());
-        AnnotationFS clickedFs = createPOSAnno(jcas, type, "NN", 0, 0);
+        AnnotationFS clickedFs = createPOSAnno(jcas, "NN", 0, 0);
 
-        JCas mergeCAs = JCasFactory.createJCas();
-        AnnotationFS existingFs = mergeCAs.getCas().createAnnotation(type, 0, 0);
+        JCas mergeCas = createJCas();
+        AnnotationFS existingFs = mergeCas.getCas().createAnnotation(type, 0, 0);
         Feature posValue = type.getFeatureByBaseName("PosValue");
         existingFs.setStringValue(posValue, "NN");
-        mergeCAs.addFsToIndexes(existingFs);
+        mergeCas.addFsToIndexes(existingFs);
 
-        exception.expect(AnnotationException.class);
-        MergeCas.addSpanAnnotation(new AnnotatorStateImpl(Mode.CURATION), annotationSchemaService,
-                posLayer, mergeCAs, clickedFs, false);
+        Assertions.assertThatExceptionOfType(AnnotationException.class)
+                .isThrownBy(() -> MergeCas.addSpanAnnotation(new AnnotatorStateImpl(Mode.CURATION),
+                        annotationSchemaService, posLayer, mergeCas, clickedFs, false))
+                .withMessageContaining("annotation already exists");
     }
 
     @Test
     public void simpleCopyToDiffExistingAnnoWithNoStackingTest()
         throws Exception
     {
-        JCas jcas = JCasFactory.createJCas();
+        JCas jcas = createJCas();
         Type type = jcas.getTypeSystem().getType(POS.class.getTypeName());
-        AnnotationFS clickedFs = createPOSAnno(jcas, type, "NN", 0, 0);
+        AnnotationFS clickedFs = createPOSAnno(jcas, "NN", 0, 0);
 
-        JCas mergeCAs = JCasFactory.createJCas();
+        JCas mergeCAs = createJCas();
         AnnotationFS existingFs = mergeCAs.getCas().createAnnotation(type, 0, 0);
         Feature posValue = type.getFeatureByBaseName("PosValue");
         existingFs.setStringValue(posValue, "NE");
         mergeCAs.addFsToIndexes(existingFs);
 
-        MergeCas.addSpanAnnotation(new AnnotatorStateImpl(Mode.CURATION), annotationSchemaService,
+        MergeCas.addSpanAnnotation(new AnnotatorStateImpl(CURATION), annotationSchemaService,
                 posLayer, mergeCAs, clickedFs, false);
 
         assertEquals(1, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 0).size());
@@ -246,26 +282,26 @@ public class CopyAnnotationTest
     public void simpleCopyToDiffExistingAnnoWithStackingTest()
         throws Exception
     {
-        AnnotatorState state = new AnnotatorStateImpl(Mode.CURATION);
+        AnnotatorState state = new AnnotatorStateImpl(CURATION);
         state.setUser(new User());
         
-        posLayer.setAllowStacking(true);
+        neLayer.setAllowStacking(true);
 
-        JCas jcas = JCasFactory.createJCas();
-        Type type = jcas.getTypeSystem().getType(POS.class.getTypeName());
-        AnnotationFS clickedFs = createPOSAnno(jcas, type, "NN", 0, 0);
+        JCas jcas = createJCas();
+        Type type = jcas.getTypeSystem().getType(NamedEntity.class.getTypeName());
+        AnnotationFS clickedFs = createNEAnno(jcas, "NN", 0, 0);
 
-        JCas mergeCAs = JCasFactory.createJCas();
+        JCas mergeCAs = createJCas();
         createTokenAnno(mergeCAs, 0, 0);
         AnnotationFS existingFs = mergeCAs.getCas().createAnnotation(type, 0, 0);
-        Feature posValue = type.getFeatureByBaseName("PosValue");
+        Feature posValue = type.getFeatureByBaseName("value");
         existingFs.setStringValue(posValue, "NE");
         mergeCAs.addFsToIndexes(existingFs);
 
-        MergeCas.addSpanAnnotation(state, annotationSchemaService, posLayer, mergeCAs, clickedFs,
+        MergeCas.addSpanAnnotation(state, annotationSchemaService, neLayer, mergeCAs, clickedFs,
                 true);
 
-        assertEquals(2, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 0).size());
+        assertEquals(2, selectCovered(mergeCAs.getCas(), type, 0, 0).size());
     }
 
     @Test
@@ -274,7 +310,7 @@ public class CopyAnnotationTest
     {
         slotLayer.setAllowStacking(false);
         
-        JCas jcasA = JCasFactory.createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
+        JCas jcasA = createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
         Type type = jcasA.getTypeSystem().getType(DiffUtils.HOST_TYPE);
         Feature feature = type.getFeatureByBaseName("f1");
 
@@ -287,22 +323,23 @@ public class CopyAnnotationTest
         DiffUtils.makeLinkHostMultiSPanFeatureFS(mergeCAs, 0, 0, feature, "C",
                 DiffUtils.makeLinkFS(mergeCAs, "slot1", 0, 0));
 
-        MergeCas.addSpanAnnotation(new AnnotatorStateImpl(Mode.CURATION), annotationSchemaService,
+        MergeCas.addSpanAnnotation(new AnnotatorStateImpl(CURATION), annotationSchemaService,
                 slotLayer, mergeCAs, clickedFs, false);
 
-        assertEquals(1, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 0).size());
+        assertEquals(1, selectCovered(mergeCAs.getCas(), type, 0, 0).size());
     }
 
     @Test
     public void copySpanWithSlotWithStackingTest()
         throws Exception
     {
-        AnnotatorState state = new AnnotatorStateImpl(Mode.CURATION);
+        AnnotatorState state = new AnnotatorStateImpl(CURATION);
         state.setUser(new User());
         
+        slotLayer.setAnchoringMode(TOKENS);
         slotLayer.setAllowStacking(true);
         
-        JCas jcasA = JCasFactory.createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
+        JCas jcasA = createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
         Type type = jcasA.getTypeSystem().getType(DiffUtils.HOST_TYPE);
         Feature feature = type.getFeatureByBaseName("f1");
 
@@ -318,16 +355,14 @@ public class CopyAnnotationTest
         MergeCas.addSpanAnnotation(state, annotationSchemaService, slotLayer, mergeCAs, clickedFs,
                 true);
 
-        assertEquals(2, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 0).size());
+        assertEquals(2, selectCovered(mergeCAs.getCas(), type, 0, 0).size());
     }
 
     @Test
     public void copyLinkToEmptyTest()
         throws Exception
     {
-
-        JCas mergeCAs = JCasFactory
-                .createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
+        JCas mergeCAs = createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
         Type type = mergeCAs.getTypeSystem().getType(DiffUtils.HOST_TYPE);
         Feature feature = type.getFeatureByBaseName("f1");
 
@@ -340,7 +375,7 @@ public class CopyAnnotationTest
         linkFs.add(copyFS);
         WebAnnoCasUtil.setLinkFeatureValue(mergeFs, type.getFeatureByBaseName("links"), linkFs);
 
-        JCas jcasA = JCasFactory.createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
+        JCas jcasA = createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
         DiffUtils.makeLinkHostMultiSPanFeatureFS(jcasA, 0, 0, feature, "A",
                 DiffUtils.makeLinkFS(jcasA, "slot1", 0, 0));
 
@@ -380,7 +415,7 @@ public class CopyAnnotationTest
         linkFs.add(copyFS);
         WebAnnoCasUtil.setLinkFeatureValue(mergeFs, type.getFeatureByBaseName("links"), linkFs);
 
-        JCas jcasA = JCasFactory.createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
+        JCas jcasA = createJCas(DiffUtils.createMultiLinkWithRoleTestTypeSytem("f1"));
         DiffUtils.makeLinkHostMultiSPanFeatureFS(jcasA, 0, 0, feature, "A",
                 DiffUtils.makeLinkFS(jcasA, "slot1", 0, 0));
 
@@ -405,15 +440,14 @@ public class CopyAnnotationTest
     public void simpleCopyRelationToEmptyAnnoTest()
         throws Exception
     {
-        JCas jcas = JCasFactory.createJCas();
+        JCas jcas = createJCas();
         Type type = jcas.getTypeSystem().getType(Dependency.class.getTypeName());
-        Type posType = jcas.getTypeSystem().getType(POS.class.getTypeName());
 
         AnnotationFS originClickedToken = createTokenAnno(jcas, 0, 0);
         AnnotationFS targetClickedToken = createTokenAnno(jcas, 1, 1);
 
-        AnnotationFS originClicked = createPOSAnno(jcas, posType, "NN", 0, 0);
-        AnnotationFS targetClicked = createPOSAnno(jcas, posType, "NN", 1, 1);
+        AnnotationFS originClicked = createPOSAnno(jcas, "NN", 0, 0);
+        AnnotationFS targetClicked = createPOSAnno(jcas, "NN", 1, 1);
 
         jcas.addFsToIndexes(originClicked);
         jcas.addFsToIndexes(targetClicked);
@@ -423,17 +457,17 @@ public class CopyAnnotationTest
         targetClickedToken.setFeatureValue(targetClickedToken.getType().getFeatureByBaseName("pos"),
                 targetClicked);
 
-        Feature sourceFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_SOURCE);
-        Feature targetFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_TARGET);
+        Feature sourceFeature = type.getFeatureByBaseName(FEAT_REL_SOURCE);
+        Feature targetFeature = type.getFeatureByBaseName(FEAT_REL_TARGET);
 
         AnnotationFS clickedFs = jcas.getCas().createAnnotation(type, 0, 1);
         clickedFs.setFeatureValue(sourceFeature, originClickedToken);
         clickedFs.setFeatureValue(targetFeature, targetClickedToken);
         jcas.addFsToIndexes(clickedFs);
 
-        JCas mergeCAs = JCasFactory.createJCas();
-        AnnotationFS origin = createPOSAnno(mergeCAs, posType, "NN", 0, 0);
-        AnnotationFS target = createPOSAnno(mergeCAs, posType, "NN", 1, 1);
+        JCas mergeCAs = createJCas();
+        AnnotationFS origin = createPOSAnno(mergeCAs, "NN", 0, 0);
+        AnnotationFS target = createPOSAnno(mergeCAs, "NN", 1, 1);
 
         mergeCAs.addFsToIndexes(origin);
         mergeCAs.addFsToIndexes(target);
@@ -448,22 +482,22 @@ public class CopyAnnotationTest
 
         MergeCas.addRelationArcAnnotation(mergeCAs, clickedFs, true, false, originToken,
                 targetToken);
-        assertEquals(1, CasUtil.selectCovered(mergeCAs.getCas(), type, 0, 1).size());
+        
+        assertEquals(1, selectCovered(mergeCAs.getCas(), type, 0, 1).size());
     }
 
     @Test
     public void simpleCopyRelationToStackedTargetsTest()
         throws Exception
     {
-        JCas jcas = JCasFactory.createJCas();
+        JCas jcas = createJCas();
         Type type = jcas.getTypeSystem().getType(Dependency.class.getTypeName());
-        Type posType = jcas.getTypeSystem().getType(POS.class.getTypeName());
 
         AnnotationFS originClickedToken = createTokenAnno(jcas, 0, 0);
         AnnotationFS targetClickedToken = createTokenAnno(jcas, 1, 1);
 
-        AnnotationFS originClicked = createPOSAnno(jcas, posType, "NN", 0, 0);
-        AnnotationFS targetClicked = createPOSAnno(jcas, posType, "NN", 1, 1);
+        AnnotationFS originClicked = createPOSAnno(jcas, "NN", 0, 0);
+        AnnotationFS targetClicked = createPOSAnno(jcas, "NN", 1, 1);
 
         jcas.addFsToIndexes(originClicked);
         jcas.addFsToIndexes(targetClicked);
@@ -473,17 +507,17 @@ public class CopyAnnotationTest
         targetClickedToken.setFeatureValue(targetClickedToken.getType().getFeatureByBaseName("pos"),
                 targetClicked);
 
-        Feature sourceFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_SOURCE);
-        Feature targetFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_TARGET);
+        Feature sourceFeature = type.getFeatureByBaseName(FEAT_REL_SOURCE);
+        Feature targetFeature = type.getFeatureByBaseName(FEAT_REL_TARGET);
 
         AnnotationFS clickedFs = jcas.getCas().createAnnotation(type, 0, 1);
         clickedFs.setFeatureValue(sourceFeature, originClickedToken);
         clickedFs.setFeatureValue(targetFeature, targetClickedToken);
         jcas.addFsToIndexes(clickedFs);
 
-        JCas mergeCAs = JCasFactory.createJCas();
-        AnnotationFS origin = createPOSAnno(mergeCAs, posType, "NN", 0, 0);
-        AnnotationFS target = createPOSAnno(mergeCAs, posType, "NN", 1, 1);
+        JCas mergeCAs = createJCas();
+        AnnotationFS origin = createPOSAnno(mergeCAs, "NN", 0, 0);
+        AnnotationFS target = createPOSAnno(mergeCAs, "NN", 1, 1);
 
         mergeCAs.addFsToIndexes(origin);
         mergeCAs.addFsToIndexes(target);
@@ -496,8 +530,8 @@ public class CopyAnnotationTest
         mergeCAs.addFsToIndexes(originToken);
         mergeCAs.addFsToIndexes(targetToken);
 
-        AnnotationFS origin2 = createPOSAnno(mergeCAs, posType, "NN", 0, 0);
-        AnnotationFS target2 = createPOSAnno(mergeCAs, posType, "NN", 1, 1);
+        AnnotationFS origin2 = createPOSAnno(mergeCAs, "NN", 0, 0);
+        AnnotationFS target2 = createPOSAnno(mergeCAs, "NN", 1, 1);
 
         mergeCAs.addFsToIndexes(origin2);
         mergeCAs.addFsToIndexes(target2);
@@ -510,25 +544,24 @@ public class CopyAnnotationTest
         mergeCAs.addFsToIndexes(originToken2);
         mergeCAs.addFsToIndexes(targetToken2);
 
-        exception.expect(AnnotationException.class);
-        MergeCas.addRelationArcAnnotation(mergeCAs, clickedFs, true, false, originToken,
-                targetToken);
-
+        assertThatExceptionOfType(AnnotationException.class)
+                .isThrownBy(() -> MergeCas.addRelationArcAnnotation(mergeCAs, clickedFs, true,
+                        false, originToken, targetToken))
+                .withMessageContaining("Stacked sources exist");
     }
 
     @Test
-    public void simpleCopyStackedRelationTest()
+    public void thatMergingRelationIsRejectedIfAlreadyExists()
         throws Exception
     {
-        JCas jcas = JCasFactory.createJCas();
+        JCas jcas = createJCas();
         Type type = jcas.getTypeSystem().getType(Dependency.class.getTypeName());
-        Type posType = jcas.getTypeSystem().getType(POS.class.getTypeName());
 
         AnnotationFS originClickedToken = createTokenAnno(jcas, 0, 0);
         AnnotationFS targetClickedToken = createTokenAnno(jcas, 1, 1);
 
-        AnnotationFS originClicked = createPOSAnno(jcas, posType, "NN", 0, 0);
-        AnnotationFS targetClicked = createPOSAnno(jcas, posType, "NN", 1, 1);
+        AnnotationFS originClicked = createPOSAnno(jcas, "NN", 0, 0);
+        AnnotationFS targetClicked = createPOSAnno(jcas, "NN", 1, 1);
 
         jcas.addFsToIndexes(originClicked);
         jcas.addFsToIndexes(targetClicked);
@@ -538,17 +571,17 @@ public class CopyAnnotationTest
         targetClickedToken.setFeatureValue(targetClickedToken.getType().getFeatureByBaseName("pos"),
                 targetClicked);
 
-        Feature sourceFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_SOURCE);
-        Feature targetFeature = type.getFeatureByBaseName(WebAnnoConst.FEAT_REL_TARGET);
+        Feature sourceFeature = type.getFeatureByBaseName(FEAT_REL_SOURCE);
+        Feature targetFeature = type.getFeatureByBaseName(FEAT_REL_TARGET);
 
         AnnotationFS clickedFs = jcas.getCas().createAnnotation(type, 0, 1);
         clickedFs.setFeatureValue(sourceFeature, originClickedToken);
         clickedFs.setFeatureValue(targetFeature, targetClickedToken);
         jcas.addFsToIndexes(clickedFs);
 
-        JCas mergeCAs = JCasFactory.createJCas();
-        AnnotationFS origin = createPOSAnno(mergeCAs, posType, "NN", 0, 0);
-        AnnotationFS target = createPOSAnno(mergeCAs, posType, "NN", 1, 1);
+        JCas mergeCAs = createJCas();
+        AnnotationFS origin = createPOSAnno(mergeCAs, "NN", 0, 0);
+        AnnotationFS target = createPOSAnno(mergeCAs, "NN", 1, 1);
 
         mergeCAs.addFsToIndexes(origin);
         mergeCAs.addFsToIndexes(target);
@@ -566,11 +599,9 @@ public class CopyAnnotationTest
         existing.setFeatureValue(targetFeature, targetToken);
         mergeCAs.addFsToIndexes(clickedFs);
 
-        exception.expect(AnnotationException.class);
-        MergeCas.addRelationArcAnnotation(mergeCAs, clickedFs, true, false, originToken,
-                targetToken);
+        assertThatExceptionOfType(AnnotationException.class)
+                .isThrownBy(() -> MergeCas.addRelationArcAnnotation(mergeCAs, clickedFs, true,
+                        false, originToken, targetToken))
+                .withMessageContaining("annotation already exists");
     }
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 }


### PR DESCRIPTION
- Remove unnecessary fields in ArcAdapter and obtain values from layer instead
- Move behavior code into separate methods in ArcAdapter and SpanAdapter and encapsulate annotation creation parameters into a command class
- Change in behavior: When trying to create a span at a location where a span is already existing and stacking is not enabled, generate an error instead of selecting the existing span