### PR TITLE
#1338 - Relation feature is not saved when pressing enter

### DIFF
--- a/webanno-api-annotation/pom.xml
+++ b/webanno-api-annotation/pom.xml
@@ -120,6 +120,10 @@
       <artifactId>wicket-kendo-ui</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-extensions</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicketstuff-select2</artifactId>
     </dependency>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.java
@@ -19,11 +19,14 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.checkbox.bootstrapcheckbox.BootstrapCheckBoxPicker;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.checkbox.bootstrapcheckbox.BootstrapCheckBoxPickerConfig;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 
 public class BooleanFeatureEditor
@@ -38,7 +41,20 @@ public class BooleanFeatureEditor
 
         add(new Label("feature", getModelObject().feature.getUiName()));
 
-        field = new CheckBox("value");
+        BootstrapCheckBoxPickerConfig config = new BootstrapCheckBoxPickerConfig();
+        config.withReverse(true);
+        field = new BootstrapCheckBoxPicker("value", config) {
+            private static final long serialVersionUID = -3413189824637877732L;
+
+            @Override
+            protected void onComponentTag(ComponentTag aTag)
+            {
+                super.onComponentTag(aTag);
+                
+                aTag.put("data-group-cls", "btn-group-justified");
+            }
+        };
+        
         add(field);
     }
 

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
 import org.apache.wicket.model.IModel;
 
@@ -39,6 +40,8 @@ public class InputFieldTextFeatureEditor
     @Override
     protected AbstractTextComponent createInputField()
     {
-        return new TextField<String>("value");
+        TextField<String> textfield = new TextField<>("value");
+        textfield.add(new AjaxPreventSubmitBehavior());
+        return textfield;
     }
 }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -137,6 +137,9 @@
                 <div id="featureValues" wicket:id="featureValues">
                   <div wicket:id="editor"></div>
                 </div>
+                <div style="width: 1px; height: 1px; overflow: hidden; opacity: 0; margin-top: -1px;">
+                  <input wicket:id="focusResetHelper" tabindex="-1"></input>
+                </div>
               </div>
             </div>
           </div>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -269,7 +269,7 @@ public abstract class AnnotationDetailEditorPanel
      * 
      * @see #getTagForKeySequence(String, Map)
      */
-    Map<String, String> buildKeySequenceToTagMap()
+    private Map<String, String> buildKeySequenceToTagMap()
     {
         AnnotationFeature f = annotationService
                 .listAnnotationFeature(getModelObject().getDefaultAnnotationLayer()).get(0);

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -40,6 +40,7 @@ import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.JCas;
 import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
@@ -67,6 +68,8 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.googlecode.wicket.kendo.ui.form.TextField;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
@@ -139,6 +142,7 @@ public class AnnotationFeatureForm
         add(layerSelector = createDefaultAnnotationLayerSelector());
         add(featureEditorPanel = createFeatureEditorPanel());
         add(createSelectedAnnotationTypeLabel());
+        setDefaultButton(null);
     }
 
     private WebMarkupContainer createFeatureEditorPanel()
@@ -152,10 +156,40 @@ public class AnnotationFeatureForm
 
         container.add(createNoFeaturesWarningLabel());
         container.add(featureEditorPanelContent = createFeatureEditorPanelContent());
+        container.add(createFocusResetHelper());
         container.add(createSelectedTextLabel());
         container.add(selectedAnnotationLayer = createSelectedAnnotationLayerLabel());
 
         return container;
