### PR TITLE
#1361 - docker-compose instructions do not work

### DIFF
--- a/webanno-constraints/src/main/resources/META-INF/asciidoc/user-guide/constraints.adoc
+++ b/webanno-constraints/src/main/resources/META-INF/asciidoc/user-guide/constraints.adoc
@@ -121,7 +121,7 @@ pos.PosValue
 
 Hereby all annotations of type `<shortLayerName>` at the same position as the current context are found.
 
-== Comments
+=== Comments
 
 The constraint language supports block comments which start with `/*` and end with `*/`. These
 comments may span across multiple lines.
@@ -137,7 +137,7 @@ comments may span across multiple lines.
 ----
 
 
-== Conditional features
+=== Conditional features
 
 Constraints can be used to set up conditional features, that is features that only become available
 in the UI if another feature has a specific value. Let's say that for example you want to annotate
@@ -199,7 +199,7 @@ SemPred {
 }
 ----
 
-=== Constraints language grammar
+== Constraints language grammar
 
 .Constraints language grammar
 [source,text]

--- a/webanno-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
+++ b/webanno-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 [[sect_casdoctor]]
-== CAS Doctor
+= CAS Doctor
 
 The CAS Doctor is an essential development tool. When enabled, it checks the CAS for
 consistency when loading or saving a CAS. It can also automatically repair inconsistencies when
@@ -48,7 +48,7 @@ In such a case, CAS Doctor can be configured to be non-fatal. Mind that users ca
 to work on documents that are consistent. CAS Doctor only prevents loading inconsistent documents
 and saving inconsistent documents.
 
-=== Configuration
+== Configuration
 
 [cols="4*", options="header"]
 |===
@@ -79,10 +79,10 @@ and saving inconsistent documents.
 |===
 
 [[sect_checks]]
-=== Checks
+== Checks
 
 [[check_AllFeatureStructuresIndexedCheck]]
-==== All Feature Structures Indexed
+=== All feature structures indexed
 
 [horizontal]
 ID:: `AllFeatureStructuresIndexedCheck`
@@ -98,7 +98,7 @@ accessible through relations which had used the span as a source or target.
 This check is very extensive and slow. 
 
 [[check_FeatureAttachedSpanAnnotationsTrulyAttachedCheck]]
-==== Feature-Attached Span Annotations Truly Attached
+=== Feature-attached spans truly attached
 
 [horizontal]
 ID:: `FeatureAttachedSpanAnnotationsTrulyAttachedCheck`
@@ -110,7 +110,7 @@ a Token annotation via the Token feature `pos`. This check ensures that annotati
 as the POS layer are properly referenced from the attaching layer (e.g. the Token layer).
 
 [[check_LinksReachableThroughChainsCheck]]
-==== Links Reachable Through Chains
+=== Links reachable through chains
 
 [horizontal]
 ID:: `LinksReachableThroughChainsCheck`
@@ -121,7 +121,7 @@ points to the first link and each link points to the following link. If the CAS 
 that are not reachable through a chain, then this is likely due to a bug.
 
 [[check_NoMultipleIncomingRelationsCheck]]
-==== No Multiple Incoming Relations
+=== No multiple incoming relations
 
 [horizontal]
 ID:: `NoMultipleIncomingRelationsCheck`
@@ -131,7 +131,7 @@ Since dependency relations form a tree, every node of this tree can only have at
 This check outputs a message that includes the sentence number (useful to jump directly to the problem) and the actual offending dependency edges.
 
 [[check_NoZeroSizeTokensAndSentencesCheck]]
-==== No Zero-Size Tokens and Sentences
+=== No 0-sized tokens and sentences
 
 [horizontal]
 ID:: `NoZeroSizeTokensAndSentencesCheck`
@@ -140,7 +140,7 @@ Related repairs:: <<repair_RemoveZeroSizeTokensAndSentencesRepair>>
 Zero-sized tokens and sentences are not valid and can cause undefined behavior.
 
 [[check_RelationOffsetsCheck]]
-==== Relation Offsets Check
+=== Relation offsets consistency
 
 [horizontal]
 ID:: `RelationOffsetsCheck`
@@ -151,7 +151,7 @@ Core convention that the offsets of a dependency relation must match the offsets
 dependent.
 
 [[check_CASMetadataTypeIsPresentCheck]]
-==== CASMetadata Type Is PresentCheck
+=== CASMetadata presence
 [horizontal]
 ID:: `CASMetadataTypeIsPresentCheck`
 Related repairs:: <<repair_UpgradeCasRepair>>
@@ -161,10 +161,10 @@ not the case, then the application may not be able to detect concurrent modifica
 
 
 [[sect_repairs]]
