### PR TITLE
#1455 - Larger string input features for annotations

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature;
 
 import static java.util.Arrays.asList;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,6 +30,8 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -42,17 +45,21 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.InputFiel
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.KendoAutoCompleteTextFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.KendoComboboxTextFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.NumberFeatureEditor;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.UimaStringTraits;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.UimaStringTraitsEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 
 @Component
 public class PrimitiveUimaFeatureSupport
     implements FeatureSupport<Void>, InitializingBean
 {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    
     private final PrimitiveUimaFeatureSupportProperties properties;
     
     private final AnnotationSchemaService schemaService;
@@ -178,7 +185,7 @@ public class PrimitiveUimaFeatureSupport
                 editor = FeatureSupport.super.createTraitsEditor(aId, aFeatureModel);
                 break;
             case CAS.TYPE_NAME_STRING:
-                editor = new UimaStringTraitsEditor(aId, aFeatureModel);
+                editor = new UimaStringTraitsEditor(aId, this, aFeatureModel);
                 break;
             default:
                 throw unsupportedFeatureTypeException(feature);
@@ -273,6 +280,33 @@ public class PrimitiveUimaFeatureSupport
         }
         else {
             return FeatureSupport.super.renderFeatureValue(aFeature, aLabel);
+        }
+    }
+    
+    public UimaStringTraits readUimaStringTraits(AnnotationFeature aFeature)
+    {
+        UimaStringTraits traits = null;
+        try {
+            traits = JSONUtil.fromJsonString(UimaStringTraits.class, aFeature.getTraits());
+        }
+        catch (IOException e) {
+            log.error("Unable to read traits", e);
+        }
+        
+        if (traits == null) {
+            traits = new UimaStringTraits();
+        }
+        
+        return traits;
+    }
+    
+    public void writeUimaStringTraits(AnnotationFeature aFeature, UimaStringTraits aTraits)
+    {
+        try {
+            aFeature.setTraits(JSONUtil.toJsonString(aTraits));
+        }
+        catch (IOException e) {
+            log.error("Unable to write traits", e);
         }
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/PrimitiveUimaFeatureSupport.java
@@ -45,6 +45,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.InputFiel
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.KendoAutoCompleteTextFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.KendoComboboxTextFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.NumberFeatureEditor;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.TextAreaFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.UimaStringTraits;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.UimaStringTraitsEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -223,9 +224,15 @@ public class PrimitiveUimaFeatureSupport
                 break;
             }
             case CAS.TYPE_NAME_STRING: {
+                UimaStringTraits traits = readUimaStringTraits(feature);
                 if (feature.getTagset() == null) {
-                    // If there is no tagset, use a simple input field
-                    editor = new InputFieldTextFeatureEditor(aId, aOwner, aFeatureStateModel);
+                    if (traits.isMultipleRows()) {
+                        // If multiple rows are set use a textarea
+                        editor = new TextAreaFeatureEditor(aId, aOwner, aFeatureStateModel);
+                    } else {
+                        // Otherwise use a simple input field
+                        editor = new InputFieldTextFeatureEditor(aId, aOwner, aFeatureStateModel);
+                    }
                 }
                 else if (aFeatureStateModel.getObject().tagset.size() < properties
                         .getAutoCompleteThreshold()) {

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.html
@@ -23,7 +23,7 @@
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>
     <div class="col-sm-9">
-      <textarea wicket:id="value" class="form-control"></textarea>
+      <textarea wicket:id="value" class="form-control" style="resize: vertical;"></textarea>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+#Copyright 2019
+#Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+#Technische Universität Darmstadt
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <div class="form-group" wicket:enclosure="value">
+    <label wicket:for="value" class="col-sm-3 control-label">
+      <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
+    </label>
+    <div class="col-sm-9">
+      <textarea wicket:id="value" class="form-control"></textarea>
+    </div>
+  </div>
+</wicket:panel>
+</html>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
+
+import java.io.IOException;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
+import org.apache.wicket.behavior.AttributeAppender;
+import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.model.IModel;
+
+import com.googlecode.wicket.kendo.ui.form.TextArea;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+
+public class TextAreaFeatureEditor
+    extends TextFeatureEditorBase
+{
+    private static final long serialVersionUID = 8686646370500180943L;
+
+    public TextAreaFeatureEditor(String aId, MarkupContainer aItem,
+            IModel<FeatureState> aModel)
+    {
+        super(aId, aItem, aModel);
+    }
+
+    @Override
+    protected AbstractTextComponent createInputField()
+    {
+        TextArea<String> textarea = new TextArea<>("value");
+        textarea.add(new AjaxPreventSubmitBehavior());
+        try {
+            String traitsString = getModelObject().feature.getTraits();
+            UimaStringTraits traits = 
+                    JSONUtil.fromJsonString(UimaStringTraits.class, traitsString);
+            textarea.add(new AttributeModifier("rows", traits.getCollapsedRows()));
+            textarea.add(new AttributeAppender("onfocus",
+                    "this.rows=" + traits.getExpandedRows() + ";"));
+            textarea.add(new AttributeAppender("onblur",
+                    "this.rows=" + traits.getCollapsedRows() + ";"));
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+        return textarea;
+    }
+}

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
@@ -24,9 +24,8 @@ import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.model.IModel;
-
-import com.googlecode.wicket.kendo.ui.form.TextArea;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraits.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraits.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
+
+import java.io.Serializable;
+
+/**
+ * Traits for input field text features.
+ */
+public class UimaStringTraits
+        implements Serializable
+{
+    private static final long serialVersionUID = -8450181605003189055L;
+    
+    private boolean multipleRows = false;
+    private int collapsedRows = 1;
+    private int expandedRows = 1;
+    
+    public UimaStringTraits()
+    {
+        // Nothing to do
+    }
+    
+    public boolean isMultipleRows()
+    {
+        return multipleRows;
+    }
+    
+    public void setMultipleRows(boolean multipleRows)
+    {
+        this.multipleRows = multipleRows;
+    }
+    
+    public int getCollapsedRows()
+    {
+        return collapsedRows;
+    }
+    
+    public void setCollapsedRows(int collapsedRows)
+    {
+        this.collapsedRows = collapsedRows;
+    }
+    
+    public int getExpandedRows()
+    {
+        return expandedRows;
+    }
+    
+    public void setExpandedRows(int expandedRows)
+    {
+        this.expandedRows = expandedRows;
+    }
+}

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.html
@@ -18,6 +18,34 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
+  <div class="form-group" wicket:enclosure="multipleRows">
+    <div class="col-sm-8 col-sm-offset-4">
+      <div class="checkbox">
+        <label wicket:for="multipleRows">
+          <input wicket:id="multipleRows" type="checkbox">
+          Multiple Rows
+        </label>
+      </div>
+    </div>
+  </div>
+  <form wicket:id="form">
+    <div class="form-group">
+      <label wicket:for="collapsedRows" class="col-sm-4 control-label">
+        Collapsed Rows
+      </label>
+      <div class="col-sm-8">
+        <input type="number"  wicket:id="collapsedRows" data-container="body"></input>
+      </div>
+    </div>
+    <div class="form-group">
+      <label wicket:for="expandedRows" class="col-sm-4 control-label">
+        Expanded Rows
+      </label>
+      <div class="col-sm-8">
+        <input type="number"  wicket:id="expandedRows" data-container="body"></input>
+      </div>
+    </div>
+  </form>
   <div class="form-group">
     <label wicket:for="tagset" class="col-sm-4 control-label">
       <wicket:label key="tagset"/>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.html
@@ -18,18 +18,18 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="form-group" wicket:enclosure="multipleRows">
-    <div class="col-sm-8 col-sm-offset-4">
-      <div class="checkbox">
-        <label wicket:for="multipleRows">
-          <input wicket:id="multipleRows" type="checkbox">
-          Multiple Rows
-        </label>
-      </div>
-    </div>
-  </div>
   <form wicket:id="form">
     <div class="form-group">
+      <div class="col-sm-8 col-sm-offset-4">
+        <div class="checkbox">
+          <label wicket:for="multipleRows">
+            <input wicket:id="multipleRows" type="checkbox">
+            Multiple Rows
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="form-group" wicket:enclosure="collapsedRows">
       <label wicket:for="collapsedRows" class="col-sm-4 control-label">
         Collapsed Rows
       </label>
@@ -37,7 +37,7 @@
         <input type="number"  wicket:id="collapsedRows" data-container="body"></input>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group" wicket:enclosure="expandedRows">
       <label wicket:for="expandedRows" class="col-sm-4 control-label">
         Expanded Rows
       </label>
@@ -45,14 +45,14 @@
         <input type="number"  wicket:id="expandedRows" data-container="body"></input>
       </div>
     </div>
-  </form>
-  <div class="form-group">
-    <label wicket:for="tagset" class="col-sm-4 control-label">
-      <wicket:label key="tagset"/>
-    </label>
-    <div class="col-sm-8">
-      <select wicket:id="tagset" class="form-control" data-container="body"></select>
+    <div class="form-group" wicket:enclosure="tagset">
+      <label wicket:for="tagset" class="col-sm-4 control-label">
+        <wicket:label key="tagset"/>
+      </label>
+      <div class="col-sm-8">
+        <select wicket:id="tagset" class="form-control" data-container="body"></select>
+      </div>
     </div>
-  </div>
+  </form>
 </wicket:panel>
 </html>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
@@ -17,31 +17,92 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+
+import java.io.Serializable;
+
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import com.googlecode.wicket.kendo.ui.form.NumberTextField;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.PrimitiveUimaFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 
 public class UimaStringTraitsEditor
     extends Panel
 {
-    private static final long serialVersionUID = 2129000875921279514L;
+    private static final long serialVersionUID = -9082045435380184514L;
+    
+    private static final String MID_FORM = "form";
 
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean FeatureSupportRegistry featureSupportRegistry;
     
-    public UimaStringTraitsEditor(String aId, IModel<AnnotationFeature> aFeature)
+    private String featureSupportId;
+    private IModel<AnnotationFeature> feature;
+    private IModel<Traits> traits;
+    
+    public UimaStringTraitsEditor(String aId, PrimitiveUimaFeatureSupport aFS, 
+            IModel<AnnotationFeature> aFeature)
     {
-        super(aId);
+        super(aId, aFeature);
+    
+        // We cannot retain a reference to the actual SlotFeatureSupport instance because that
+        // is not serializable, but we can retain its ID and look it up again from the registry
+        // when required.
+        featureSupportId = aFS.getId();
+        feature = aFeature;
+    
+        traits = Model.of(readTraits());
+    
+        Form<Traits> form = new Form<Traits>(MID_FORM, CompoundPropertyModel.of(traits))
+        {
+            private static final long serialVersionUID = -3109239605783291123L;
+        
+            @Override
+            protected void onSubmit()
+            {
+                super.onSubmit();
+                writeTraits();
+            }
+        };
+        form.setOutputMarkupPlaceholderTag(true);
+        form.add(visibleWhen(() -> traits.getObject().isMultipleRows()
+                && feature.getObject().getTagset() == null));
+        add(form);
+    
+        NumberTextField collapsedRows = new NumberTextField<>("collapsedRows", Integer.class);
+        collapsedRows.setModel(PropertyModel.of(traits, "collapsedRows"));
+        collapsedRows.setMinimum(1);
+        form.add(collapsedRows);
+        
+        NumberTextField expandedRows = new NumberTextField<>("expandedRows", Integer.class);
+        expandedRows.setModel(PropertyModel.of(traits, "expandedRows"));
+        expandedRows.setMinimum(1);
+        form.add(expandedRows);
+    
+        CheckBox multipleRows = new CheckBox("multipleRows");
+        multipleRows.setModel(PropertyModel.of(traits, "multipleRows"));
+        multipleRows.add(enabledWhen(() -> feature.getObject().getTagset() == null));
+        multipleRows.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
+                target -> target.add(form)));
+        add(multipleRows);
         
         DropDownChoice<TagSet> tagset = new BootstrapSelect<>("tagset");
         tagset.setOutputMarkupPlaceholderTag(true);
@@ -51,6 +112,92 @@ public class UimaStringTraitsEditor
         tagset.setModel(PropertyModel.of(aFeature, "tagset"));
         tagset.setChoices(LoadableDetachableModel.of(() -> annotationService
                 .listTagSets(aFeature.getObject().getProject())));
+        tagset.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
+                target -> {
+                    target.add(multipleRows);
+                    target.add(form);
+                }));
         add(tagset);
+    }
+    
+    private PrimitiveUimaFeatureSupport getFeatureSupport()
+    {
+        return featureSupportRegistry.getFeatureSupport(featureSupportId);
+    }
+    
+    /**
+     * Read traits and then transfer the values from the actual traits model
+     * {{@link UimaStringTraits}} to the the UI traits model ({@link UimaStringTraits}).
+     */
+    private Traits readTraits()
+    {
+        Traits result = new Traits();
+    
+        UimaStringTraits t = getFeatureSupport().readUimaStringTraits(feature.getObject());
+        
+        result.setMultipleRows(t.isMultipleRows());
+        result.setCollapsedRows(t.getCollapsedRows());
+        result.setExpandedRows(t.getExpandedRows());
+                
+        return result;
+    }
+    
+    /**
+     * Transfer the values from the UI traits model ({@link UimaStringTraits})to the actual
+     * traits model {{@link UimaStringTraits}} and then store them.
+     */
+    private void writeTraits()
+    {
+        UimaStringTraits t = new UimaStringTraits();
+        
+        t.setMultipleRows(traits.getObject().isMultipleRows());
+        t.setCollapsedRows(traits.getObject().getCollapsedRows());
+        t.setExpandedRows(traits.getObject().getExpandedRows());
+        
+        getFeatureSupport().writeUimaStringTraits(feature.getObject(), t);
+    }
+    
+    /**
+     * A UI model holding the traits while the user is editing them. They are read/written to the
+     * actual {@link UimaStringTraits} via {@link #readTraits()} and
+     * {@link #writeTraits()}.
+     */
+    private static class Traits implements Serializable
+    {
+        private static final long serialVersionUID = 350784828528183399L;
+    
+        private boolean multipleRows = false;
+        private int collapsedRows = 1;
+        private int expandedRows = 1;
+    
+        public boolean isMultipleRows()
+        {
+            return multipleRows;
+        }
+    
+        public void setMultipleRows(boolean multipleRows)
+        {
+            this.multipleRows = multipleRows;
+        }
+    
+        public int getCollapsedRows()
+        {
+            return collapsedRows;
+        }
+    
+        public void setCollapsedRows(int collapsedRows)
+        {
+            this.collapsedRows = collapsedRows;
+        }
+    
+        public int getExpandedRows()
+        {
+            return expandedRows;
+        }
+    
+        public void setExpandedRows(int expandedRows)
+        {
+            this.expandedRows = expandedRows;
+        }
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
@@ -100,8 +100,8 @@ public class UimaStringTraitsEditor
         CheckBox multipleRows = new CheckBox("multipleRows");
         multipleRows.setModel(PropertyModel.of(traits, "multipleRows"));
         multipleRows.add(enabledWhen(() -> feature.getObject().getTagset() == null));
-        multipleRows.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
-                target -> target.add(form)));
+        multipleRows.add(new LambdaAjaxFormComponentUpdatingBehavior("change", 
+            target -> target.add(form)));
         add(multipleRows);
         
         DropDownChoice<TagSet> tagset = new BootstrapSelect<>("tagset");
