### PR TITLE
#1252 - Cannot annotate custom layer unless first select existing annotation

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/PreferencesUtil.java
@@ -30,6 +30,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.UserPreferencesService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
 /**
  * This class contains Utility methods that can be used in Project settings
@@ -62,7 +63,10 @@ public class PreferencesUtil
         // set layers according to preferences
         aState.setAnnotationLayers(aAnnotationService
                 .listAnnotationLayer(aState.getProject()).stream()
-                .filter(l -> l.isEnabled())// only allow enabled layers
+                // Token layer cannot be selected!
+                .filter(l -> !Token.class.getName().equals(l.getName()))
+                // Only allow enabled layers
+                .filter(l -> l.isEnabled()) 
                 .filter(l -> !preference.getHiddenAnnotationLayerIds().contains(l.getId()))
                 .collect(Collectors.toList()));
         

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -272,7 +272,7 @@ public abstract class AnnotationDetailEditorPanel
     Map<String, String> buildKeySequenceToTagMap()
     {
         AnnotationFeature f = annotationService
-                .listAnnotationFeature(getModelObject().getSelectedAnnotationLayer()).get(0);
+                .listAnnotationFeature(getModelObject().getDefaultAnnotationLayer()).get(0);
         TagSet tagSet = f.getTagset();
         Map<Character, String> tagNames = new LinkedHashMap<>();
         Map<String, String> bindTag2Key = new LinkedHashMap<>();
@@ -664,7 +664,7 @@ public abstract class AnnotationDetailEditorPanel
             // disabled, then select that annotation and load the feature value of that annotation
             // into the {@link AnnotationFeatureForm#setSelectedTag(String) selected tag}.
             SpanAdapter adapter = (SpanAdapter) annotationService
-                    .getAdapter(state.getSelectedAnnotationLayer());
+                    .getAdapter(state.getDefaultAnnotationLayer());
             Type type = CasUtil.getType(aJCas.getCas(), adapter.getAnnotationTypeName());
             AnnotationFS annotation = selectSingleFsAt(aJCas, type, nextToken.getBegin(),
                     nextToken.getEnd());
@@ -832,7 +832,7 @@ public abstract class AnnotationDetailEditorPanel
         // #186 - After filling a slot, the annotation detail panel is not updated
         aTarget.add(annotationFeatureForm.getFeatureEditorPanel());
 
-        TypeAdapter adapter = annotationService.getAdapter(state.getSelectedAnnotationLayer());
+        TypeAdapter adapter = annotationService.getAdapter(state.getDefaultAnnotationLayer());
 
         // If this is an annotation creation action, create the annotation
         if (state.getSelection().getAnnotation().isNotSet()) {

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -530,7 +530,7 @@ public class AnnotationFeatureForm
         
         List<AnnotationFeature> features = getEnabledAndVisibleFeatures(
                 AnnotationFeatureForm.this.getModelObject()
-                        .getSelectedAnnotationLayer());
+                        .getDefaultAnnotationLayer());
         if (features.size() != 1) {
             // should not come here in the first place (controlled during
             // forward annotation process)


### PR DESCRIPTION
**What's in the PR**
- Properly use the default layer instead of the selected layer when forwarding or creating annotations
- Prevent the Token layer from sneaking into the layer selection - although it never actually shows up, it could be pre-selected so far in certain project configurations

**How to test manually**
* Disable all layers and try creating an annotation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
