### PR TITLE
#1411 - Delete button for LinkFeatureEditor missing

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -337,7 +337,7 @@ public class LinkFeatureEditor
 
                 AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
                 setVisible(state.isSlotArmed() && LinkFeatureEditor.this.getModelObject().feature
-                        .equals(state.getArmedFeature()));
+                        .equals(state.getArmedFeature().feature));
             }
         });
     }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -246,7 +246,9 @@ public class LinkFeatureEditor
             // If a slot is armed, then load the slot's role into the dropdown
             FeatureState featureState = LinkFeatureEditor.this.getModelObject();
             AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
-            if (state.isSlotArmed() && featureState.feature.equals(state.getArmedFeature())) {
+            if (state.isSlotArmed()
+                    && featureState.feature.equals(state.getArmedFeature().feature))
+            {
                 List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) featureState.value;
                 field.setModelObject(links.get(state.getArmedSlot()).role);
             }
@@ -304,7 +306,7 @@ public class LinkFeatureEditor
 
                 AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
                 setVisible(!(state.isSlotArmed() && LinkFeatureEditor.this.getModelObject().feature
-                        .equals(state.getArmedFeature())));
+                        .equals(state.getArmedFeature().feature)));
             }
         });
 
@@ -321,7 +323,7 @@ public class LinkFeatureEditor
 
                 AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
                 setVisible(state.isSlotArmed() && LinkFeatureEditor.this.getModelObject().feature
-                        .equals(state.getArmedFeature()));
+                        .equals(state.getArmedFeature().feature));
             }
         });
 


### PR DESCRIPTION
**What's in the PR**
- fix visibility setting for delete button in LinkFeatureEditor

**How to test manually**
1. Open a document that has a layer with a link feature
2. Select an annotation that has a link
3. Select the filled slot
4. Delete button is there
5. Click it to test functionality

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
