### PR TITLE
#1282 - Missing comments on export to CONLL-U

### DIFF
--- a/webanno-io-conll/NOTICE.txt
+++ b/webanno-io-conll/NOTICE.txt
@@ -1,3 +1,3 @@
-This module contains CoNLL support backported from DKPro Core 1.9.0-SNAPSHOT and is meant to be
-dropped again and replaced by the proper DKPro Core 1.9.0 CoNLL module when it has been released
+This module contains CoNLL support backported from an unreleased DKPro Core version and is meant to
+be dropped again and replaced by the proper DKPro Core CoNLL module when it has been released
 and when WebAnno is able to depend on this version of DKPro Core.

--- a/webanno-io-conll/pom.xml
+++ b/webanno-io-conll/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.io.conll-asl</artifactId>
     </dependency>

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
@@ -28,8 +28,6 @@ import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.dkpro.core.io.conll.ConllUReader;
-import de.tudarmstadt.ukp.dkpro.core.io.conll.ConllUWriter;
 
 @Component
 public class ConllUFormatSupport

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReader.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReader.java
@@ -57,7 +57,6 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DependencyFlavor;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ROOT;
-import eu.openminted.share.annotations.api.DocumentationResource;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
@@ -67,7 +66,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
  * @see <a href="http://universaldependencies.github.io/docs/format.html">CoNLL-U Format</a>
  */
 @ResourceMetaData(name = "CoNLL-U Reader")
