### PR TITLE
#1233 - NPE when exporting Orthography without operation as TCF

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/OrthographyLayerInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/OrthographyLayerInitializer.java
@@ -87,6 +87,7 @@ public class OrthographyLayerInitializer
         operation.setLayer(orthography);
         operation.setVisible(false);
         operation.setTagset(operationTagset);
+        operation.setRequired(true);
 
         annotationSchemaService.createFeature(operation);
     }

--- a/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfReader.java
+++ b/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfReader.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import org.apache.uima.collection.CollectionException;
@@ -46,6 +47,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.transform.type.SofaChangeAnnotation;
 import eu.clarin.weblicht.wlfxb.io.TextCorpusStreamed;
 import eu.clarin.weblicht.wlfxb.io.WLDObjector;
 import eu.clarin.weblicht.wlfxb.io.WLFormatException;
+import eu.clarin.weblicht.wlfxb.tc.api.CorrectionOperation;
 import eu.clarin.weblicht.wlfxb.tc.api.DependencyParse;
 import eu.clarin.weblicht.wlfxb.tc.api.Reference;
 import eu.clarin.weblicht.wlfxb.tc.api.TextCorpus;
@@ -202,17 +204,19 @@ public class TcfReader extends JCasResourceCollectionReader_ImplBase {
 
     }
 
-    private void convertOrthoGraphy(JCas aJCas, TextCorpus aCorpusData,
-            Map<String, Token> aTokens) {
+    private void convertOrthoGraphy(JCas aJCas, TextCorpus aCorpusData, Map<String, Token> aTokens)
+    {
         if (aCorpusData.getOrthographyLayer() == null) {
             return;
         }
+        
         for (int i = 0; i < aCorpusData.getOrthographyLayer().size(); i++) {
             eu.clarin.weblicht.wlfxb.tc.api.Token[] orthoTokens = aCorpusData.getOrthographyLayer()
                     .getTokens(aCorpusData.getOrthographyLayer().getCorrection(i));
             String value = aCorpusData.getOrthographyLayer().getCorrection(i).getString();
-            String operation = aCorpusData.getOrthographyLayer().getCorrection(i).getOperation()
-                    .name();
+            String operation = Optional
+                    .ofNullable(aCorpusData.getOrthographyLayer().getCorrection(i).getOperation())
+                    .map(CorrectionOperation::name).orElse(null);
 
             SofaChangeAnnotation ortho = new SofaChangeAnnotation(aJCas);
             ortho.setBegin(aTokens.get(orthoTokens[0].getID()).getBegin());
@@ -221,7 +225,6 @@ public class TcfReader extends JCasResourceCollectionReader_ImplBase {
             ortho.setOperation(operation);
             ortho.addToIndexes();
         }
-
     }
 
     private void convertSentences(JCas aJCas, TextCorpus aCorpusData, Map<String, Token> aTokens) {

--- a/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfWriter.java
+++ b/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfWriter.java
@@ -31,6 +31,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.fit.descriptor.ConfigurationParameter;
@@ -398,8 +399,11 @@ public class TcfWriter
             List<SofaChangeAnnotation> scas = selectCovered(aJCas, SofaChangeAnnotation.class,
                     token.getBegin(), token.getEnd());
             if (scas.size() > 0 && orthographyLayer != null) {
+                SofaChangeAnnotation change = scas.get(0);
+                
                 orthographyLayer.addCorrection(scas.get(0).getValue(), tokensLayer.getToken(j),
-                        CorrectionOperation.valueOf(scas.get(0).getOperation()));
+                        Optional.ofNullable(change.getOperation()).map(CorrectionOperation::valueOf)
+                                .orElse(null));
             }
             j++;
         }

--- a/webanno-io-tcf/src/test/resources/tcf04-karin-wl.xml
+++ b/webanno-io-tcf/src/test/resources/tcf04-karin-wl.xml
@@ -374,6 +374,7 @@
     </textstructure>
     <orthography>
       <correction operation="replace" tokenIDs="t_0">Karina</correction>
+      <correction tokenIDs="t_1">flog</correction>
     </orthography>
   </TextCorpus>
 </D-Spin>

--- a/webanno-io-tcf/src/test/resources/tcf04-karin-wl_expected.xml
+++ b/webanno-io-tcf/src/test/resources/tcf04-karin-wl_expected.xml
@@ -312,6 +312,7 @@
     </textstructure>
     <orthography>
       <correction operation="replace" tokenIDs="t_0">Karina</correction>
+      <correction tokenIDs="t_1">flog</correction>
     </orthography>
     <tc:lemmas xmlns:tc="http://www.dspin.de/data/textcorpus">
       <tc:lemma ID="l_0" tokenIDs="t_0">Karin</tc:lemma>


### PR DESCRIPTION
**What's in the PR**
- Fixed NPEs when importing/exporting orthography annotations where the operation is not yet
- Make the operation feature on the orthography layer required by default since it doesn't really make much sense if it remains unset

**How to test manually**
* See issue

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