-=== Repairs
+== Repairs
 
 [[repair_ReattachFeatureAttachedSpanAnnotationsRepair]]
-==== Re-attach Feature-Attached Span Annotations
+=== Re-attach feature-attached spans
 
 [horizontal]
 ID:: `ReattachFeatureAttachedSpanAnnotationsRepair`
@@ -179,7 +179,7 @@ This is a safe repair action as it does not delete anything.
 
 
 [[repair_ReattachFeatureAttachedSpanAnnotationsAndDeleteExtrasRepair]]
-==== Re-attach Feature-Attached Span Annotations And Delete Extras
+=== Re-attach feature-attached spans and delete extras
 
 [horizontal]
 ID:: `ReattachFeatureAttachedSpanAnnotationsAndDeleteExtrasRepair`
@@ -192,7 +192,7 @@ which one is deleted is undefined.
 
 
 [[repair_ReindexFeatureAttachedSpanAnnotationsRepair]]
-==== Re-index Feature-Attached Span Annotations
+=== Re-index feature-attached spans
 
 [horizontal]
 ID:: `ReindexFeatureAttachedSpanAnnotationsRepair`
@@ -203,7 +203,7 @@ indexed in the CAS. Such annotations are then added back to the CAS indexes.
 This is a safe repair action as it does not delete anything.
 
 [[repair_RelationOffsetsRepair]]
-==== Repair Relation Offsets
+=== Repair relation offsets
 
 [horizontal]
 ID:: `RelationOffsetsRepair`
@@ -213,7 +213,7 @@ Core convention that the offsets of a dependency relation must match the offsets
 dependent.
 
 [[repair_RemoveDanglingChainLinksRepair]]
-==== Remove Dangling Chain Links
+=== Remove dangling chain links
 
 [horizontal]
 ID:: `RemoveDanglingChainLinksRepair`
@@ -224,7 +224,7 @@ Although this is a destructive repair action, it is likely a safe action in most
 not able see chain links that are not part of a chain in the user interface anyway.
 
 [[repair_RemoveDanglingRelationsRepair]]
-==== Remove Dangling Relations
+=== Remove dangling relations
 
 [horizontal]
 ID:: `RemoveDanglingRelationsRepair`
