### PR TITLE
#1301 - Error on curation page when all annotators are removed from a project

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
@@ -391,8 +391,9 @@ public class CasStorageServiceImpl
                 realWriteCas(aDocument, aUsername, jcas);
             }
             else {
-                throw new FileNotFoundException("CAS [" + aDocument.getId() + "," + aUsername
-                        + "] does not exist and no initializer is specified.");
+                throw new FileNotFoundException("CAS file for [" + aDocument.getId() + ","
+                        + aUsername + "] does not exist at [" + casFile
+                        + "] and no initializer is specified.");
             }
             
             // Add/update the CAS metadata

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -345,9 +345,8 @@ public class DocumentServiceImpl
                 .getSingleResult();
     }
     
-    @Override
     @Transactional
-    public SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
+    private SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
             SourceDocumentState aState)
     {
         Validate.notNull(aDocument, "Source document must be specified");

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -167,11 +167,7 @@ public interface DocumentService
      * @throws IOException
      *             if an I/O error occurs.
      */
-    File getDocumentFolder(SourceDocument aDocument)
-        throws IOException;
-
-    SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
-            SourceDocumentState aState);
+    File getDocumentFolder(SourceDocument aDocument) throws IOException;
 
     SourceDocumentState transitionSourceDocumentState(SourceDocument aDocument,
             SourceDocumentStateTransition aTransition);

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -666,6 +666,9 @@ public class CurationPage
             if (finishedAnnotationDocuments.size() > 0) {
                 randomAnnotationDocument = finishedAnnotationDocuments.get(0);
             }
+            else {
+                throw new IllegalStateException("There are no finished annotation documents!");
+            }
     
             // upgrade CASes for each user, what if new type is added once the user finished
             // annotation

--- a/webanno-ui-project/pom.xml
+++ b/webanno-ui-project/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-curation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-api-formats</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- For the start provide a better error message if there are no curatable annotation documents even if a source document can be opened for curation
- Remove unused `setSourceDocumentState()` method

**How to test manually**
* This PR doesn't fix the issue, but makes it a bit better to deal with it.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
