### PR TITLE
#1196 - Crossing sentence bounardies is not permitted

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationCrossSentenceBehavior.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationCrossSentenceBehavior.java
@@ -18,7 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VCommentType.ERROR;
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isSameSentence;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isBeginEndInSameSentence;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isBeginInSameSentence;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectByAddr;
 import static java.util.Collections.emptyList;
 import static org.apache.uima.fit.util.CasUtil.getType;
@@ -62,7 +63,7 @@ public class RelationCrossSentenceBehavior
             return aRequest;
         }
         
-        if (!isSameSentence(aRequest.getJcas(), aRequest.getOriginFs().getBegin(),
+        if (!isBeginEndInSameSentence(aRequest.getJcas(), aRequest.getOriginFs().getBegin(),
                 aRequest.getTargetFs().getEnd())) {
             throw new MultipleSentenceCoveredException("Annotation coveres multiple sentences, "
                     + "limit your annotation to single sentence!");
@@ -83,7 +84,7 @@ public class RelationCrossSentenceBehavior
             for (Entry<AnnotationFS, VArc> e : aAnnoToArcIdx.entrySet()) {
                 JCas jcas = e.getKey().getCAS().getJCas();
                 
-                if (!isSameSentence(jcas, 
+                if (!isBeginInSameSentence(jcas, 
                         selectByAddr(jcas, e.getValue().getSource().getId()).getBegin(),
                         selectByAddr(jcas, e.getValue().getTarget().getId()).getBegin()))
                 {
@@ -117,7 +118,7 @@ public class RelationCrossSentenceBehavior
             AnnotationFS targetFs = (AnnotationFS) fs.getFeatureValue(targetFeature);
             AnnotationFS sourceFs = (AnnotationFS) fs.getFeatureValue(sourceFeature);
 
-            if (!isSameSentence(aJCas, targetFs.getBegin(), sourceFs.getBegin())) {
+            if (!isBeginInSameSentence(aJCas, targetFs.getBegin(), sourceFs.getBegin())) {
                 messages.add(Pair.of(
                         LogMessage.error(this, "Crossing sentence bounardies is not permitted."),
                         fs));

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanCrossSentenceBehavior.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanCrossSentenceBehavior.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VCommentType.ERROR;
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isSameSentence;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isBeginEndInSameSentence;
 import static java.util.Collections.emptyList;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
@@ -68,7 +68,7 @@ public class SpanCrossSentenceBehavior
             return aRequest;
         }
         
-        if (!isSameSentence(aRequest.getJcas(), aRequest.getBegin(), aRequest.getEnd())) {
+        if (!isBeginEndInSameSentence(aRequest.getJcas(), aRequest.getBegin(), aRequest.getEnd())) {
             throw new MultipleSentenceCoveredException("Annotation covers multiple sentences, "
                     + "limit your annotation to single sentence!");
         }
@@ -107,7 +107,7 @@ public class SpanCrossSentenceBehavior
         List<Pair<LogMessage, AnnotationFS>> messages = new ArrayList<>();
         
         for (AnnotationFS fs : select(cas, type)) {
-            if (!isSameSentence(aJCas, fs.getBegin(), fs.getEnd())) {
+            if (!isBeginEndInSameSentence(aJCas, fs.getBegin(), fs.getEnd())) {
                 messages.add(Pair.of(
                         LogMessage.error(this, "Crossing sentence bounardies is not permitted."),
                         fs));

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
@@ -146,8 +146,11 @@ public class SpanRenderer
         for (Sentence sent : aVisibleSentences) {
             if (beginSent == null) {
                 // Here we catch the first sentence in document order which covers the begin
-                // offset of the current annotation.
-                if (sent.getBegin() <= aFS.getBegin() && aFS.getBegin() <= sent.getEnd()) {
+                // offset of the current annotation. Note that in UIMA annotations are
+                // half-open intervals [begin,end) so that a begin offset must always be
+                // smaller than the end of a covering annotation to be considered properly
+                // covered.
+                if (sent.getBegin() <= aFS.getBegin() && aFS.getBegin() < sent.getEnd()) {
                     beginSent = sent;
                 }
                 // Make sure that zero-width annotations always start and end in the same

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VRange.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VRange.java
@@ -37,4 +37,10 @@ public class VRange
     {
         return end;
     }
+
+    @Override
+    public String toString()
+    {
+        return "[" + begin + "-" + end + "]";
+    }
 }

--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
@@ -90,6 +90,8 @@ public class BratRenderer
 {
     private static final Logger LOG = LoggerFactory.getLogger(BratAnnotationEditor.class);
     
+    private static final boolean DEBUG = false;
+    
     public static void render(GetDocumentResponse aResponse, AnnotatorState aState,
             VDocument aVDoc, JCas aJCas, AnnotationSchemaService aAnnotationService)
     {
@@ -146,9 +148,13 @@ public class BratRenderer
                 } else {
                     color = vspan.getColorHint();
                 }
-                aResponse.addEntity(
-                        new Entity(vspan.getVid(), vspan.getType(), offsets,
-                                bratLabelText, color, bratHoverText));
+                
+                if (DEBUG) {
+                    bratHoverText = vspan.getOffsets() + "\n" + bratHoverText;
+                }
+                
+                aResponse.addEntity(new Entity(vspan.getVid(), vspan.getType(), offsets,
+                        bratLabelText, color, bratHoverText));
             }
 
             for (VArc varc : aVDoc.arcs(layer.getId())) {
@@ -268,6 +274,13 @@ public class BratRenderer
                 continue;
             }
             aResponse.addToken(fs.getBegin() - windowBegin, fs.getEnd() - windowBegin);
+            
+            if (DEBUG) {
+                aResponse.addEntity(new Entity(new VID(fs), "Token",
+                        new Offsets(fs.getBegin() - windowBegin, fs.getEnd() - windowBegin),
+                        fs.getCoveredText(), "#d9d9d9",
+                        "[" + fs.getBegin() + "-" + fs.getEnd() + "]"));
+            }
         }
         
         // Replace newline characters before sending to the client to avoid rendering glitches

--- a/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/controller/BratAjaxCasUtilTest.java
+++ b/webanno-brat/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/controller/BratAjaxCasUtilTest.java
@@ -17,7 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.brat.controller;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isSameSentence;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isBeginEndInSameSentence;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isBeginInSameSentence;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -31,29 +32,69 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 public class BratAjaxCasUtilTest
 {
     @Test
-    public void testIsSameSentence()
-        throws Exception
+    public void testIsBeginInSameSentence() throws Exception
     {
         JCas jcas = JCasFactory.createJCas();
-        
+
         JCasBuilder jb = new JCasBuilder(jcas);
         Sentence s1 = jb.add("Sentence 1.", Sentence.class);
         jb.add(" ");
         Sentence s2 = jb.add("Sentence 2.", Sentence.class);
+        jb.add(" ");
+        Sentence s3 = jb.add(".", Sentence.class);
+        Sentence s4 = jb.add(".", Sentence.class);
         jb.close();
 
-        assertTrue(isSameSentence(jcas, s2.getBegin(), s2.getEnd()));
-        assertTrue(isSameSentence(jcas, s2.getEnd(), s2.getBegin()));
+        assertFalse(isBeginInSameSentence(jcas, s2.getBegin(), s2.getEnd()));
+        assertFalse(isBeginInSameSentence(jcas, s2.getEnd(), s2.getBegin()));
 
-        assertTrue(isSameSentence(jcas, s1.getBegin() + 1, s1.getEnd() - 1));
-        assertTrue(isSameSentence(jcas, s1.getEnd() - 1, s1.getBegin() + 1));
+        assertTrue(isBeginInSameSentence(jcas, s1.getBegin() + 1, s1.getEnd() - 1));
+        assertTrue(isBeginInSameSentence(jcas, s1.getEnd() - 1, s1.getBegin() + 1));
+
+        assertFalse(isBeginInSameSentence(jcas, s1.getBegin(), s1.getEnd()));
+        assertFalse(isBeginInSameSentence(jcas, s1.getEnd(), s1.getBegin()));
+
+        assertFalse(isBeginInSameSentence(jcas, s2.getBegin(), s1.getBegin()));
+        assertFalse(isBeginInSameSentence(jcas, s1.getBegin(), s2.getBegin()));
+
+        assertFalse(isBeginInSameSentence(jcas, s3.getBegin(), s4.getBegin()));
+
+        assertTrue(isBeginInSameSentence(jcas, 0, 0));
+    }
+
+    @Test
+    public void testIsBeginEndInSameSentence() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+
+        JCasBuilder jb = new JCasBuilder(jcas);
+        Sentence s1 = jb.add("Sentence 1.", Sentence.class);
+        jb.add(" ");
+        Sentence s2 = jb.add("Sentence 2.", Sentence.class);
+        jb.add(" ");
+        Sentence s3 = jb.add(".", Sentence.class);
+        Sentence s4 = jb.add(".", Sentence.class);
+        jb.close();
+
+        assertTrue(isBeginEndInSameSentence(jcas, s2.getBegin(), s2.getEnd()));
+
+        assertTrue(isBeginEndInSameSentence(jcas, s1.getBegin() + 1, s1.getEnd() - 1));
+        assertTrue(isBeginEndInSameSentence(jcas, s1.getEnd() - 1, s1.getBegin() + 1));
+
+        assertTrue(isBeginEndInSameSentence(jcas, s1.getBegin(), s1.getEnd()));
+
+        assertFalse(isBeginEndInSameSentence(jcas, s2.getBegin(), s1.getBegin()));
+        assertFalse(isBeginEndInSameSentence(jcas, s1.getBegin(), s2.getBegin()));
+
+        assertTrue(isBeginEndInSameSentence(jcas, 0, 0));
+
+        // Note that this is an invalid use of isBeginEndInSameSentence because two begin offsets
+        // are compared with each other
+        assertTrue(isBeginEndInSameSentence(jcas, s3.getBegin(), s4.getBegin()));
         
-        assertTrue(isSameSentence(jcas, s1.getBegin(), s1.getEnd()));
-        assertTrue(isSameSentence(jcas, s1.getEnd(), s1.getBegin()));
-
-        assertFalse(isSameSentence(jcas, s2.getBegin(), s1.getBegin()));
-        assertFalse(isSameSentence(jcas, s1.getBegin(), s2.getBegin()));
-
-        assertTrue(isSameSentence(jcas, 0, 0));
+        // Note that these are invalid uses of isBeginEndInSameSentence because the first offset
+        // must be a begin offset
+        assertFalse(isBeginEndInSameSentence(jcas, s1.getEnd(), s1.getBegin()));
+        assertFalse(isBeginEndInSameSentence(jcas, s2.getEnd(), s2.getBegin()));
     }
 }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -254,6 +254,11 @@ public abstract class AnnotationDetailEditorPanel
         throws AnnotationException
     {
         AnnotatorState state = getModelObject();
+        
+        if (!state.isForwardAnnotation()) {
+            return;
+        }
+        
         Selection selection = state.getSelection();
         List<FeatureState> featureStates = state.getFeatureStates();
         AnnotationLayer layer = aAdapter.getLayer();
@@ -278,27 +283,16 @@ public abstract class AnnotationDetailEditorPanel
                 }
             }
             
+            // allow modification for forward annotation
             if (spanValue != null) {
-                // Reassign variable so it can be used in the lambda filter below
-                Serializable _spanValue = spanValue;
-                
-                // allow modification for forward annotation
-                if (state.isForwardAnnotation()) {
-                    featureState.value = spanValue;
-                    featureStates.get(0).value = spanValue;
-                    String selectedTag = annotationFeatureForm.getBindTags().entrySet().stream()
-                            .filter(e -> e.getValue().equals(_spanValue))
-                            .map(Map.Entry::getKey)
-                            .findFirst()
-                            .orElse(null);
-                    annotationFeatureForm.setSelectedTag(selectedTag);
-                }
-                else {
-                    actionClear(aTarget);
-                    throw new AnnotationException("Cannot create another annotation of layer ["
-                        + state.getSelectedAnnotationLayer().getUiName() + "] at this"
-                        + " location - stacking is not enabled for this layer.");
-                }
+                featureState.value = spanValue;
+                featureStates.get(0).value = spanValue;
+                String selectedTag = annotationFeatureForm.getBindTags().entrySet().stream()
+                        .filter(e -> e.getValue().equals(featureState.value))
+                        .map(Map.Entry::getKey)
+                        .findFirst()
+                        .orElse(null);
+                annotationFeatureForm.setSelectedTag(selectedTag);
             }
         }
     }


### PR DESCRIPTION
- Fixed bug causing span annotations on single-token sentences to be considered overlapping sentences
- Fixed bug causing token-locked span annotations being created on single-token to be rendered wrongly (over the entire preceding sentence plus over the single-token sentence)
- Changed forward handling code such that it only becomes active when forwarding is indeed activated and removed redundant stacking check code
- Added debug mode to brat renderer which can be turned on via a constant in the code
- Improved unit tests