@@ -236,7 +236,7 @@ deleting a span, normally any attached relations are also deleted (unless there 
 Dangling relations are not visible in the user interface.
 
 [[repair_RemoveZeroSizeTokensAndSentencesRepair]]
-==== Remove Zero-Size Tokens and Sentences
+=== Remove 0-size tokens and sentences
 
 [horizontal]
 ID:: `RemoveZeroSizeTokensAndSentencesRepair`
@@ -248,7 +248,7 @@ behind. Thus, the <<repair_RemoveDanglingRelationsRepair>> repair action should 
 *after* this repair action in the settings file.
 
 [[repair_UpgradeCasRepair]]
-==== Upgrade CAS
+=== Upgrade CAS
 
 [horizontal]
 ID:: `UpgradeCasRepair`

--- a/webanno-doc/pom.xml
+++ b/webanno-doc/pom.xml
@@ -25,4 +25,41 @@
   <artifactId>webanno-doc</artifactId>
   <packaging>jar</packaging>
   <name>WebAnno - Documentation</name>
+  <dependencies>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj</artifactId>
+      <version>1.5.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj-diagram</artifactId>
+      <version>1.5.12</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <usedDependencies>
+              <!--
+                - Maven doesn't detect that we tell asciidoctor to use the diagram module
+              -->
+              <usedDependency>org.asciidoctor:asciidoctorj-diagram</usedDependency>
+            </usedDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
@@ -90,8 +90,25 @@ By default, WebAnno uses an embedded SQL database to store its metadata (not the
 annotations, these are stored in files on disk). For production use, it is highly recommended to
 use a separate MySQL database instead of the embedded SQL database.
 
-You can do so by providing a second Docker for MySQL (see for example link:https://hub.docker.com/_/mysql/[this one]).
-We provide a docker-compose example file, which combines the two containers. In order to use this, download link:https://raw.githubusercontent.com/webanno/webanno/master/webanno-webapp/src/main/docker/docker-compose.yml[docker-compose.yml] and place it into any folder, change to that folder, and issue the commands 
+== Docker Compose
+
+Using Docker Compose, you can manage multiple related containers. This section illustrates how to use
+Docker Compose to jointly set up a {product-name} container as well as a database container (i.e. 
+link:https://hub.docker.com/_/mysql/[this one]).
+
+The following Compose script sets these containers up.
+
+NOTE: The script contains example usernames and passwords used by the {product-name} container to
+       connect to the database container, namely `DBUSER` and `DBPASSWORD`. It is highly recommended that you
+       change these!
+
+[source,text,subs="+attributes"]
+.Docker Compose script
+----
+include::scripts/docker-compose.yml[]
+----
+
+Place the script into any folder, change to that folder, and issue the commands 
 
 [source,text,subs="+attributes"]
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -1,0 +1,49 @@
+##
+# docker-compose up [-d]
+# docker-compose down
+##
+version: '2.1'
+
+networks:
+  webanno-net:
+
+services:
+  mysqlserver:
+    image: "mysql:5"
+    environment:
+      - MYSQL_RANDOM_ROOT_PASSWORD=yes
+      - MYSQL_DATABASE=webanno
+      - MYSQL_USER=DBUSER
+      - MYSQL_PORT=3306
+      - MYSQL_PASSWORD=DBPASSWORD
+    volumes:
+      - ${WEBANNO_HOME}/mysql-data:/var/lib/mysql
+    command: ["--character-set-server=utf8", "--collation-server=utf8_bin"]
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "-pDBPASSWORD", "-uDBUSER"]
+      interval: 20s
+      timeout: 10s
+      retries: 10
+    networks:
+      webanno-net:
+
+  webserver:
+    image: "webanno/webanno-snapshots:{revnumber}"
+    ports:
+      - "${WEBANNO_PORT}:8080"
+    environment:
+      - WEBANNO_DB_DIALECT=org.hibernate.dialect.MySQL5InnoDBDialect
+      - WEBANNO_DB_DRIVER=com.mysql.jdbc.Driver
+      - WEBANNO_DB_URL=jdbc:mysql://mysqlserver:3306/webanno?useSSL=false&useUnicode=true&characterEncoding=UTF-8
+      - WEBANNO_DB_USERNAME=DBUSER
+      - WEBANNO_DB_PASSWORD=DBPASSWORD
+    volumes:
+      - ${WEBANNO_HOME}/server-data:/export
+    depends_on:
+      mysqlserver:
+        condition: service_healthy
+    mem_limit: 1g
+    memswap_limit: 1g
+    restart: unless-stopped
+    networks:
+      webanno-net:

--- a/webanno-doc/src/test/java/de/tudarmstadt/ukp/clarin/webanno/doc/GenerateDocumentation.java
+++ b/webanno-doc/src/test/java/de/tudarmstadt/ukp/clarin/webanno/doc/GenerateDocumentation.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.doc;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.SafeMode;
+
+public class GenerateDocumentation
+{
+    private static Path asciiDocPath = Paths.get("src", "main", "resources", "META-INF", "asciidoc");
+
+    private static List<Path> getAsciiDocs(Path dir) throws Exception
+    {
+        return Files.list(dir)
+                .filter(Files::isDirectory)
+                .filter(p -> Files.exists(p.resolve("pom.xml")))
+                .map(p -> p.resolve(asciiDocPath))
+                .filter(Files::isDirectory)
+                .collect(Collectors.toList());
+    }
+
+    private static void buildDoc(String type, Path outputDir)
+    {
+        Attributes attributes = AttributesBuilder.attributes()
+                .attribute("source-dir", getWebannoDir() + "/")
+                .attribute("include-dir", outputDir.resolve("asciidoc").resolve(type)
+                        .toString() + "/")
+                .attribute("imagesdir", outputDir.resolve("asciidoc").resolve(type)
+                        .resolve("images").toString() + "/")
+                .attribute("doctype", "book")
+                .attribute("toclevels", "8")
+                .attribute("sectanchors", "true")
+                .attribute("docinfo1", "true")
+                .attribute("project-version", "DEVELOPER BUILD")
+                .attribute("revnumber", "DEVELOPER BUILD")
+                .attribute("product-name", "WebAnno")
+                .attribute("product-website-url", "https://webanno.github.io/webanno/")
+                .attribute("icons", "font")
+                .attribute("toc", "preamble")
+                .attribute("sourceHighlighter", "coderay")
+                .get();
+        OptionsBuilder options = OptionsBuilder.options()
+                .toDir(outputDir.toFile())
+                .safe(SafeMode.UNSAFE)
+                .attributes(attributes);
+        Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+        asciidoctor.requireLibrary("asciidoctor-diagram");
+        File f = new File(outputDir.resolve("asciidoc").resolve(type).toString() + ".adoc");
+        asciidoctor.convertFile(f , options);
+    }
+
+    public static void main(String... args) throws Exception
+    {
+        Path webannoDir = getWebannoDir();
+        Path outputDir = Paths.get(System.getProperty("user.dir")).resolve("target")
+                .resolve("doc-out");
+
+        List<Path> modules = new ArrayList<>();
+        modules.addAll(getAsciiDocs(webannoDir));
+
+        FileUtils.deleteQuietly(outputDir.toFile());
+        Files.createDirectory(outputDir);
+
+        for (Path module : modules) {
+            System.out.printf("Including module: %s\n", module);
+            
+            for (File f : FileUtils.listFiles(module.toFile(), TrueFileFilter.INSTANCE,
+                    TrueFileFilter.INSTANCE)) {
+                Path p = f.toPath();
+                Path targetPath = f.toPath().subpath(module.toAbsolutePath().getNameCount()
+                        , p.toAbsolutePath().getNameCount());
+                FileUtils.copyFile(f, outputDir.resolve("asciidoc").resolve(targetPath).toFile());
+            }
+        }
+
+        buildDoc("user-guide", outputDir);
+        buildDoc("developer-guide", outputDir);
+        buildDoc("admin-guide", outputDir);
+        
+        System.out.printf("Documentation written to: %s\n", outputDir);
+    }
+
+    private static Path getWebannoDir()
+    {
+        Path userDir = Paths.get(System.getProperty("user.dir"));
+        return runningFromIntelliJ() ? userDir : userDir.getParent();
+    }
+
+    private static boolean runningFromIntelliJ()
+    {
+        return System.getenv().containsKey("INTELLIJ");
+    }
+}

--- a/webanno-webapp/src/main/docker/README
+++ b/webanno-webapp/src/main/docker/README
@@ -8,11 +8,15 @@ For a release build:
   mvn -Pdocker clean install docker:build -Ddocker.image.name="webanno/webanno"
   mvn -Pdocker clean install docker:push
 
+Run the latest image using
 
-docker run -v /path/on/host/webanno/repository:/export -p port-on-host:8080 webanno/webanno:latest
+  docker run -v /path/on/host/webanno/repository:/export -p port-on-host:8080 webanno/webanno:latest
 
-export WEBANNO_HOME=/path/on/host/webanno
-export WEBANNO_PORT=port-on-host
-docker-compose up -d
+To run via docker-compose, use
 
-docker-compose down
+  export WEBANNO_HOME=/path/on/host/webanno
+  export WEBANNO_PORT=port-on-host
+  docker-compose up -d
+  docker-compose down
+  
+The docker-compose script can be found in the admin documentation.

--- a/webanno-webapp/src/main/docker/docker-compose.yml
+++ b/webanno-webapp/src/main/docker/docker-compose.yml
@@ -1,49 +1,5 @@
 ##
-# docker-compose up [-d]
-# docker-compose down
+# The WebAnno Docker Compose script is now part of the Admin Guide document. 
+# 
+# Please refer to the documentation of the latest WebAnno release.
 ##
-version: '2.1'
-
-networks:
-  webanno-net:
-
-services:
-  mysqlserver:
-    image: "mysql:5"
-    environment:
-      - MYSQL_RANDOM_ROOT_PASSWORD=yes
-      - MYSQL_DATABASE=webanno
-      - MYSQL_USER=webanno
-      - MYSQL_PORT=3306
-      - MYSQL_PASSWORD=webanno
-    volumes:
-      - ${WEBANNO_HOME}/mysql-data:/var/lib/mysql
-    command: ["--character-set-server=utf8", "--collation-server=utf8_bin"]
-    healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "-pwebanno", "-uwebanno"]
-      interval: 20s
-      timeout: 10s
-      retries: 10
-    networks:
-      webanno-net:
-
-  webserver:
-    image: "webanno/webanno-snapshots:latest"
-    ports:
-      - "${WEBANNO_PORT}:8080"
-    environment:
-      - WEBANNO_DB_DIALECT=org.hibernate.dialect.MySQL5InnoDBDialect
-      - WEBANNO_DB_DRIVER=com.mysql.jdbc.Driver
-      - WEBANNO_DB_URL=jdbc:mysql://mysqlserver:3306/webanno?useSSL=false&useUnicode=true&characterEncoding=UTF-8
-      - WEBANNO_DB_USERNAME=webanno
-      - WEBANNO_DB_PASSWORD=webanno
-    volumes:
-      - ${WEBANNO_HOME}/server-data:/export
-    depends_on:
-      mysqlserver:
-        condition: service_healthy
-    mem_limit: 1g
-    memswap_limit: 1g
-    restart: unless-stopped
-    networks:
-      webanno-net:


### PR DESCRIPTION
**What's in the PR**
- Embed the Docker Compose script directly into the Admin Guide to allow replacing the version string and not having to use `latest`
- Fix heading level of documentation sections on constraints and CAS doctor
- Added small program to build documentation without having to do a Maven build (backported from INCEpTION)
