### PR TITLE
#1427 - Sentences list jumps back to top again

### DIFF
--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.html
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.html
@@ -91,7 +91,12 @@
   <wicket:panel>
     <div class="annotation-editor-container flex-content flex-h-container flex-gutter">
 
-      <div class="flex-sidebar flex-v-container flex-gutter" wicket:enclosure="sentencesListView">
+      <!-- 
+         We cannot put a 'wicket:enclosure="sentencesListView"' on this div because this 
+         inevitably causes the sentence list to "jump up" when re-rendering it (i.e. when paging
+         or when selecting a sentence).
+       -->
+      <div wicket:id="sentenceListContainer" class="flex-sidebar flex-v-container flex-gutter">
         <div class="flex-content panel panel-default panel-flex">
           <div class="panel-heading">
             <h3 class="panel-title">Sentences</h3>

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/CurationPanel.java
@@ -90,6 +90,7 @@ public class CurationPanel
 
     private SuggestionViewPanel suggestionViewPanel;
 
+    private final WebMarkupContainer sentenceListContainer;
     private final WebMarkupContainer sentencesListView;
     private final WebMarkupContainer crossSentAnnoView;
 
@@ -263,12 +264,16 @@ public class CurationPanel
     
         };
         crossSentAnnoView.add(crossSentAnnoList);
-    
+
+        // add container for sentences panel
+        sentenceListContainer = new WebMarkupContainer("sentenceListContainer");
+        sentenceListContainer.setOutputMarkupPlaceholderTag(true);
+        sentenceListContainer.add(LambdaBehavior.visibleWhen(() -> state.getDocument() != null));
+        add(sentenceListContainer);
+
         // add container for list of sentences panel
         sentencesListView = new WebMarkupContainer("sentencesListView");
         sentencesListView.setOutputMarkupPlaceholderTag(true);
-        sentencesListView.add(LambdaBehavior.visibleWhen(() -> state.getDocument() != null));
-        add(sentencesListView);
         sentencesListView.add(new ListView<SourceListView>("sentencesList",
                 LoadableDetachableModel.of(() -> getModelObject().getCurationViews()))
         {
@@ -280,6 +285,8 @@ public class CurationPanel
                 item.add(new SentenceLink("sentenceNumber", item.getModel()));
             }
         });
+        
+        sentenceListContainer.add(sentencesListView);
     }
     
     private List<String> invisibleCrossSentenceAnnotations()


### PR DESCRIPTION
**What's in the PR**
- Remove enclosure and add container instead
- Add a comment to the HTML to avoid another regression

**How to test manually**
* Open document with many sentences
* Scroll down
* Select a sentence
* Observe that sentence list does **not** jump back to top

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
