### PR TITLE
#1414 - Performance improvements for curation mode

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
@@ -33,6 +33,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -124,7 +126,8 @@ public class WebAnnoCasUtil
      */
     public static boolean isBeginEndInSameSentence(CAS aCas, int aBegin, int aEnd)
     {
-        return selectCovering(aCas, getType(aCas, Sentence.class), aBegin, aBegin).stream()
+        return StreamSupport.stream(aCas.getAnnotationIndex(
+                    getType(aCas, Sentence.class)).spliterator(), false)
                 .filter(s -> s.getBegin() <= aBegin && aBegin < s.getEnd())
                 .filter(s -> s.getBegin() <= aEnd && aEnd <= s.getEnd())
                 .findFirst()
@@ -157,12 +160,9 @@ public class WebAnnoCasUtil
 
     public static List<AnnotationFS> selectAt(CAS aCas, final Type type, int aBegin, int aEnd)
     {
-        List<AnnotationFS> covered = CasUtil.selectCovered(aCas, type, aBegin, aEnd);
-
-        // Remove all that do not have the exact same offset
-        covered.removeIf(cur -> !(cur.getBegin() == aBegin && cur.getEnd() == aEnd));
-
-        return covered;
+        return StreamSupport.stream(aCas.getAnnotationIndex(type).spliterator(), false)
+            .filter(cur -> cur.getBegin() == aBegin && cur.getEnd() == aEnd)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -181,6 +181,11 @@ public class WebAnnoCasUtil
      */
     public static AnnotationFS selectSingleFsAt(CAS aCas, Type aType, int aBegin, int aEnd)
     {
+//        return StreamSupport.stream(aCas.getAnnotationIndex(aType).spliterator(), false)
+//            .filter(cur -> cur.getBegin() == aBegin && cur.getEnd() == aEnd)
+//            .findFirst()
+//            .orElse(null);
+        
         for (AnnotationFS anFS : selectCovered(aCas, aType, aBegin, aEnd)) {
             if (anFS.getBegin() == aBegin && anFS.getEnd() == aEnd) {
                 return anFS;

--- a/webanno-curation/pom.xml
+++ b/webanno-curation/pom.xml
@@ -126,6 +126,11 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- JUNIT DEPENDENCY FOR TESTING -->
     <dependency>
       <groupId>junit</groupId>

--- a/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -1018,12 +1018,9 @@ public class CasDiff
          */
         public boolean isAgreement(ConfigurationSet aConfigurationSet)
         {
-            if (!data.containsValue(aConfigurationSet)) {
-                throw new IllegalArgumentException("Configuration set does not belong to this diff");
-            }
-
             if (data.get(aConfigurationSet.position) != aConfigurationSet) {
-                throw new IllegalArgumentException("Configuration set position mismatch");
+                throw new IllegalArgumentException(
+                        "Configuration set does not belong to this diff or positions mismatch");
             }
             
             // If there is only a single configuration in the set, we call it an agreement
@@ -1054,12 +1051,9 @@ public class CasDiff
          */
         public boolean isComplete(ConfigurationSet aConfigurationSet)
         {
-            if (!data.containsValue(aConfigurationSet)) {
-                throw new IllegalArgumentException("Configuration set does not belong to this diff");
-            }
-
             if (data.get(aConfigurationSet.position) != aConfigurationSet) {
-                throw new IllegalArgumentException("Configuration set position mismatch");
+                throw new IllegalArgumentException(
+                        "Configuration set does not belong to this diff or positions mismatch");
             }
 
             Boolean complete = completenessCache.get(aConfigurationSet);


### PR DESCRIPTION
**What's in the PR**
- Avoid using Map.containsValue(...) in isAgreement(...) and isComplete(...) - it is currently only being used for a redundant sanity check of the parameter and it is very slow.
- Avoid generating an event for every single merged annotation. Instead generate a bulk-update event.
- Cache type adapters in CasMerge since creating a new one involves looking up the feature list in the DB which becomes rather slow when the type adapter is repeatedly looked up.
- Avoid using CasUtil. selectCovering and instead use streaming operations on the annotation index for a bit of speedup in operations like selectAt.

**How to test manually**
* Try using curation mode with a large documents with many annotators and many annotations

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
