### PR TITLE
#1413 - Telemetry sent one last time when it is disabled

### DIFF
--- a/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
+++ b/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
@@ -167,6 +167,6 @@ public class TelemetryServiceImpl
             writeSettings(settings);
         }
         
-        eventPublisher.publishEvent(new TelemetrySettingsSavedEvent(this));
+        eventPublisher.publishEvent(new TelemetrySettingsSavedEvent(this, aSettings));
     }
 }

--- a/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/event/TelemetrySettingsSavedEvent.java
+++ b/webanno-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/event/TelemetrySettingsSavedEvent.java
@@ -17,7 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.telemetry.event;
 
+import java.util.List;
+
 import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.model.TelemetrySettings;
 
 /**
  * Sent when the telemetry settings are saved by the user. This event does not indicate whether
@@ -28,8 +32,16 @@ public class TelemetrySettingsSavedEvent
 {
     private static final long serialVersionUID = 3421993849783695318L;
 
-    public TelemetrySettingsSavedEvent(Object aSource)
+    private final List<TelemetrySettings> settings;
+    
+    public TelemetrySettingsSavedEvent(Object aSource, List<TelemetrySettings> aSettings)
     {
         super(aSource);
+        settings = aSettings;
+    }
+    
+    public List<TelemetrySettings> getSettings()
+    {
+        return settings;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Send the telemetry settings along with the TelemetrySettingsChanged event and check the latest settings before triggering the transmission

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
