### PR TITLE
#1318 - Allow upgrading of CAS during load

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -446,6 +446,9 @@ public interface AnnotationSchemaService
     void upgradeCas(CAS aCas, SourceDocument aSourceDocument, String aUser)
             throws UIMAException, IOException;
 
+    void upgradeCas(CAS aCas, SourceDocument aSourceDocument, String aUser, CasUpgradeMode aMode)
+            throws UIMAException, IOException;
+    
     /**
      * Better call {@link #upgradeCas(CAS, SourceDocument, String)} which also logs the action
      * nicely to the log files. This method here is rather for unconditional bulk use such as

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -75,6 +75,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
@@ -845,11 +846,29 @@ public class AnnotationSchemaServiceImpl
 
         return (TypeSystemDescription_impl) mergeTypeSystems(typeSystems);
     }
+    
     @Override
     public void upgradeCas(CAS aCas, AnnotationDocument aAnnotationDocument)
         throws UIMAException, IOException
     {
         upgradeCas(aCas, aAnnotationDocument.getDocument(), aAnnotationDocument.getUser());
+    }
+
+    @Override
+    public void upgradeCas(CAS aCas, SourceDocument aSourceDocument, String aUser,
+            CasUpgradeMode aMode)
+        throws UIMAException, IOException
+    {
+        switch (aMode) {
+        case NO_CAS_UPGRADE:
+            return;
+        case AUTO_CAS_UPGRADE:
+            upgradeCasIfRequired(aCas, aSourceDocument, aUser);
+            return;
+        case FORCE_CAS_UPGRADE:
+            upgradeCas(aCas, aSourceDocument, aUser);
+            return;
+        }
     }
 
     @Override
@@ -903,6 +922,8 @@ public class AnnotationSchemaServiceImpl
 
         upgradeCas(aCas, ts);
     }
+    
+    
     
     @Override
     public CAS prepareCasForExport(CAS aCas, SourceDocument aSourceDocument)

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasMetadataUtils.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasMetadataUtils.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
@@ -133,10 +134,42 @@ public class CasMetadataUtils
         else {
             cmd = aCas.createAnnotation(casMetadataType, 0, 0);
         }
-        FSUtil.setFeature(cmd, "username", aUsername);
-        FSUtil.setFeature(cmd, "sourceDocumentId", aDocument.getId());
-        FSUtil.setFeature(cmd, "projectId", aDocument.getProject().getId());
-        FSUtil.setFeature(cmd, "lastChangedOnDisk", aCasFile.lastModified());
+        
+        if (cmd.getType().getFeatureByBaseName("username") != null) {
+            FSUtil.setFeature(cmd, "username", aUsername);
+        }
+        
+        if (cmd.getType().getFeatureByBaseName("sourceDocumentId") != null) {
+            FSUtil.setFeature(cmd, "sourceDocumentId", aDocument.getId());
+        }
+
+        if (cmd.getType().getFeatureByBaseName("sourceDocumentName") != null) {
+            FSUtil.setFeature(cmd, "sourceDocumentName", aDocument.getName());
+        }
+
+        if (cmd.getType().getFeatureByBaseName("projectId") != null) {
+            FSUtil.setFeature(cmd, "projectId", aDocument.getProject().getId());
+        }
+
+        if (cmd.getType().getFeatureByBaseName("projectName") != null) {
+            FSUtil.setFeature(cmd, "projectName", aDocument.getProject().getName());
+        }
+
+        if (cmd.getType().getFeatureByBaseName("lastChangedOnDisk") != null) {
+            FSUtil.setFeature(cmd, "lastChangedOnDisk", aCasFile.lastModified());
+        }
+        
         aCas.addFsToIndexes(cmd);
+    }
+    
+    public static Optional<String> getSourceDocumentName(CAS aCas)
+    {
+        try {
+            FeatureStructure fs = CasUtil.selectSingle(aCas, getType(aCas, CASMetadata.class));
+            return Optional.ofNullable(FSUtil.getFeature(fs, "sourceDocumentName", String.class));
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
@@ -414,11 +414,13 @@ public class CasStorageServiceImpl
             }
             else if (aSupplier != null) {
                 cas = aSupplier.get();
-                try {
-                    schemaService.upgradeCas(cas, aDocument, aUsername, aUpgradeMode);
-                }
-                catch (UIMAException e) {
-                    throw new IOException(e);
+                if (schemaService != null) {
+                    try {
+                        schemaService.upgradeCas(cas, aDocument, aUsername, aUpgradeMode);
+                    }
+                    catch (UIMAException e) {
+                        throw new IOException(e);
+                    }
                 }
                 source = "importer";
                 realWriteCas(aDocument, aUsername, cas);

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.NO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.DOCUMENT_FOLDER;
 import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.PROJECT_FOLDER;
 import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.SOURCE_FOLDER;
@@ -62,6 +63,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
@@ -605,11 +607,21 @@ public class DocumentServiceImpl
     public CAS readAnnotationCas(SourceDocument aDocument, String aUserName)
             throws IOException
     {
+        return readAnnotationCas(aDocument, aUserName, NO_CAS_UPGRADE);
+    }
+
+    @Override
+    @Transactional
+    public CAS readAnnotationCas(SourceDocument aDocument, String aUserName,
+            CasUpgradeMode aUpgradeMode)
+            throws IOException
+    {
         // If there is no CAS yet for the source document, create one.
-        CAS cas  = casStorageService.readOrCreateCas(aDocument, aUserName, () -> {
-            // Convert the source file into an annotation CAS
-            return createOrReadInitialCas(aDocument);
-        });
+        CAS cas = casStorageService.readOrCreateCas(aDocument, aUserName, true, aUpgradeMode,
+            () -> {
+                // Convert the source file into an annotation CAS
+                return createOrReadInitialCas(aDocument);
+            });
 
         // We intentionally do not upgrade the CAS here because in general the IDs
         // must remain stable. If an upgrade is required the caller should do it
@@ -621,12 +633,21 @@ public class DocumentServiceImpl
     public CAS readAnnotationCas(AnnotationDocument aAnnotationDocument)
         throws IOException
     {
+        return readAnnotationCas(aAnnotationDocument, NO_CAS_UPGRADE);
+    }
+
+    @Override
+    @Transactional
+    public CAS readAnnotationCas(AnnotationDocument aAnnotationDocument,
+            CasUpgradeMode aUpgradeMode)
+        throws IOException
+    {
         Validate.notNull(aAnnotationDocument, "Annotation document must be specified");
         
         SourceDocument aDocument = aAnnotationDocument.getDocument();
         String userName = aAnnotationDocument.getUser();
         
-        return readAnnotationCas(aDocument, userName);
+        return readAnnotationCas(aDocument, userName, aUpgradeMode);
     }
     
     @Override

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -46,7 +46,6 @@ public class CasStorageServiceImplTest
     private CasStorageService sut;
     private BackupProperties backupProperties;
     private RepositoryProperties repositoryProperties;
-    private AnnotationSchemaServiceImpl schemaService;
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -58,8 +57,6 @@ public class CasStorageServiceImplTest
         
         repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(testFolder.newFolder());
-        
-        schemaService = new AnnotationSchemaServiceImpl();
         
         sut = new CasStorageServiceImpl(null, null, repositoryProperties, backupProperties);
     }

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -61,7 +61,7 @@ public class CasStorageServiceImplTest
         
         schemaService = new AnnotationSchemaServiceImpl();
         
-        sut = new CasStorageServiceImpl(null, repositoryProperties, backupProperties);
+        sut = new CasStorageServiceImpl(null, null, repositoryProperties, backupProperties);
     }
     
     @Test

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -74,7 +74,8 @@ public class DocumentServiceImplTest
         repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(testFolder.newFolder());
 
-        storageService = new CasStorageServiceImpl(null, repositoryProperties, backupProperties);
+        storageService = new CasStorageServiceImpl(null, null, repositoryProperties,
+                backupProperties);
 
         sut = new DocumentServiceImpl(repositoryProperties, userRepository, storageService,
                 importExportService, projectService, applicationEventPublisher, entityManager);

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ImportExportServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ImportExportServiceImplTest.java
@@ -76,7 +76,8 @@ public class ImportExportServiceImplTest
         repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(testFolder.newFolder());
 
-        storageService = new CasStorageServiceImpl(null, repositoryProperties, backupProperties);
+        storageService = new CasStorageServiceImpl(null, null, repositoryProperties,
+                backupProperties);
 
         sut = new ImportExportServiceImpl(repositoryProperties, asList(new XmiFormatSupport()),
                 storageService, schemaService);

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasStorageService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasStorageService.java
@@ -92,6 +92,10 @@ public interface CasStorageService
     CAS readOrCreateCas(SourceDocument aDocument, String aUsername, CasProvider aSupplier)
         throws IOException;
 
+    CAS readOrCreateCas(SourceDocument aDocument, String aUsername, boolean aAnalyzeAndRepair,
+            CasUpgradeMode aUpgradeMode, CasProvider aSupplier)
+        throws IOException;
+
     boolean deleteCas(SourceDocument aDocument, String aUsername) throws IOException;
     
     File getAnnotationFolder(SourceDocument aDocument) throws IOException;

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasUpgradeMode.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasUpgradeMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api;
+
+public enum CasUpgradeMode
+{
+    /**
+     * Do not upgrade the CAS to the current project type system.
+     */
+    NO_CAS_UPGRADE,
+    
+    /**
+     * Try automatically detecting if the CAS type system is not up-to-date and perform
+     * and upgrade if this is the case.
+     */
+    AUTO_CAS_UPGRADE,
+    
+    /**
+     * Require a CAS upgrade.
+     */
+    FORCE_CAS_UPGRADE;
+}

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -336,6 +336,9 @@ public interface DocumentService
     CAS readAnnotationCas(AnnotationDocument annotationDocument)
         throws IOException;
 
