### PR TITLE
#1257 - Unable to create relation annotations

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -832,7 +832,11 @@ public abstract class AnnotationDetailEditorPanel
         // #186 - After filling a slot, the annotation detail panel is not updated
         aTarget.add(annotationFeatureForm.getFeatureEditorPanel());
 
-        TypeAdapter adapter = annotationService.getAdapter(state.getDefaultAnnotationLayer());
+        // internalCommitAnnotation is used to update an existing annotation as well as to create
+        // a new one. In either case, the selectedAnnotationLayer indicates the layer type! Do not
+        // use the defaultAnnotationLayer here as e.g. when creating relation annotations, it would
+        // point to the span type to which the relation attaches, not to the relation type!
+        TypeAdapter adapter = annotationService.getAdapter(state.getSelectedAnnotationLayer());
 
         // If this is an annotation creation action, create the annotation
         if (state.getSelection().getAnnotation().isNotSet()) {


### PR DESCRIPTION
**What's in the PR**
- Reverted a change introduced in e17d1fdc1f13f5b74d7ad5e847c2c27403fea759 wrongly assuming that the layer indicating the annotation type to be updated/created would be stored in defaultAnnotationLayer which is not the case when creating relation annotations.

**How to test manually**
* Create two POS annotations
* Try connecting them using a Dependency relation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
