### PR TITLE
#1300 illegal access warning on injection

### DIFF
--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/spring/ApplicationEventPublisherHolder.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/spring/ApplicationEventPublisherHolder.java
@@ -17,21 +17,13 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.support.spring;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Component;
 
 /**
  * Helper component because we cannot inject the {@link ApplicationEventPublisher} directly into
  * Wicket components.
  */
-@Component
-public class ApplicationEventPublisherHolder
+public interface ApplicationEventPublisherHolder
 {
-    private @Autowired ApplicationEventPublisher applicationEventPublisher;
-
-    public ApplicationEventPublisher get()
-    {
-        return applicationEventPublisher;
-    }
+    public ApplicationEventPublisher get();
 }

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/spring/ApplicationEventPublisherHolderImpl.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/spring/ApplicationEventPublisherHolderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018
+ * Copyright 2019
  * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
  * Technische Universität Darmstadt
  *
@@ -15,11 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.ui.core.users;
+package de.tudarmstadt.ukp.clarin.webanno.support.spring;
 
-public interface RemoteApiProperties
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationEventPublisherHolderImpl implements ApplicationEventPublisherHolder
 {
-    public boolean isEnabled();
+    private @Autowired ApplicationEventPublisher applicationEventPublisher;
 
-    public void setEnabled(boolean aRemoteApiEnabled);
+    @Override
+    public ApplicationEventPublisher get()
+    {
+        return applicationEventPublisher;
+    }
 }

--- a/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
+++ b/webanno-ui-automation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/automation/page/AutomationPage.java
@@ -68,7 +68,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.SentenceOrientedPagingStrategy;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.BratPropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.BratProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderAnnotationsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.automation.service.AutomationService;
@@ -128,7 +128,7 @@ public class AutomationPage
     private @SpringBean DocumentService documentService;
     private @SpringBean ProjectService projectService;
     private @SpringBean ConstraintsService constraintsService;
-    private @SpringBean BratPropertiesImpl defaultPreferences;
+    private @SpringBean BratProperties defaultPreferences;
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean UserDao userRepository;
     private @SpringBean CurationDocumentService curationDocumentService;

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/RemoteApiPropertiesImpl.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/RemoteApiPropertiesImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018
+ * Copyright 2019
  * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
  * Technische Universität Darmstadt
  *
@@ -17,9 +17,27 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.users;
 
-public interface RemoteApiProperties
-{
-    public boolean isEnabled();
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
-    public void setEnabled(boolean aRemoteApiEnabled);
+@Component("RemoteApiProperties-secondary")
+@ConfigurationProperties("remote-api")
+public class RemoteApiPropertiesImpl implements RemoteApiProperties
+{
+    private boolean enabled = false;
+
+    @Override
+    public boolean isEnabled()
+    {
+        boolean enabledViaLegacySystemProperty = "true"
+                .equals(System.getProperty("webanno.remote-api.enable"));
+        
+        return enabled || enabledViaLegacySystemProperty;
+    }
+
+    @Override
+    public void setEnabled(boolean aRemoteApiEnabled)
+    {
+        enabled = aRemoteApiEnabled;
+    }
 }

--- a/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
+++ b/webanno-ui-correction/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/correction/CorrectionPage.java
@@ -64,7 +64,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateImpl
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateUtils;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.SentenceOrientedPagingStrategy;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.BratPropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.BratProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderAnnotationsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratAnnotationEditor;
@@ -120,7 +120,7 @@ public class CorrectionPage
     private @SpringBean CorrectionDocumentService correctionDocumentService;
     private @SpringBean ProjectService projectService;
     private @SpringBean ConstraintsService constraintsService;
-    private @SpringBean BratPropertiesImpl defaultPreferences;
+    private @SpringBean BratProperties defaultPreferences;
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean UserDao userRepository;
 


### PR DESCRIPTION
**What's in the PR**
Refers to issue https://github.com/inception-project/inception/issues/780.
Wicket @SpringBean injection generates illegal access warning on recent JDKs. This is solved by using existing interfaces or creating new ones. 

**How to test manually**
* Add --illegal-access=debug to the VM arguments
* Use a recent JDK (9 or higher)
* Access pages which use bean injection