-@DocumentationResource("${docbase}/format-reference.html#format-${command}")
 @MimeTypeCapability({MimeTypes.TEXT_X_CONLL_U})
 @TypeCapability(
         outputs = { 

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReader.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReader.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2016
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.conll;
+
+import static de.tudarmstadt.ukp.dkpro.core.api.resources.MappingProviderFactory.createPosMappingProvider;
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.cas.Type;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.descriptor.TypeCapability;
+import org.apache.uima.fit.factory.JCasBuilder;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
+
+import de.tudarmstadt.ukp.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.MimeTypes;
+import de.tudarmstadt.ukp.dkpro.core.api.resources.CompressionUtils;
+import de.tudarmstadt.ukp.dkpro.core.api.resources.MappingProvider;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.SurfaceForm;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DependencyFlavor;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.ROOT;
+import eu.openminted.share.annotations.api.DocumentationResource;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+/**
+ * Reads a file in the CoNLL-U format.
+ * 
+ * @see <a href="http://universaldependencies.github.io/docs/format.html">CoNLL-U Format</a>
+ */
+@ResourceMetaData(name = "CoNLL-U Reader")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({MimeTypes.TEXT_X_CONLL_U})
+@TypeCapability(
+        outputs = { 
+                "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma",
+                "de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency" })
+public class ConllUReader
+    extends JCasResourceCollectionReader_ImplBase
+{
+    /**
+     * Character encoding of the input data.
+     */
+    public static final String PARAM_SOURCE_ENCODING = ComponentParameters.PARAM_SOURCE_ENCODING;
+    @ConfigurationParameter(name = PARAM_SOURCE_ENCODING, mandatory = true, 
+            defaultValue = ComponentParameters.DEFAULT_ENCODING)
+    private String sourceEncoding;
+
+    /**
+     * Read fine-grained part-of-speech information.
+     */
+    public static final String PARAM_READ_POS = ComponentParameters.PARAM_READ_POS;
+    @ConfigurationParameter(name = PARAM_READ_POS, mandatory = true, defaultValue = "true")
+    private boolean readPos;
+
+    /**
+     * Read coarse-grained part-of-speech information.
+     */
+    public static final String PARAM_READ_CPOS = ComponentParameters.PARAM_READ_CPOS;
+    @ConfigurationParameter(name = PARAM_READ_CPOS, mandatory = true, defaultValue = "true")
+    private boolean readCPos;
+
+    /**
+     * Treat coarse-grained part-of-speech as fine-grained part-of-speech information.
+     */
+    public static final String PARAM_USE_CPOS_AS_POS = "useCPosAsPos";
+    @ConfigurationParameter(name = PARAM_USE_CPOS_AS_POS, mandatory = true, defaultValue = "false")
+    private boolean useCPosAsPos;
+
+    /**
+     * Use this part-of-speech tag set to use to resolve the tag set mapping instead of using the
+     * tag set defined as part of the model meta data. This can be useful if a custom model is
+     * specified which does not have such meta data, or it can be used in readers.
+     */
+    public static final String PARAM_POS_TAG_SET = ComponentParameters.PARAM_POS_TAG_SET;
+    @ConfigurationParameter(name = PARAM_POS_TAG_SET, mandatory = false)
+    protected String posTagset;
+
+    /**
+     * Load the part-of-speech tag to UIMA type mapping from this location instead of locating
+     * the mapping automatically.
+     */
+    public static final String PARAM_POS_MAPPING_LOCATION = 
+            ComponentParameters.PARAM_POS_MAPPING_LOCATION;
+    @ConfigurationParameter(name = PARAM_POS_MAPPING_LOCATION, mandatory = false)
+    protected String posMappingLocation;
+    
+    /**
+     * Read morphological features.
+     */
+    public static final String PARAM_READ_MORPH = ComponentParameters.PARAM_READ_MORPH;
+    @ConfigurationParameter(name = PARAM_READ_MORPH, mandatory = true, defaultValue = "true")
+    private boolean readMorph;
+
+    /**
+     * Read lemma information.
+     */
+    public static final String PARAM_READ_LEMMA = ComponentParameters.PARAM_READ_LEMMA;
+    @ConfigurationParameter(name = PARAM_READ_LEMMA, mandatory = true, defaultValue = "true")
+    private boolean readLemma;
+
+    /**
+     * Read syntactic dependency information.
+     */
+    public static final String PARAM_READ_DEPENDENCY = ComponentParameters.PARAM_READ_DEPENDENCY;
+    @ConfigurationParameter(name = PARAM_READ_DEPENDENCY, mandatory = true, defaultValue = "true")
+    private boolean readDependency;
+
+    private static final String UNUSED = "_";
+
+    private static final int ID = 0;
+    private static final int FORM = 1;
+    private static final int LEMMA = 2;
+    private static final int CPOSTAG = 3;
+    private static final int POSTAG = 4;
+    private static final int FEATS = 5;
+    private static final int HEAD = 6;
+    private static final int DEPREL = 7;
+    private static final int DEPS = 8;
+    private static final int MISC = 9;
+    
+    public static final String META_SEND_ID = "sent_id";
+    public static final String META_TEXT = "text";
+
+    private MappingProvider posMappingProvider;
+
+    @Override
+    public void initialize(UimaContext aContext)
+        throws ResourceInitializationException
+    {
+        super.initialize(aContext);
+        
+        posMappingProvider = createPosMappingProvider(posMappingLocation, posTagset, getLanguage());
+    }
+    
+    @Override
+    public void getNext(JCas aJCas)
+        throws IOException, CollectionException
+    {
+        Resource res = nextFile();
+        initCas(aJCas, res);
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new InputStreamReader(
+                    CompressionUtils.getInputStream(res.getLocation(), res.getInputStream()),
+                    sourceEncoding));
+            convert(aJCas, reader);
+        }
+        finally {
+            closeQuietly(reader);
+        }
+    }
+
+    public void convert(JCas aJCas, BufferedReader aReader)
+        throws IOException
+    {
+        if (readPos) {
+            try {
+                posMappingProvider.configure(aJCas.getCas());
+            }
+            catch (AnalysisEngineProcessException e) {
+                throw new IOException(e);
+            }
+        }
+        
+        JCasBuilder doc = new JCasBuilder(aJCas);
+
+        while (true) {
+            // Read sentence comments (if any)
+            Map<String, String> comments = readSentenceComments(aReader);
+            
+            // Read sentence
+            List<String[]> words = readSentence(aReader);
+            if (words == null) {
+                // End of file
+                break;
+            }
+            
+            if (words.isEmpty()) {
+                 // Ignore empty sentences. This can happen when there are multiple end-of-sentence
+                 // markers following each other.
+                continue; 
+            }
+
+            int sentenceBegin = doc.getPosition();
+            int sentenceEnd = sentenceBegin;
+
+            int surfaceBegin = -1;
+            int surfaceEnd = -1;
+            String surfaceString = null;
+            
+            // Tokens, Lemma, POS
+            Int2ObjectMap<Token> tokens = new Int2ObjectOpenHashMap<>();
+            Iterator<String[]> wordIterator = words.iterator();
+            while (wordIterator.hasNext()) {
+                String[] word = wordIterator.next();
+                if (word[ID].contains("-")) {
+                    String[] fragments = word[ID].split("-");
+                    surfaceBegin = Integer.valueOf(fragments[0]);
+                    surfaceEnd = Integer.valueOf(fragments[1]);
+                    surfaceString = word[FORM];
+                    continue;
+                }
+                
+                // Read token
+                int tokenIdx = Integer.valueOf(word[ID]);
+                Token token = doc.add(word[FORM], Token.class);
+                tokens.put(tokenIdx, token);
+                if (!StringUtils.contains(word[MISC], "SpaceAfter=No") && wordIterator.hasNext()) {
+                    doc.add(" ");
+                }
+
+                // Read lemma
+                if (!UNUSED.equals(word[LEMMA]) && readLemma) {
+                    Lemma lemma = new Lemma(aJCas, token.getBegin(), token.getEnd());
+                    lemma.setValue(word[LEMMA]);
+                    lemma.addToIndexes();
+                    token.setLemma(lemma);
+                }
+
+                // Read part-of-speech tag
+                POS pos = null;
+                String tag = useCPosAsPos ? word[CPOSTAG] : word[POSTAG];
+                if (!UNUSED.equals(tag) && readPos) {
+                    Type posTag = posMappingProvider.getTagType(tag);
+                    pos = (POS) aJCas.getCas().createAnnotation(posTag, token.getBegin(),
+                            token.getEnd());
+                    pos.setPosValue(tag != null ? tag.intern() : null);
+                }
+
+                // Read coarse part-of-speech tag
+                if (!UNUSED.equals(word[CPOSTAG]) && readCPos) {
+                    if (pos == null) {
+                        pos = new POS(aJCas, token.getBegin(), token.getEnd());
+                    }
+                    pos.setCoarseValue(word[CPOSTAG].intern());
+                }
+                
+                if (pos != null) {
+                    pos.addToIndexes();
+                    token.setPos(pos);
+                }
+
+                // Read morphological features
+                if (!UNUSED.equals(word[FEATS]) && readMorph) {
+                    MorphologicalFeatures morphtag = new MorphologicalFeatures(aJCas,
+                            token.getBegin(), token.getEnd());
+                    morphtag.setValue(word[FEATS]);
+                    morphtag.addToIndexes();
+                    token.setMorph(morphtag);
+                    
+                    // Try parsing out individual feature values. Since the DKPro Core
+                    // MorphologicalFeatures type is based on the definition from the UD project,
+                    // we can do this rather straightforwardly.
+                    Type morphType = morphtag.getType();
+                    String[] items = word[FEATS].split("\\|");
+                    for (String item : items) {
+                        String[] keyValue = item.split("=");
+                        StringBuilder key = new StringBuilder(keyValue[0]);
+                        key.setCharAt(0, Character.toLowerCase(key.charAt(0)));
+                        String value = keyValue[1];
+                        
+                        Feature feat = morphType.getFeatureByBaseName(key.toString());
+                        if (feat != null) {
+                            morphtag.setStringValue(feat, value);
+                        }
+                    }
+                }
+
+                // Read surface form
+                if (tokenIdx == surfaceEnd) {
+                    int begin = tokens.get(surfaceBegin).getBegin();
+                    int end = tokens.get(surfaceEnd).getEnd();
+                    SurfaceForm surfaceForm = new SurfaceForm(aJCas, begin, end);
+                    surfaceForm.setValue(surfaceString);
+                    surfaceForm.addToIndexes();
+                    surfaceBegin = -1;
+                    surfaceEnd = -1;
+                    surfaceString = null;
+                }
+                
+                sentenceEnd = token.getEnd();
+            }
+
+            // Dependencies
+            if (readDependency) {
+                for (String[] word : words) {
+                    if (!UNUSED.equals(word[DEPREL])) {
+                        int depId = Integer.valueOf(word[ID]);
+                        int govId = Integer.valueOf(word[HEAD]);
+    
+                        // Model the root as a loop onto itself
+                        makeDependency(aJCas, govId, depId, word[DEPREL], DependencyFlavor.BASIC,
+                                tokens, word);
+                    }
+                    
+                    if (!UNUSED.equals(word[DEPS])) {
+                        // list items separated by vertical bar
+                        String[] items = word[DEPS].split("\\|");
+                        for (String item : items) {
+                            String[] sItem = item.split(":");
+                            
+                            int depId = Integer.valueOf(word[ID]);
+                            int govId = Integer.valueOf(sItem[0]);
+
+                            makeDependency(aJCas, govId, depId, sItem[1], DependencyFlavor.ENHANCED,
+                                    tokens, word);
+                        }
+                    }
+                }
+            }
+
+            // Sentence
+            Sentence sentence = new Sentence(aJCas, sentenceBegin, sentenceEnd);
+            sentence.setId(comments.get(META_SEND_ID));
+            sentence.addToIndexes();
+
+            // Once sentence per line.
+            doc.add("\n");
+        }
+
+        doc.close();
+    }
+    
+    private Dependency makeDependency(JCas aJCas, int govId, int depId, String label, String flavor,
+            Int2ObjectMap<Token> tokens, String[] word)
+    {
+        Dependency rel;
+
+        if (govId == 0) {
+            rel = new ROOT(aJCas);
+            rel.setGovernor(tokens.get(depId));
+            rel.setDependent(tokens.get(depId));
+        }
+        else {
+            rel = new Dependency(aJCas);
+            rel.setGovernor(tokens.get(govId));
+            rel.setDependent(tokens.get(depId));
+        }
+
+        rel.setDependencyType(label);
+        rel.setFlavor(flavor);
+        rel.setBegin(rel.getDependent().getBegin());
+        rel.setEnd(rel.getDependent().getEnd());
+        rel.addToIndexes();
+
+        return rel;
+    }
+
+    private Map<String, String> readSentenceComments(BufferedReader aReader)
+        throws IOException
+    {
+        Map<String, String> comments = new LinkedHashMap<>();
+        
+        while (true) {
+            // Check if the next line could be a header line
+            aReader.mark(2);
+            char character = (char) aReader.read();
+            if ('#' == character) {
+                // Read the rest of the line
+                String line = aReader.readLine();
+                if (line.contains("=")) {
+                    String[] parts = line.split("=", 2);
+                    comments.put(parts[0].trim(), parts[1].trim());
+                }
+                else {
+                    // Comment or unknown header line
+                }
+            }
+            else {
+                aReader.reset();
+                break;
+            }
+        }
+        
+        return comments;
+    }
+    
+    /**
+     * Read a single sentence.
+     */
+    private static List<String[]> readSentence(BufferedReader aReader)
+        throws IOException
+    {
+        List<String[]> words = new ArrayList<>();
+        String line;
+        while ((line = aReader.readLine()) != null) {
+            if (StringUtils.isBlank(line)) {
+                break; // End of sentence
+            }
+            if (line.startsWith("#")) {
+                // Comment line
+                continue;
+            }
+            String[] fields = line.split("\t");
+            if (fields.length != 10) {
+                throw new IOException(
+                        "Invalid file format. Line needs to have 10 tab-separated fields, but it has "
+                                + fields.length + ": [" + line + "]");
+            }
+            words.add(fields);
+        }
+
+        if (line == null && words.isEmpty()) {
+            return null;
+        }
+        else {
+            return words;
+        }
+    }
+}

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUWriter.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUWriter.java
@@ -46,7 +46,6 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.SurfaceForm;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DependencyFlavor;
-import eu.openminted.share.annotations.api.DocumentationResource;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
@@ -56,7 +55,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
  * @see <a href="http://universaldependencies.github.io/docs/format.html">CoNLL-U Format</a>
  */
 @ResourceMetaData(name = "CoNLL-U Writer")