+    CAS readAnnotationCas(AnnotationDocument aAnnotationDocument, CasUpgradeMode aUpgradeMode)
+            throws IOException;
+    
     void deleteAnnotationCas(AnnotationDocument annotationDocument)
         throws IOException;
     
@@ -373,6 +376,9 @@ public interface DocumentService
      *             if there was an I/O error.
      */
     CAS readAnnotationCas(SourceDocument document, String userName)
+        throws IOException;
+
+    CAS readAnnotationCas(SourceDocument aDocument, String aUserName, CasUpgradeMode aUpgradeMode)
         throws IOException;
 
     /**

--- a/webanno-api/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal.xml
+++ b/webanno-api/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal.xml
@@ -16,9 +16,19 @@
           <rangeTypeName>uima.cas.Long</rangeTypeName>
         </featureDescription>
         <featureDescription>
+          <name>projectName</name>
+          <description>The name of the project to which these annotations belong.</description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
           <name>sourceDocumentId</name>
           <description>The ID of the source documents to which these annotations belong.</description>
           <rangeTypeName>uima.cas.Long</rangeTypeName>
+        </featureDescription>
+        <featureDescription>
+          <name>sourceDocumentName</name>
+          <description>The name of the source documents to which these annotations belong.</description>
+          <rangeTypeName>uima.cas.String</rangeTypeName>
         </featureDescription>
         <featureDescription>
           <name>username</name>

--- a/webanno-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController2Test.java
+++ b/webanno-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/RemoteApiController2Test.java
@@ -318,7 +318,8 @@ public class RemoteApiController2Test
         @Bean
         public CasStorageService casStorageService()
         {
-            return new CasStorageServiceImpl(null, repositoryProperties(), backupProperties());
+            return new CasStorageServiceImpl(null, null, repositoryProperties(),
+                    backupProperties());
         }
         
         @Bean

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_DOCUMENT_ID;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_FOCUS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJECT_ID;
@@ -534,10 +535,9 @@ public class AnnotationPage
                     .createOrGetAnnotationDocument(state.getDocument(), state.getUser());
 
             // Read the CAS
-            CAS editorCas = documentService.readAnnotationCas(annotationDocument);
-
             // Update the annotation document CAS
-            annotationService.upgradeCas(editorCas, annotationDocument);
+            CAS editorCas = documentService.readAnnotationCas(annotationDocument,
+                    FORCE_CAS_UPGRADE);
 
             // After creating an new CAS or upgrading the CAS, we need to save it
             documentService.writeAnnotationCas(editorCas, annotationDocument, false);


### PR DESCRIPTION
**What's in the PR**
- Added sourceDocumentName and projectName to the CasMetadata
- Added option for readAnnotationCas to upgrade the type system during read
- Upgrade and add CasMetadata in one go when opening a document through the AnnotationPage

**How to test manually**
* Internal refactoring that is difficult to manually test - in theory you'd try opening a document with CAS with does not have a CasMetadata annotation yet (from an old project) and check in the log if there is *no* message about CasMetadata not being supported and thus not being added

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
