### PR TITLE
1296 relation update event

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
@@ -17,8 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectByAddr;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
 import static org.apache.uima.fit.util.CasUtil.getType;
@@ -30,7 +29,6 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
-import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.slf4j.Logger;
@@ -181,12 +179,10 @@ public class RelationAdapter
     @Override
     public void delete(SourceDocument aDocument, String aUsername, CAS aCas, VID aVid)
     {
-        int addr = aVid.getId();
-        FeatureStructure fs = selectFsByAddr(aCas, addr);
+        AnnotationFS fs = selectByAddr(aCas, AnnotationFS.class, aVid.getId());
         aCas.removeFsFromIndexes(fs);
-        AnnotationFS anno = selectAnnotationByAddr(aCas, addr);
         publishEvent(new RelationUpdateEvent(this, aDocument, aUsername,
-                anno));
+                fs));
     }
 
     public String getSourceFeatureName()

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.RelationCreatedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
@@ -142,9 +143,13 @@ public class RelationAdapter
         for (RelationLayerBehavior behavior : behaviors) {
             request = behavior.onCreate(this, request);
         }
-        
-        return createRelationAnnotation(request.getCas(), request.getOriginFs(),
-                request.getTargetFs());
+
+        AnnotationFS relationAnno = createRelationAnnotation(request.getCas(),
+                request.getOriginFs(), request.getTargetFs());
+        publishEvent(new RelationCreatedEvent(this, request.getDocument(), request.getUsername(),
+                relationAnno));
+
+        return relationAnno;
     }
 
     private AnnotationFS createRelationAnnotation(CAS cas, AnnotationFS originFS,

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
@@ -37,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.RelationCreatedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.RelationUpdateEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
@@ -146,7 +147,7 @@ public class RelationAdapter
 
         AnnotationFS relationAnno = createRelationAnnotation(request.getCas(),
                 request.getOriginFs(), request.getTargetFs());
-        publishEvent(new RelationCreatedEvent(this, request.getDocument(), request.getUsername(),
+        publishEvent(new RelationUpdateEvent(this, request.getDocument(), request.getUsername(),
                 relationAnno));
 
         return relationAnno;
@@ -180,8 +181,12 @@ public class RelationAdapter
     @Override
     public void delete(SourceDocument aDocument, String aUsername, CAS aCas, VID aVid)
     {
-        FeatureStructure fs = selectFsByAddr(aCas, aVid.getId());
+        int addr = aVid.getId();
+        FeatureStructure fs = selectFsByAddr(aCas, addr);
         aCas.removeFsFromIndexes(fs);
+        AnnotationFS anno = selectAnnotationByAddr(aCas, addr);
+        publishEvent(new RelationUpdateEvent(this, aDocument, aUsername,
+                anno));
     }
 
     public String getSourceFeatureName()

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/RelationCreatedEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/RelationCreatedEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.event;
+
+import org.apache.uima.cas.Feature;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public class RelationCreatedEvent extends ApplicationEvent
+{
+    private static final long serialVersionUID = -8621413642390759892L;
+    
+    private final SourceDocument document;
+    private final String user;
+    private final AnnotationFS annotation;
+
+    public RelationCreatedEvent(Object aSource, SourceDocument aDocument, String aUser,
+            AnnotationFS aAnnotation)
+    {
+        super(aSource);
+        document = aDocument;
+        user = aUser;
+        annotation = aAnnotation;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public AnnotationFS getAnnotation()
+    {
+        return annotation;
+    }
+    
+    @Override
+    public String toString()
+    {
+        String govFeatureName = ((RelationAdapter) getSource()).getSourceFeatureName();
+        Feature govFeature = annotation.getType().getFeatureByBaseName(govFeatureName);
+        AnnotationFS govToken = (AnnotationFS) annotation.getFeatureValue(govFeature);
+        
+        StringBuilder builder = new StringBuilder();
+        builder.append("RelationCreatedEvent [");
+        if (document != null) {
+            builder.append("docID=");
+            builder.append(document.getId());
+            builder.append(", user=");
+            builder.append(user);
+            builder.append(", ");
+        }
+        builder.append("relation=[");
+        builder.append(annotation.getBegin());
+        builder.append("-");
+        builder.append(annotation.getEnd());
+        builder.append("](");
+        builder.append(annotation.getCoveredText());
+        builder.append(") <-[");
+        builder.append(govToken.getBegin());
+        builder.append("-");
+        builder.append(govToken.getEnd());
+        builder.append("](");
+        builder.append(govToken.getCoveredText());
+        builder.append(")]");
+        return builder.toString();
+    }
+
+}

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/RelationUpdateEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/RelationUpdateEvent.java
@@ -24,7 +24,7 @@ import org.springframework.context.ApplicationEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
-public class RelationCreatedEvent extends ApplicationEvent
+public class RelationUpdateEvent extends ApplicationEvent
 {
     private static final long serialVersionUID = -8621413642390759892L;
     
@@ -32,7 +32,7 @@ public class RelationCreatedEvent extends ApplicationEvent
     private final String user;
     private final AnnotationFS annotation;
 
-    public RelationCreatedEvent(Object aSource, SourceDocument aDocument, String aUser,
+    public RelationUpdateEvent(Object aSource, SourceDocument aDocument, String aUser,
             AnnotationFS aAnnotation)
     {
         super(aSource);


### PR DESCRIPTION
**What's in the PR**
* closes https://github.com/webanno/webanno/issues/1296
* I would like to publish an event when Relations are created or deleted. I will use this to identify annotation events for resuming previous work in Inception.

**How to test manually**
* checkout inception PR https://github.com/inception-project/inception/pull/1142
* this PR will show last activities as events on the project dashboard page
* try annotating documents with dependency relations (e.g. POS) 
* try deleting dependencies
* when opening the dashboard page, the last event should be shown

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