-@DocumentationResource("${docbase}/format-reference.html#format-${command}")
 @MimeTypeCapability({MimeTypes.TEXT_X_CONLL_U})
 @TypeCapability(
         inputs = {

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUWriter.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUWriter.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2016
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.conll;
+
+import static org.apache.uima.fit.util.JCasUtil.indexCovered;
+import static org.apache.uima.fit.util.JCasUtil.select;
+import static org.apache.uima.fit.util.JCasUtil.selectCovered;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.fit.descriptor.TypeCapability;
+import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.ComponentParameters;
+import de.tudarmstadt.ukp.dkpro.core.api.parameter.MimeTypes;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.SurfaceForm;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.DependencyFlavor;
+import eu.openminted.share.annotations.api.DocumentationResource;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+/**
+ * Writes a file in the CoNLL-U format.
+ * 
+ * @see <a href="http://universaldependencies.github.io/docs/format.html">CoNLL-U Format</a>
+ */
+@ResourceMetaData(name = "CoNLL-U Writer")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({MimeTypes.TEXT_X_CONLL_U})
+@TypeCapability(
+        inputs = {
+                "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures",
+                "de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS",
+                "de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma",
+                "de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency" })
+public class ConllUWriter
+    extends JCasFileWriter_ImplBase
+{
+    private static final String UNUSED = "_";
+    private static final int UNUSED_INT = -1;
+
+    /**
+     * Character encoding of the output data.
+     */
+    public static final String PARAM_TARGET_ENCODING = ComponentParameters.PARAM_TARGET_ENCODING;
+    @ConfigurationParameter(name = PARAM_TARGET_ENCODING, mandatory = true, 
+            defaultValue = ComponentParameters.DEFAULT_ENCODING)
+    private String targetEncoding;
+
+    /**
+     * Use this filename extension.
+     */
+    public static final String PARAM_FILENAME_EXTENSION = 
+            ComponentParameters.PARAM_FILENAME_EXTENSION;
+    @ConfigurationParameter(name = PARAM_FILENAME_EXTENSION, mandatory = true, defaultValue = ".conll")
+    private String filenameSuffix;
+
+    /**
+     * Write fine-grained part-of-speech information.
+     */
+    public static final String PARAM_WRITE_POS = ComponentParameters.PARAM_WRITE_POS;
+    @ConfigurationParameter(name = PARAM_WRITE_POS, mandatory = true, defaultValue = "true")
+    private boolean writePos;
+
+    /**
+     * Write coarse-grained part-of-speech information.
+     */
+    public static final String PARAM_WRITE_CPOS = ComponentParameters.PARAM_WRITE_CPOS;
+    @ConfigurationParameter(name = PARAM_WRITE_CPOS, mandatory = true, defaultValue = "true")
+    private boolean writeCPos;
+
+    /**
+     * Write morphological features.
+     */
+    public static final String PARAM_WRITE_MORPH = ComponentParameters.PARAM_WRITE_MORPH;
+    @ConfigurationParameter(name = PARAM_WRITE_MORPH, mandatory = true, defaultValue = "true")
+    private boolean writeMorph;
+
+    /**
+     * Write lemma information.
+     */
+    public static final String PARAM_WRITE_LEMMA = ComponentParameters.PARAM_WRITE_LEMMA;
+    @ConfigurationParameter(name = PARAM_WRITE_LEMMA, mandatory = true, defaultValue = "true")
+    private boolean writeLemma;
+
+    /**
+     * Write syntactic dependency information.
+     */
+    public static final String PARAM_WRITE_DEPENDENCY = ComponentParameters.PARAM_WRITE_DEPENDENCY;
+    @ConfigurationParameter(name = PARAM_WRITE_DEPENDENCY, mandatory = true, defaultValue = "true")
+    private boolean writeDependency;
+    
+    /**
+     * Write text covered by the token instead of the token form.
+     */
+    public static final String PARAM_WRITE_COVERED_TEXT = 
+            ComponentParameters.PARAM_WRITE_COVERED_TEXT;
+    @ConfigurationParameter(name = PARAM_WRITE_COVERED_TEXT, mandatory = true, defaultValue = "true")
+    private boolean writeCovered;
+    
+    /**
+     * Include the full sentence text as a comment in front of each sentence.
+     */
+    public static final String PARAM_WRITE_TEXT_COMMENT = "writeTextComment";
+    @ConfigurationParameter(name = PARAM_WRITE_TEXT_COMMENT, mandatory = true, defaultValue = "true")
+    private boolean writeTextHeader;
+
+    @Override
+    public void process(JCas aJCas)
+        throws AnalysisEngineProcessException
+    {
+        try (PrintWriter out = new PrintWriter(
+                new OutputStreamWriter(getOutputStream(aJCas, filenameSuffix), targetEncoding));) {
+            convert(aJCas, out);
+        }
+        catch (Exception e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+    }
+
+    private void convert(JCas aJCas, PrintWriter aOut)
+    {
+        Map<SurfaceForm, Collection<Token>> surfaceIdx = indexCovered(aJCas, SurfaceForm.class,
+                Token.class);
+        Int2ObjectMap<SurfaceForm> surfaceBeginIdx = new Int2ObjectOpenHashMap<>();
+        for (SurfaceForm sf : select(aJCas, SurfaceForm.class)) {
+            surfaceBeginIdx.put(sf.getBegin(), sf);
+        }
+        
+        for (Sentence sentence : select(aJCas, Sentence.class)) {
+            Map<Token, Row> ctokens = new LinkedHashMap<>();
+
+            // Comments
+            if (sentence.getId() != null) {
+                aOut.printf("# %s = %s\n", ConllUReader.META_SEND_ID, sentence.getId());
+            }
+            if (writeTextHeader) {
+                aOut.printf("# %s = %s\n", ConllUReader.META_TEXT, sentence.getCoveredText());
+            }
+            
+            // Tokens
+            List<Token> tokens = selectCovered(Token.class, sentence);
+            
+            for (int i = 0; i < tokens.size(); i++) {
+                Row row = new Row();
+                row.id = i + 1;
+                row.token = tokens.get(i);
+                row.noSpaceAfter = (i + 1 < tokens.size())
+                        && row.token.getEnd() == tokens.get(i + 1).getBegin();
+                ctokens.put(row.token, row);
+            }
+
+            // Dependencies
+            for (Dependency rel : selectCovered(Dependency.class, sentence)) {
+                if (StringUtils.isBlank(rel.getFlavor())
+                        || DependencyFlavor.BASIC.equals(rel.getFlavor())) {
+                    ctokens.get(rel.getDependent()).deprel = rel;
+                }
+                else {
+                    ctokens.get(rel.getDependent()).deps.add(rel);
+                }
+            }
+
+            // Write sentence in CONLL-U format
+            for (Row row : ctokens.values()) {
+                
+                String form = row.token.getCoveredText();
+                if (!writeCovered) {
+                    form = row.token.getText();
+                }
+                
+                String lemma = UNUSED;
+                if (writeLemma && (row.token.getLemma() != null)) {
+                    lemma = row.token.getLemma().getValue();
+                }
+
+                String pos = UNUSED;
+                if (writePos && (row.token.getPos() != null)
+                    && row.token.getPos().getPosValue() != null) {
+                    POS posAnno = row.token.getPos();
+                    pos = posAnno.getPosValue();
+                }
+
+                String cpos = UNUSED;
+                if (writeCPos && (row.token.getPos() != null)
+                        && row.token.getPos().getCoarseValue() != null) {
+                    POS posAnno = row.token.getPos();
+                    cpos = posAnno.getCoarseValue();
+                }
+
+                int headId = UNUSED_INT;
+                String deprel = UNUSED;
+                String deps = UNUSED;
+                if (writeDependency) {
+                    if ((row.deprel != null)) {
+                        deprel = row.deprel.getDependencyType();
+                        headId = ctokens.get(row.deprel.getGovernor()).id;
+                        if (headId == row.id) {
+                            // ROOT dependencies may be modeled as a loop, ignore these.
+                            headId = 0;
+                        }
+                    }
+                    
+                    StringBuilder depsBuf = new StringBuilder();
+                    for (Dependency d : row.deps) {
+                        if (depsBuf.length() > 0) {
+                            depsBuf.append('|');
+                        }
+                        // Resolve self-looping root to 0-indexed root
+                        int govId = ctokens.get(d.getGovernor()).id;
+                        if (govId == row.id) {
+                            govId = 0;
+                        }
+                        depsBuf.append(govId);
+                        depsBuf.append(':');
+                        depsBuf.append(d.getDependencyType());
+                    }
+                    if (depsBuf.length() > 0) {
+                        deps = depsBuf.toString();
+                    }
+                }
+                
+                String head = UNUSED;
+                if (headId != UNUSED_INT) {
+                    head = Integer.toString(headId);
+                }
+                
+                String feats = UNUSED;
+                if (writeMorph && (row.token.getMorph() != null)) {
+                    feats = row.token.getMorph().getValue();
+                }
+                
+                String misc = UNUSED;
+                if (row.noSpaceAfter) {
+                    misc = "SpaceAfter=No";
+                }
+
+                SurfaceForm sf = surfaceBeginIdx.get(row.token.getBegin());
+                if (sf != null) {
+                    @SuppressWarnings({ "unchecked", "rawtypes" })
+                    List<Token> covered = (List) surfaceIdx.get(sf);
+                    int id1 = ctokens.get(covered.get(0)).id;
+                    int id2 = ctokens.get(covered.get(covered.size() - 1)).id;
+                    aOut.printf("%d-%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", id1, id2,
+                            sf.getValue(), UNUSED, UNUSED, UNUSED, UNUSED, UNUSED, UNUSED, UNUSED,
+                            UNUSED);
+                }
+                
+                aOut.printf("%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", row.id,
+                        form, lemma, cpos, pos, feats, head, deprel, deps,
+                        misc);
+            }
+
+            aOut.println();
+        }
+    }
+
+    private static final class Row
+    {
+        int id;
+        Token token;
+        boolean noSpaceAfter;
+        Dependency deprel;
+        List<Dependency> deps = new ArrayList<>();
+    }
+}

--- a/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpReaderWriterTest.java
+++ b/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpReaderWriterTest.java
@@ -47,7 +47,8 @@ public class ConllCoreNlpReaderWriterTest
                 ConllCoreNlpWriter.class,
                 ConllCoreNlpWriter.PARAM_TARGET_LOCATION, "target/test-output/ConllCoreNlpReaderWriterTest-roundTrip",
                 ConllCoreNlpWriter.PARAM_FILENAME_SUFFIX, ".conll",
-                ConllCoreNlpWriter.PARAM_STRIP_EXTENSION, true);
+                ConllCoreNlpWriter.PARAM_STRIP_EXTENSION, true,
+                ConllCoreNlpWriter.PARAM_OVERWRITE, true);
 
         runPipeline(reader, writer);
 

--- a/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReaderTest.java
+++ b/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReaderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.conll;
+
+import static de.tudarmstadt.ukp.dkpro.core.testing.AssertAnnotations.assertMorph;
+import static de.tudarmstadt.ukp.dkpro.core.testing.AssertAnnotations.assertPOS;
+import static de.tudarmstadt.ukp.dkpro.core.testing.AssertAnnotations.assertSentence;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+import static org.apache.uima.fit.util.JCasUtil.select;
+
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.fit.pipeline.JCasIterable;
+import org.apache.uima.jcas.JCas;
+import org.junit.Rule;
+import org.junit.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
+
+public class ConllUReaderTest
+{
+    @Test
+    public void test()
+        throws Exception
+    {
+        CollectionReaderDescription reader = createReaderDescription(
+                ConllUReader.class, 
+                ConllUReader.PARAM_LANGUAGE, "en",
+                ConllUReader.PARAM_SOURCE_LOCATION, "src/test/resources/conll/u/", 
+                ConllUReader.PARAM_PATTERNS, "conllu-en-orig.conll");
+        
+        JCas jcas = new JCasIterable(reader).iterator().next();
+
+        String[] sentences = {
+                "They buy and sell books.",
+                "I have not a clue." };
+
+        String[] posMapped = { "POS", "POS_VERB", "POS_CONJ", "POS_VERB", "POS_NOUN", "POS_PUNCT", "POS", "POS_VERB", "POS_ADV",
+                "POS_DET", "POS_NOUN", "POS_PUNCT" };
+
+        String[] posOriginal = { "PRN", "VB", "CC", "VB", "NNS", ".", "PRN", "VB", "RB", "DT", "NN",
+                "." };
+
+        String[] morphologicalFeeatures = {
+                "[  0,  4]     -     -  Nom    -    -     -    -    -  Plur      -  -    -    -    -     -      -     - They (Case=Nom|Number=Plur)",
+                "[  5,  8]     -     -    -    -    -     -    -    -  Plur      -  3    -    -    -  Pres      -     - buy (Number=Plur|Person=3|Tense=Pres)",
+                "[ 13, 17]     -     -    -    -    -     -    -    -  Plur      -  3    -    -    -  Pres      -     - sell (Number=Plur|Person=3|Tense=Pres)",
+                "[ 18, 23]     -     -    -    -    -     -    -    -  Plur      -  -    -    -    -     -      -     - books (Number=Plur)",
+                "[ 25, 26]     -     -  Nom    -    -     -    -    -  Sing      -  1    -    -    -     -      -     - I (Case=Nom|Number=Sing|Person=1)",
+                "[ 27, 31]     -     -    -    -    -     -    -    -  Sing      -  1    -    -    -  Pres      -     - have (Number=Sing|Person=1|Tense=Pres)",
+                "[ 32, 35]     -     -    -    -    -     -    -  Neg     -      -  -    -    -    -     -      -     - not (Negative=Neg)",
+                "[ 36, 37]     -     -    -    -    -     -    -    -     -      -  -    -  Art    -     -      -     - a (Definite=Ind|PronType=Art)",
+                "[ 38, 42]     -     -    -    -    -     -    -    -  Sing      -  -    -    -    -     -      -     - clue (Number=Sing)"
+        };
+        
+        assertSentence(sentences, select(jcas, Sentence.class));
+        assertPOS(posMapped, posOriginal, select(jcas, POS.class));
+        assertMorph(morphologicalFeeatures, select(jcas, MorphologicalFeatures.class));
+    }
+
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+}

--- a/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReaderWriterTest.java
+++ b/webanno-io-conll/src/test/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUReaderWriterTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.conll;
+
+import static de.tudarmstadt.ukp.dkpro.core.testing.IOTestRunner.testOneWay;
+import static de.tudarmstadt.ukp.dkpro.core.testing.IOTestRunner.testRoundTrip;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.testing.DkproTestContext;
+
+public class ConllUReaderWriterTest
+{
+    @Test
+    public void roundTrip()
+        throws Exception
+    {
+        testRoundTrip(
+                createReaderDescription(ConllUReader.class),
+                createEngineDescription(ConllUWriter.class,
+                        ConllUWriter.PARAM_WRITE_TEXT_COMMENT, false),
+                "conll/u/conllu-en-orig.conll");
+    }
+
+    @Ignore("This unfortunately doesn't work yet.")
+    @Test
+    public void roundTripV2EmptyNodes()
+        throws Exception
+    {
+        testRoundTrip(ConllUReader.class, ConllUWriter.class, "conll/u_v2/conllu-empty_nodes.conll");
+    }
+
+    @Test
+    public void roundTripV2MorphologicalAnnotation()
+        throws Exception
+    {
+        testRoundTrip(ConllUReader.class, ConllUWriter.class, "conll/u_v2/conllu-morphological_annotation.conll");
+    }
+
+    @Ignore("This unfortunately doesn't work yet.")
+    @Test
+    public void roundTripV2ParagraphAndDocumentBoundaries()
+        throws Exception
+    {
+        testRoundTrip(
+                createReaderDescription(ConllUReader.class),
+                createEngineDescription(ConllUWriter.class,
+                        ConllUWriter.PARAM_WRITE_TEXT_COMMENT, true),
+                "conll/u_v2/conllu-paragraph_and_document_boundaries.conll");
+    }
+
+    @Test
+    public void roundTripV2SentenceBoundariesAndComments()
+        throws Exception
+    {
+        testRoundTrip(
+                createReaderDescription(ConllUReader.class),
+                createEngineDescription(ConllUWriter.class,
+                        ConllUWriter.PARAM_WRITE_TEXT_COMMENT, true),
+                "conll/u_v2/conllu-sentence_bounaries_and_comments.conll");
+    }
+
+    @Test
+    public void roundTripV2SyntacticAnnotation()
+        throws Exception
+    {
+        testRoundTrip(ConllUReader.class, ConllUWriter.class, "conll/u_v2/conllu-syntactic_annotation.conll");
+    }
+
+    @Ignore("This unfortunately doesn't work yet.")
+    @Test
+    public void roundTripV2UntokenizedText()
+        throws Exception
+    {
+        testRoundTrip(
+                createReaderDescription(ConllUReader.class),
+                createEngineDescription(ConllUWriter.class,
+                        ConllUWriter.PARAM_WRITE_TEXT_COMMENT, true),
+                "conll/u_v2/conllu-untokenized_text.conll");
+    }
+
+    @Test
+    public void roundTripV2WordsAndTokens()
+        throws Exception
+    {
+        testRoundTrip(ConllUReader.class, ConllUWriter.class, "conll/u_v2/conllu-words_and_tokens.conll");
+    }
+
+    @Test
+    public void withComments()
+        throws Exception
+    {
+        testOneWay(
+                createReaderDescription(ConllUReader.class),
+                createEngineDescription(ConllUWriter.class,
+                        ConllUWriter.PARAM_WRITE_TEXT_COMMENT, false),
+                "conll/u/conllu-en-ref.conll",
+                "conll/u/conllu-en-orig2.conll");
+    }
+
+    @Rule
+    public DkproTestContext testContext = new DkproTestContext();
+}

--- a/webanno-io-conll/src/test/resources/conll/u/conllu-en-orig.conll
+++ b/webanno-io-conll/src/test/resources/conll/u/conllu-en-orig.conll
@@ -1,14 +1,14 @@
-1	They	they	PRN	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
-2	buy	buy	VB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
-3	and	and	CC	CC	_	2	cc	_	_
-4	sell	sell	VB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
-5	books	book	NNS	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+1	They	they	PRON	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
+2	buy	buy	VERB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
+3	and	and	CONJ	CC	_	2	cc	_	_
+4	sell	sell	VERB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
+5	books	book	NOUN	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_
 
-1	I	I	PRN	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
+1	I	I	PRON	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
 2-3	haven't	_	_	_	_	_	_	_	_
-2	have	have	VB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
-3	not	not	RB	RB	Negative=Neg	2	neg	_	_
-4	a	a	DT	DT	Definite=Ind|PronType=Art	5	det	_	_
-5	clue	clue	NN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+2	have	have	VERB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
+3	not	not	PART	RB	Negative=Neg	2	neg	_	_
+4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	_	_
+5	clue	clue	NOUN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_

--- a/webanno-io-conll/src/test/resources/conll/u/conllu-en-orig2.conll
+++ b/webanno-io-conll/src/test/resources/conll/u/conllu-en-orig2.conll
@@ -1,16 +1,18 @@
 # sent_id = 1
-1	They	they	PRN	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
-2	buy	buy	VB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
-3	and	and	CC	CC	_	2	cc	_	_
-4	sell	sell	VB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
-5	books	book	NNS	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+# ...
+1	They	they	PRON	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
+2	buy	buy	VERB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
+3	and	and	CONJ	CC	_	2	cc	_	_
+4	sell	sell	VERB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
+5	books	book	NOUN	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 2
-1	I	I	PRN	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
+# ...
+1	I	I	PRON	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
 2-3	haven't	_	_	_	_	_	_	_	_
-2	have	have	VB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
-3	not	not	RB	RB	Negative=Neg	2	neg	_	_
-4	a	a	DT	DT	Definite=Ind|PronType=Art	5	det	_	_
-5	clue	clue	NN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+2	have	have	VERB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
+3	not	not	PART	RB	Negative=Neg	2	neg	_	_
+4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	_	_
+5	clue	clue	NOUN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_

--- a/webanno-io-conll/src/test/resources/conll/u/conllu-en-ref.conll
+++ b/webanno-io-conll/src/test/resources/conll/u/conllu-en-ref.conll
@@ -1,16 +1,16 @@
 # sent_id = 1
-1	They	they	PRN	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
-2	buy	buy	VB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
-3	and	and	CC	CC	_	2	cc	_	_
-4	sell	sell	VB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
-5	books	book	NNS	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+1	They	they	PRON	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
+2	buy	buy	VERB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
+3	and	and	CONJ	CC	_	2	cc	_	_
+4	sell	sell	VERB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
+5	books	book	NOUN	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 2
-1	I	I	PRN	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
+1	I	I	PRON	PRN	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
 2-3	haven't	_	_	_	_	_	_	_	_
-2	have	have	VB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
-3	not	not	RB	RB	Negative=Neg	2	neg	_	_
-4	a	a	DT	DT	Definite=Ind|PronType=Art	5	det	_	_
-5	clue	clue	NN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
-6	.	.	.	.	_	2	punct	_	_
+2	have	have	VERB	VB	Number=Sing|Person=1|Tense=Pres	0	root	_	_
+3	not	not	PART	RB	Negative=Neg	2	neg	_	_
+4	a	a	DET	DT	Definite=Ind|PronType=Art	5	det	_	_
+5	clue	clue	NOUN	NN	Number=Sing	2	dobj	_	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_

--- a/webanno-io-conll/src/test/resources/conll/u_v2/conllu-morphological_annotation.conll
+++ b/webanno-io-conll/src/test/resources/conll/u_v2/conllu-morphological_annotation.conll
@@ -1,7 +1,7 @@
 # text = Då var han elva år .
-1	Då	då	AB	AB	_	_	_	_	_
-2	var	vara	VB.PRET.ACT	VB.PRET.ACT	Tense=Past|Voice=Act	_	_	_	_
-3	han	han	PN.UTR.SIN.DEF.NOM	PN.UTR.SIN.DEF.NOM	Case=Nom|Definite=Def|Gender=Com|Number=Sing	_	_	_	_
-4	elva	elva	RG.NOM	RG.NOM	Case=Nom|NumType=Card	_	_	_	_
-5	år	år	NN.NEU.PLU.IND.NOM	NN.NEU.PLU.IND.NOM	Case=Nom|Definite=Ind|Gender=Neut|Number=Plur	_	_	_	_
-6	.	.	DL.MAD	DL.MAD	_	_	_	_	_
+1	Då	då	ADV	AB	_	_	_	_	_
+2	var	vara	VERB	VB.PRET.ACT	Tense=Past|Voice=Act	_	_	_	_
+3	han	han	PRON	PN.UTR.SIN.DEF.NOM	Case=Nom|Definite=Def|Gender=Com|Number=Sing	_	_	_	_
+4	elva	elva	NUM	RG.NOM	Case=Nom|NumType=Card	_	_	_	_
+5	år	år	NOUN	NN.NEU.PLU.IND.NOM	Case=Nom|Definite=Ind|Gender=Neut|Number=Plur	_	_	_	_
+6	.	.	PUNCT	DL.MAD	_	_	_	_	_

--- a/webanno-io-conll/src/test/resources/conll/u_v2/conllu-sentence_bounaries_and_comments.conll
+++ b/webanno-io-conll/src/test/resources/conll/u_v2/conllu-sentence_bounaries_and_comments.conll
@@ -1,16 +1,16 @@
 # sent_id = 1
 # text = They buy and sell books.
-1	They	they	PRP	PRP	Case=Nom|Number=Plur	2	nsubj	2:nsubj|4:nsubj	_
-2	buy	buy	VBP	VBP	Number=Plur|Person=3|Tense=Pres	0	root	0:root	_
-3	and	and	CC	CC	_	4	cc	4:cc	_
-4	sell	sell	VBP	VBP	Number=Plur|Person=3|Tense=Pres	2	conj	0:root|2:conj	_
-5	books	book	NNS	NNS	Number=Plur	2	obj	2:obj|4:obj	SpaceAfter=No
-6	.	.	.	.	_	2	punct	2:punct	_
+1	They	they	PRON	PRP	Case=Nom|Number=Plur	2	nsubj	2:nsubj|4:nsubj	_
+2	buy	buy	VERB	VBP	Number=Plur|Person=3|Tense=Pres	0	root	0:root	_
+3	and	and	CONJ	CC	_	4	cc	4:cc	_
+4	sell	sell	VERB	VBP	Number=Plur|Person=3|Tense=Pres	2	conj	0:root|2:conj	_
+5	books	book	NOUN	NNS	Number=Plur	2	obj	2:obj|4:obj	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	2:punct	_
 
 # sent_id = 2
 # text = I have no clue.
-1	I	I	PRP	PRP	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
-2	have	have	VBP	VBP	Number=Sing|Person=1|Tense=Pres	0	root	_	_
-3	no	no	DT	DT	PronType=Neg	4	det	_	_
-4	clue	clue	NN	NN	Number=Sing	2	obj	_	SpaceAfter=No
-5	.	.	.	.	_	2	punct	_	_
+1	I	I	PRON	PRP	Case=Nom|Number=Sing|Person=1	2	nsubj	_	_
+2	have	have	VERB	VBP	Number=Sing|Person=1|Tense=Pres	0	root	_	_
+3	no	no	DET	DT	PronType=Neg	4	det	_	_
+4	clue	clue	NOUN	NN	Number=Sing	2	obj	_	SpaceAfter=No
+5	.	.	PUNCT	.	_	2	punct	_	_

--- a/webanno-io-conll/src/test/resources/conll/u_v2/conllu-syntactic_annotation.conll
+++ b/webanno-io-conll/src/test/resources/conll/u_v2/conllu-syntactic_annotation.conll
@@ -1,7 +1,7 @@
 # text = They buy and sell books .
-1	They	they	PRP	PRP	Case=Nom|Number=Plur	2	nsubj	2:nsubj|4:nsubj	_
-2	buy	buy	VBP	VBP	Number=Plur|Person=3|Tense=Pres	0	root	0:root	_
-3	and	and	CC	CC	_	4	cc	4:cc	_
-4	sell	sell	VBP	VBP	Number=Plur|Person=3|Tense=Pres	2	conj	0:root|2:conj	_
-5	books	book	NNS	NNS	Number=Plur	2	obj	2:obj|4:obj	_
-6	.	.	.	.	_	2	punct	2:punct	_
+1	They	they	PRON	PRP	Case=Nom|Number=Plur	2	nsubj	2:nsubj|4:nsubj	_
+2	buy	buy	VERB	VBP	Number=Plur|Person=3|Tense=Pres	0	root	0:root	_
+3	and	and	CONJ	CC	_	4	cc	4:cc	_
+4	sell	sell	VERB	VBP	Number=Plur|Person=3|Tense=Pres	2	conj	0:root|2:conj	_
+5	books	book	NOUN	NNS	Number=Plur	2	obj	2:obj|4:obj	_
+6	.	.	PUNCT	.	_	2	punct	2:punct	_


### PR DESCRIPTION
**What's in the PR**
- Temporarily backport latest DKPro Core CoNLL-U reader and writer code to enable reading/writing of sentence text comment and sentence ID comment

**How to test manually**
* Check if the export in CoNLL-U format contains the sentence text comment
* A sentence ID comment is only present if the file was originally imported from CoNLL-U and contained a sentence ID

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation