### PR TITLE
Feature/1330 backup parameters misinterpreted as milliseconds

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
@@ -96,7 +96,7 @@ public class CasStorageServiceImpl
         }
 
         if (backupProperties.getInterval() > 0) {
-            log.info("CAS backups enabled - interval: {}  max-backups: {}  max-age: {}",
+            log.info("CAS backups enabled - interval: {}sec  max-backups: {}  max-age: {}sec",
                     backupProperties.getInterval(), backupProperties.getKeep().getNumber(),
                     backupProperties.getKeep().getTime());
         }
@@ -278,7 +278,7 @@ public class CasStorageServiceImpl
             else {
                 // Check if the newest history file is significantly older than the current one
                 File latestHistory = history[history.length - 1];
-                if (latestHistory.lastModified() + backupProperties.getInterval() < now) {
+                if (latestHistory.lastModified() + (backupProperties.getInterval() * 1000) < now) {
                     FileUtils.copyFile(currentVersion, historyFile);
                     historyFileCreated = true;
                 }
@@ -321,7 +321,8 @@ public class CasStorageServiceImpl
                 // Prune history based on time
                 if (backupProperties.getKeep().getTime() > 0) {
                     for (File file : history) {
-                        if ((file.lastModified() + backupProperties.getKeep().getTime()) < now) {
+                        if ((file.lastModified()
+                                + (backupProperties.getKeep().getTime() * 1000)) < now) {
                             FileUtils.forceDelete(file);
 
                             try (MDC.MDCCloseable closable = MDC.putCloseable(


### PR DESCRIPTION
**What's in the PR**
* Treat values from settings file as seconds, meaning we need to multiply them before doing calculations

**How to test manually**
* Configure the backup settings for a short period of time, e.g. an interval of 5 seconds and a max age of 20 seconds
* Make a couple of changes and observer if the backup files are generated in a sensible interval and if the max age is respected

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
