### PR TITLE
#1417 - Feature editors missing form-control CSS class

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.html
@@ -21,7 +21,7 @@
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label"><span wicket:id="feature"/></label>
     <div class="col-sm-9">
-      <input wicket:id="value" type="checkbox"/>
+      <input wicket:id="value" class="form-control" type="checkbox"/>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.html
@@ -23,7 +23,7 @@
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
-      <input wicket:id="value" style="width: 100%;"></input>
+      <input wicket:id="value" class="form-control" style="width: 100%;"></input>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.html
@@ -23,7 +23,7 @@
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
-      <input wicket:id="value"/>
+      <input wicket:id="value" class="form-control"/>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.html
@@ -23,7 +23,7 @@
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
-      <input wicket:id="value" style="width: 100%;"></input>
+      <input wicket:id="value" class="form-control" style="width: 100%;"></input>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.html
@@ -23,7 +23,7 @@
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
-      <input wicket:id="value" style="width: 100%;"></input>
+      <input wicket:id="value" class="form-control" style="width: 100%;"></input>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.html
@@ -21,7 +21,7 @@
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label"><span wicket:id="feature"/></label>
     <div class="col-sm-9">
-      <input wicket:id="value" type="number"/>
+      <input wicket:id="value" class="form-control" type="number"/>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureEditor.java
@@ -44,7 +44,6 @@ public class NumberFeatureEditor<T extends Number>
         }
         case CAS.TYPE_NAME_FLOAT: {
             field = new NumberTextField<>("value", Float.class);
-            add(field);
             break;
         }
         default:


### PR DESCRIPTION
**What's in the PR**
- add form-control css class to feature editor inputs
- remove duplicate call of add() method in NumberFeatureEditor

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
