### PR TITLE
#1191 - Saving feature with traits causes NPE

### DIFF
--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaButton.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaButton.java
@@ -29,6 +29,7 @@ public class LambdaButton
 
     private SerializableRunnable action;
     private SerializableConsumer<Exception> exceptionHandler;
+    private boolean triggerAfterSubmit;
 
     public LambdaButton(String aId, SerializableRunnable aAction)
     {
@@ -42,9 +43,30 @@ public class LambdaButton
         action = aAction;
         exceptionHandler = aExceptionHandler;
     }
+    
+    public LambdaButton triggerAfterSubmit()
+    {
+        triggerAfterSubmit = true;
+        return this;
+    }
 
     @Override
     public void onSubmit()
+    {
+        if (!triggerAfterSubmit) {
+            action();
+        }
+    }
+    
+    @Override
+    public void onAfterSubmit()
+    {
+        if (triggerAfterSubmit) {
+            action();
+        }
+    }
+    
+    private void action()
     {
         try {
             action.run();

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
@@ -184,7 +184,7 @@ public class FeatureDetailForm
             }
         });
 
-        add(new LambdaButton("save", this::actionSave));
+        add(new LambdaButton("save", this::actionSave).triggerAfterSubmit());
         add(new LambdaAjaxButton<>("delete", this::actionDelete).add(
                 visibleWhen(() -> !isNull(getModelObject().getId()))));
         // Set default form processing to false to avoid saving data


### PR DESCRIPTION
- Allow LambdaAjaxButton to trigger its action after the form submit
- Use this do delay the call to actionSave which clear the model object until after the form has been fully processed (i.e. onAfterSubmit)