### PR TITLE
#1218 - Handle feature value validation against tagset in FeatureSupport

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/FeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/FeatureSupport.java
@@ -106,20 +106,6 @@ public interface FeatureSupport<T>
             AnnotationFeature aFeature);
 
     /**
-     * Checks whether tagsets are supported on the given feature which must be provided by the
-     * current feature support (i.e. {@link #accepts(AnnotationFeature)} must have returned
-     * {@code true} on this feature.
-     * 
-     * @param aFeature
-     *            a feature definition.
-     * @return whether tagsets are supported on the given feature.
-     */
-    default boolean isTagsetSupported(AnnotationFeature aFeature)
-    {
-        return false;
-    }
-    
-    /**
      * Called when the user selects a feature in the feature detail form. It allows the feature
      * support to fill in settings which are not configurable through the UI, e.g. link feature
      * details.

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.MarkupContainer;
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.PrimitiveUimaFeatureSupportProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.BooleanFeatureEditor;
@@ -46,12 +48,15 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 
 @Component
 public class PrimitiveUimaFeatureSupport
     implements FeatureSupport<Void>, InitializingBean
 {
     private final PrimitiveUimaFeatureSupportProperties properties;
+    
+    private final AnnotationSchemaService schemaService;
     
     private List<FeatureType> primitiveTypes;
 
@@ -63,12 +68,15 @@ public class PrimitiveUimaFeatureSupport
     public PrimitiveUimaFeatureSupport()
     {
         properties = new PrimitiveUimaFeatureSupportProperties();
+        schemaService = null;
     }
 
-    @Autowired(required = true)
-    public PrimitiveUimaFeatureSupport(PrimitiveUimaFeatureSupportProperties aProperties)
+    @Autowired
+    public PrimitiveUimaFeatureSupport(PrimitiveUimaFeatureSupportProperties aProperties,
+            @Autowired(required = false) AnnotationSchemaService aSchemaService)
     {
         properties = aProperties;
+        schemaService = aSchemaService;
     }
 
     @Override
@@ -119,6 +127,30 @@ public class PrimitiveUimaFeatureSupport
         }
     }
 
+    @Override
+    public void setFeatureValue(JCas aJcas, AnnotationFeature aFeature, int aAddress, Object aValue)
+    {
+        if (
+                schemaService != null && 
+                aFeature.getTagset() != null && 
+                CAS.TYPE_NAME_STRING.equals(aFeature.getType()) && 
+                !schemaService.existsTag((String) aValue, aFeature.getTagset())
+        ) {
+            if (!aFeature.getTagset().isCreateTag()) {
+                throw new IllegalArgumentException("[" + aValue
+                        + "] is not in the tag list. Please choose from the existing tags");
+            }
+            else {
+                Tag selectedTag = new Tag();
+                selectedTag.setName((String) aValue);
+                selectedTag.setTagSet(aFeature.getTagset());
+                schemaService.createTag(selectedTag);
+            }
+        }
+        
+        FeatureSupport.super.setFeatureValue(aJcas, aFeature, aAddress, aValue);
+    }
+    
     @Override
     public Object wrapFeatureValue(AnnotationFeature aFeature, CAS aCAS, Object aValue)
     {
@@ -226,12 +258,5 @@ public class PrimitiveUimaFeatureSupport
         if (!(CAS.TYPE_NAME_STRING.equals(aFeature.getType()))) {
             aFeature.setTagset(null);
         }
-    }
-    
-    @Override
-    public boolean isTagsetSupported(AnnotationFeature aFeature)
-    {
-        // Only string features support tagsets
-        return CAS.TYPE_NAME_STRING.equals(aFeature.getType());
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/SlotFeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/SlotFeatureSupport.java
@@ -28,6 +28,7 @@ import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.MarkupContainer;
@@ -53,6 +54,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -180,12 +182,6 @@ public class SlotFeatureSupport
     }
     
     @Override
-    public boolean isTagsetSupported(AnnotationFeature aFeature)
-    {
-        return true;
-    }
-    
-    @Override
     public void generateFeature(TypeSystemDescription aTSD, TypeDescription aTD,
             AnnotationFeature aFeature)
     {
@@ -204,6 +200,32 @@ public class SlotFeatureSupport
     {
         Feature linkFeature = aFS.getType().getFeatureByBaseName(aFeature.getName());
         return wrapFeatureValue(aFeature, aFS.getCAS(), aFS.getFeatureValue(linkFeature));
+    }
+    
+    @Override
+    public void setFeatureValue(JCas aJcas, AnnotationFeature aFeature, int aAddress, Object aValue)
+    {
+        if (
+                aValue instanceof List &&
+                aFeature.getTagset() != null
+        ) {
+            for (LinkWithRoleModel link : (List<LinkWithRoleModel>) aValue) {
+                if (!annotationService.existsTag(link.role, aFeature.getTagset())) {
+                    if (!aFeature.getTagset().isCreateTag()) {
+                        throw new IllegalArgumentException("[" + link.role
+                                + "] is not in the tag list. Please choose from the existing tags");
+                    }
+                    else {
+                        Tag selectedTag = new Tag();
+                        selectedTag.setName(link.role);
+                        selectedTag.setTagSet(aFeature.getTagset());
+                        annotationService.createTag(selectedTag);
+                    }
+                }
+            }
+        }
+        
+        FeatureSupport.super.setFeatureValue(aJcas, aFeature, aAddress, aValue);
     }
     
     @Override

--- a/webanno-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupportTest.java
+++ b/webanno-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupportTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.getAddr;
+import static org.apache.uima.fit.factory.JCasFactory.createJCasFromPath;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.JCas;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.PrimitiveUimaFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+
+public class PrimitiveUimaFeatureSupportTest
+{
+    private @Mock AnnotationSchemaService schemaService;
+    
+    private PrimitiveUimaFeatureSupport sut;
+    
+    private JCas jcas;
+    private AnnotationFS spanFS;
+    private AnnotationFeature valueFeature;
+    private TagSet valueTagset;
+    
+    @Before
+    public void setUp() throws Exception
+    {
+        initMocks(this);
+        
+        sut = new PrimitiveUimaFeatureSupport(new PrimitiveUimaFeatureSupportProperties(),
+                schemaService);
+        
+        valueFeature = new AnnotationFeature("value", CAS.TYPE_NAME_STRING);
+        
+        valueTagset = new TagSet();
+        
+        jcas = createJCasFromPath("src/test/resources/desc/type/webannoTestTypes.xml");
+        jcas.setDocumentText("label");
+        
+        Type spanType = jcas.getCas().getTypeSystem().getType("webanno.custom.Span");
+        spanFS = jcas.getCas().createAnnotation(spanType, 0, jcas.getDocumentText().length());
+    }
+    
+    @Test
+    public void thatUsingOutOfTagsetValueInClosedTagsetProducesException() throws Exception
+    {
+        final String tag = "TAG-NOT-IN-LIST";
+        
+        valueFeature.setTagset(valueTagset);
+        valueTagset.setCreateTag(false);
+        
+        when(schemaService.existsTag(tag, valueTagset)).thenReturn(false);
+        
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> sut.setFeatureValue(jcas, valueFeature, getAddr(spanFS), tag))
+            .withMessageContaining("is not in the tag list");
+    }
+    
+    @Test
+    public void thatUsingOutOfTagsetValueInOpenTagsetAddsNewValue() throws Exception
+    {
+        final String tag = "TAG-NOT-IN-LIST";
+        
+        valueFeature.setTagset(valueTagset);
+        valueTagset.setCreateTag(true);
+        
+        when(schemaService.existsTag(tag, valueTagset)).thenReturn(false);
+        
+        sut.setFeatureValue(jcas, valueFeature, getAddr(spanFS), tag);
+        
+        verify(schemaService).createTag(new Tag(valueTagset, tag));
+    }
+}

--- a/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Tag.java
+++ b/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Tag.java
@@ -59,6 +59,12 @@ public class Tag
     {
         // Nothing to do
     }
+
+    public Tag(TagSet aTagSet, String aName)
+    {
+        tagSet = aTagSet;
+        name = aName;
+    }
     
     public Tag(String aName, String aDescription)
     {


### PR DESCRIPTION
**What's in the PR**
- Move handling of tagsets into `PrimitiveUimaFeatureSupport` and `SlotFeatureSupport`
- Extended `SlotFeatureSupportTest` and added `PrimitiveUimaFeatureSupport` to check if tagset handling works
- Remove unused `FeatureSupport.isTagsetSupported` method

**How to test manually**
* Basically try out features with tagsets (string features as well a slot features with open and closed tagsets) in different contexts (annotation, curation, etc.)

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