@@ -113,10 +113,10 @@ public class UimaStringTraitsEditor
         tagset.setChoices(LoadableDetachableModel.of(() -> annotationService
                 .listTagSets(aFeature.getObject().getProject())));
         tagset.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
-                target -> {
-                    target.add(multipleRows);
-                    target.add(form);
-                }));
+            target -> {
+                target.add(multipleRows);
+                target.add(form);
+            }));
         add(tagset);
     }
     

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/UimaStringTraitsEditor.java
@@ -99,7 +99,6 @@ public class UimaStringTraitsEditor
     
         CheckBox multipleRows = new CheckBox("multipleRows");
         multipleRows.setModel(PropertyModel.of(traits, "multipleRows"));
-        multipleRows.add(enabledWhen(() -> feature.getObject().getTagset() == null));
         multipleRows.add(new LambdaAjaxFormComponentUpdatingBehavior("change", 
             target -> target.add(form)));
         add(multipleRows);

--- a/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_primitive-features.adoc
+++ b/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_primitive-features.adoc
@@ -21,4 +21,5 @@
 Supported primitive features types are string, boolean, integer, and float.
 Boolean features are displayed as a checkbox that can either be marked or unmarked. Integer and 
 float features are displayed using a number field. String features are displayed using a text field
-or - in case they have a tagset - using a combobox.
+or a text area with multiple rows. The text area can be expanded if focused and collapses again if
+focus is lost. In case the string feature has a tagset it will instead use a combobox. 

--- a/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -284,4 +284,19 @@ _(Span layers)_
 | Link feature that can point only to the selected span layer.
 |====
 
+.String feature properties
+[cols="1v,2", options="header"]
+|====
+| Property | Description
+
+| Multiple Rows
+| If enabled the textfield will be replaced by a textarea which expands on focus. This also enables options to set the size of the textarea and disables tagsets.
+
+| Collapsed Rows
+| Set the number of rows for the textarea when it is collapsed and not focused.
+
+| Expanded Rows
+| Set the number of rows for the textarea when it is expanded and not focused.
+|====
+
 NOTE: Please take care that when working with non-custom layers, they have to be ex- and imported, if you want to use the resulting files in e.g. correction projects.


### PR DESCRIPTION
**What's in the PR**
- Add option for multiple rows and count of collapsed and expanded rows for primitive string features
- Use normal input textfield feature if multiple rows is disabled, otherwise use input textarea

**How to test manually**
* Create a new string feature for a layer and enable multiple rows
* Set collapsed and expanded rows
* See results in the annotation editor

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
