### PR TITLE
#726 - Whitespace treated incorrectly at the end of spans in TSV3X exporter

### DIFF
--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
@@ -135,6 +135,16 @@ public class Tsv3XCasDocumentBuilder
                 }
                 
                 Entry<Integer, TsvToken> beginTokenEntry = tokenBeginIndex.floorEntry(begin);
+                // If the current annotation has leading whitespace, we have wrongly fetched the
+                // token before the start token using floorEntry(end) - so let's try to correct this
+                if (
+                        // found begin token but found the wrong one
+                        (beginTokenEntry != null && beginTokenEntry.getValue().getEnd() < begin) ||
+                        // didn't find end begin because annotation starts before the first token
+                        beginTokenEntry == null
+                ) {
+                    beginTokenEntry = tokenEndIndex.higherEntry(begin);
+                }
                 if (beginTokenEntry == null) {
                     throw new IllegalStateException(
                             "Unable to find begin token starting at or before " + begin
@@ -144,6 +154,16 @@ public class Tsv3XCasDocumentBuilder
                 }
 
                 Entry<Integer, TsvToken> endTokenEntry = tokenEndIndex.ceilingEntry(end);
+                // If the current annotation has trailing whitespace, we have wrongly fetched the
+                // token after the end token using ceilingEntry(end) - so let's try to correct this
+                if (
+                        // found end token but found the wrong one
+                        (endTokenEntry != null && endTokenEntry.getValue().getBegin() > end) ||
+                        // didn't find end token because annotation ends beyond the last token
+                        endTokenEntry == null
+                ) {
+                    endTokenEntry = tokenEndIndex.lowerEntry(end);
+                }
                 if (endTokenEntry == null) {
                     throw new IllegalStateException("Unable to find end token ending at or after "
                             + end + " (last token ends at " + tokenEndIndex.pollLastEntry().getKey()

--- a/webanno-io-tsv/src/main/resources/META-INF/asciidoc/user-guide/webannotsv.adoc
+++ b/webanno-io-tsv/src/main/resources/META-INF/asciidoc/user-guide/webannotsv.adoc
@@ -213,6 +213,14 @@ For every features of a span Annotation, annotation value will be presented in t
 Here, the first annotation at column 4, `JJ` is avalue for a feature *PosValue* of the layer *de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS*. For the two features of the layer *webanno.custom.Sentiment* (*Category* and *Opinion*), the values `abstract` and `negative` are
 presented at column 5 and 6 resp.
 
+NOTE: When serializing a span annotation starts or ends in a space between tokens, then the
+      annotation is truncated to start at the next token after the space or to end at the last token 
+      before the space. For example, if you consider the text `[one two]` and there is an some span annotation
+      on `[one ]` (note the trailing space), the extent of this span annotation will be serialized as only
+      covering `[one]`. It is not possible in this format to have annotations starting or ending in 
+      the space between tokens because the inter-token space is not rendered as a row and therefore is not
+      addressable in the format. 
+
 === Disambiguation IDs
 
 Within a single line, an annotation can be uniquely identified by its type and stacking index.

--- a/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3ReaderWriterRoundTripTest.java
+++ b/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3ReaderWriterRoundTripTest.java
@@ -72,6 +72,7 @@ public class WebAnnoTsv3ReaderWriterRoundTripTest
     private boolean isKnownToFail(String aMethodName)
     {
         Set<String> failingTests = new HashSet<>();
+        failingTests.add("testAnnotationWithLeadingWhitespaceAtStart");
         failingTests.add("testMultiTokenChain");
         failingTests.add("testSingleStackedNonTokenRelationWithoutFeatureValue2");
         failingTests.add("testSubtokenChain");

--- a/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTest.java
+++ b/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTest.java
@@ -44,6 +44,10 @@ public class WebAnnoTsv3WriterTest extends WebAnnoTsv3WriterTestBase
     protected boolean isKnownToFail(String aMethodName)
     {
         Set<String> failingTests = new HashSet<>();
+        failingTests.add("testAnnotationWithLeadingWhitespace"); 
+        failingTests.add("testAnnotationWithLeadingWhitespaceAtStart");
+        failingTests.add("testAnnotationWithTrailingWhitespace");
+        failingTests.add("testAnnotationWithTrailingWhitespaceAtEnd");
         failingTests.add("testSubtokenChain");
         failingTests.add("testStackedSubMultiTokenSpanWithFeatureValue");
         failingTests.add("testSubMultiTokenSpanWithFeatureValue");

--- a/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTestBase.java
+++ b/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTestBase.java
@@ -59,6 +59,7 @@ import de.tudarmstadt.ukp.clarin.webanno.xmi.XmiWriter;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Stem;
@@ -1665,7 +1666,91 @@ public abstract class WebAnnoTsv3WriterTestBase
         
         writeAndAssertEquals(jcas);
     }
+    
+    /*
+     * This is something that cannot be done through the editor UI but can happen when working with
+     * externally created data.
+     */
+    @Test
+    public void testAnnotationWithTrailingWhitespace() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        DocumentMetaData.create(jcas).setDocumentId("doc");
+        jcas.setDocumentText("one  two");
+        new Token(jcas, 0, 3).addToIndexes();
+        new Token(jcas, 5, 8).addToIndexes();
+        new Sentence(jcas, 0, 8).addToIndexes();
+        
+        // NE has trailing whitespace - on export this should be silently dropped
+        new NamedEntity(jcas, 0, 4).addToIndexes();
+        
+        writeAndAssertEquals(jcas);
+    }
 
+    /*
+     * This is something that cannot be done through the editor UI but can happen when working with
+     * externally created data.
+     */
+    @Test
+    public void testAnnotationWithTrailingWhitespaceAtEnd() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        DocumentMetaData.create(jcas).setDocumentId("doc");
+        jcas.setDocumentText("one two ");
+        new Token(jcas, 0, 3).addToIndexes();
+        new Token(jcas, 4, 7).addToIndexes();
+        new Sentence(jcas, 0, 7).addToIndexes();
+        
+        // NE has trailing whitespace - on export this should be silently dropped
+        new NamedEntity(jcas, 4, 8).addToIndexes();
+        
+        writeAndAssertEquals(jcas);
+    }    
+    
+    /*
+     * This is something that cannot be done through the editor UI but can happen when working with
+     * externally created data.
+     */
+    @Test
+    public void testAnnotationWithLeadingWhitespaceAtStart() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        DocumentMetaData.create(jcas).setDocumentId("doc");
+        jcas.setDocumentText(" one two");
+        new Token(jcas, 1, 4).addToIndexes();
+        new Token(jcas, 5, 8).addToIndexes();
+        new Sentence(jcas, 1, 8).addToIndexes();
+        
+        // NE has leading whitespace - on export this should be silently dropped
+        new NamedEntity(jcas, 0, 4).addToIndexes();
+        
+        writeAndAssertEquals(jcas);
+    }
+
+    /*
+     * This is something that cannot be done through the editor UI but can happen when working with
+     * externally created data.
+     */
+    @Test
+    public void testAnnotationWithLeadingWhitespace() throws Exception
+    {
+        JCas jcas = JCasFactory.createJCas();
+        
+        DocumentMetaData.create(jcas).setDocumentId("doc");
+        jcas.setDocumentText("one  two");
+        new Token(jcas, 0, 3).addToIndexes();
+        new Token(jcas, 5, 8).addToIndexes();
+        new Sentence(jcas, 0, 8).addToIndexes();
+        
+        // NE has leading whitespace - on export this should be silently dropped
+        new NamedEntity(jcas, 4, 8).addToIndexes();
+        
+        writeAndAssertEquals(jcas);
+    }
+    
     private void writeAndAssertEquals(JCas aJCas, Object... aParams)
         throws IOException, ResourceInitializationException, AnalysisEngineProcessException
     {

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithLeadingWhitespace/reference.tsv
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithLeadingWhitespace/reference.tsv
@@ -1,0 +1,7 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
+
+
+#Text=one  two
+1-1	0-3	one	_	
+1-2	5-8	two	*	

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithLeadingWhitespaceAtStart/reference.tsv
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithLeadingWhitespaceAtStart/reference.tsv
@@ -1,0 +1,7 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
+
+
+#Text=one two
+1-1	1-4	one	*	
+1-2	5-8	two	_	

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithTrailingWhitespace/reference.tsv
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithTrailingWhitespace/reference.tsv
@@ -1,0 +1,7 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
+
+
+#Text=one  two
+1-1	0-3	one	*	
+1-2	5-8	two	_	

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithTrailingWhitespaceAtEnd/reference.tsv
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testAnnotationWithTrailingWhitespaceAtEnd/reference.tsv
@@ -1,0 +1,7 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
+
+
+#Text=one two
+1-1	0-3	one	_	
+1-2	4-7	two	*	


### PR DESCRIPTION
**What's in the PR**
- Truncate parts of an annotation that exists in inter-token space
- Update documentation
- Add unit tests

**How to test manually**
* See issue description - cannot be reproduced through UI

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