+    }
+
+    private TextField<String> createFocusResetHelper()
+    {
+        TextField<String> textfield = new TextField<>("focusResetHelper");
+        textfield.setModel(Model.of());
+        textfield.setOutputMarkupId(true);
+        textfield.add(new AjaxPreventSubmitBehavior());
+        textfield.add(new AjaxFormComponentUpdatingBehavior("focus")
+        {
+            private static final long serialVersionUID = -3030093250599939537L;
+
+            @Override
+            protected void onUpdate(AjaxRequestTarget aTarget)
+            {
+                List<FeatureEditor> editors = new ArrayList<>();
+                featureEditorPanelContent.getItems().next()
+                        .visitChildren(FeatureEditor.class, (e, visit) -> {
+                            editors.add((FeatureEditor) e);
+                            visit.dontGoDeeper();
+                        });
+                
+                if (!editors.isEmpty()) {
+                    aTarget.focusComponent(editors.get(editors.size() - 1).getFocusComponent());
+                }
+            }
+        });
+        
+        return textfield;
     }
 
     private Label createNoFeaturesWarningLabel()
@@ -743,6 +777,12 @@ public class AnnotationFeatureForm
             editor.setOutputMarkupId(true);
             editor.setOutputMarkupPlaceholderTag(true);
             
+            // Ensure that markup IDs of feature editor focus components remain constant across
+            // refreshes of the feature editor panel. This is required to restore the focus.
+            editor.getFocusComponent().setOutputMarkupId(true);
+            editor.getFocusComponent()
+                    .setMarkupId(ID_PREFIX + editor.getModelObject().feature.getId());
+            
             if (!featureState.feature.getLayer().isReadonly()) {
                 AnnotatorState state = getModelObject();
 
@@ -777,12 +817,6 @@ public class AnnotationFeatureForm
             else {
                 editor.getFocusComponent().setEnabled(false);
             }
-
-            // Ensure that markup IDs of feature editor focus components remain constant across
-            // refreshes of the feature editor panel. This is required to restore the focus.
-            editor.getFocusComponent().setOutputMarkupId(true);
-            editor.getFocusComponent()
-                    .setMarkupId(ID_PREFIX + editor.getModelObject().feature.getId());
             
             item.add(editor);
         }
@@ -865,6 +899,40 @@ public class AnnotationFeatureForm
                             editorPanel.actionCreateForward(aTarget, jCas);
                         } else {
                             editorPanel.actionCreateOrUpdate(aTarget, jCas);
+                        }
+                        
+                        // If the focus was lost during the update, then try force-focusing the
+                        // next editor or the first one if we are on the last one.
+                        if (aTarget.getLastFocusedElementId() == null) {
+                            List<FeatureEditor> allEditors = new ArrayList<>();
+                            featureEditorPanelContent.visitChildren(FeatureEditor.class,
+                                (editor, visit) -> {
+                                    allEditors.add((FeatureEditor) editor);
+                                    visit.dontGoDeeper();
+                                });
+
+                            if (!allEditors.isEmpty()) {
+                                FeatureEditor currentEditor = getComponent()
+                                        .findParent(FeatureEditor.class);
+                                
+                                int i = allEditors.indexOf(currentEditor);
+                                
+                                // If the current editor cannot be found then move the focus to the
+                                // first editor
+                                if (i == -1) {
+                                    aTarget.focusComponent(allEditors.get(0).getFocusComponent());
+                                }
+                                // ... if it is the last one, say at the last one
+                                else if (i >= (allEditors.size() - 1)) {
+                                    aTarget.focusComponent(allEditors.get(allEditors.size() - 1)
+                                            .getFocusComponent());
+                                }
+                                // ... otherwise move the focus to the next editor
+                                else {
+                                    aTarget.focusComponent(
+                                            allEditors.get(i + 1).getFocusComponent());
+                                }
+                            }
                         }
                     }
                     catch (Exception e) {


### PR DESCRIPTION
**What's in the PR**
- Added a hidden field at the after the last feature editor which directs the focus back to the last feature editor
- This extra field also fixes the bug... but for good measure, we also prevent plain text feature editors from submitting the form
- Use bootstrap "checkbox" instead of a regular one
- Try to smartly restore the focus if it gets lost when some feature is edited

**How to test manually**
* See issue description
* In general, edit some annotations, in particular some with multiple features and using tab or enter to commit feature values

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
