### PR TITLE
#1322 - Display feature description as tooltips

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
-    <label wicket:for="value" class="col-sm-3 control-label"><wicket:container wicket:id="feature"/></label>
+    <label wicket:for="value" class="col-sm-3 control-label"><span wicket:id="feature"/></label>
     <div class="col-sm-9">
       <input wicket:id="value" type="checkbox"/>
     </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <input wicket:id="value" style="width: 100%;"></input>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <input wicket:id="value"/>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <input wicket:id="value" style="width: 100%;"></input>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <input wicket:id="value" style="width: 100%;"></input>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
-    <label wicket:for="value" class="col-sm-3 control-label"><wicket:container wicket:id="feature"/></label>
+    <label wicket:for="value" class="col-sm-3 control-label"><span wicket:id="feature"/></label>
     <div class="col-sm-9">
       <input wicket:id="value" type="number"/>
     </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/Select2TextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/Select2TextFeatureEditor.html
@@ -27,7 +27,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
       <select wicket:id="value" style="width: 100%;"></select>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -737,6 +737,12 @@ public class AnnotationFeatureForm
             editor = featureSupport.createEditor("editor", AnnotationFeatureForm.this, editorPanel,
                     AnnotationFeatureForm.this.getModel(), item.getModel());
 
+            // We need to enable the markup ID here because we use it during the AJAX behavior
+            // that automatically saves feature editors on change/blur. 
+            // Check addAnnotateActionBehavior.
+            editor.setOutputMarkupId(true);
+            editor.setOutputMarkupPlaceholderTag(true);
+            
             if (!featureState.feature.getLayer().isReadonly()) {
                 AnnotatorState state = getModelObject();
 
@@ -762,6 +768,8 @@ public class AnnotationFeatureForm
                 }
 
                 Component labelComponent = editor.getLabelComponent();
+//                labelComponent.setMarkupId(
+//                        ID_PREFIX + editor.getModelObject().feature.getId() + "-w-lbl");
                 labelComponent.add(new AttributeAppender("style", "cursor: help", ";"));
                 labelComponent.add(new DescriptionTooltipBehavior(tooltipTitle.toString(),
                     featureState.feature.getDescription()));
@@ -770,12 +778,6 @@ public class AnnotationFeatureForm
                 editor.getFocusComponent().setEnabled(false);
             }
 
-            // We need to enable the markup ID here because we use it during the AJAX behavior
-            // that automatically saves feature editors on change/blur. 
-            // Check addAnnotateActionBehavior.
-            editor.setOutputMarkupId(true);
-            editor.setOutputMarkupPlaceholderTag(true);
-            
             // Ensure that markup IDs of feature editor focus components remain constant across
             // refreshes of the feature editor panel. This is required to restore the focus.
             editor.getFocusComponent().setOutputMarkupId(true);


### PR DESCRIPTION
**What's in the PR**
- Change feature label HTML code such that a span is used instead of a wicket:container as no style/JS can be attached to the latter

**How to test manually**
* Hover over the label of any feature to bring up a description tooltip

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
