### PR TITLE
#1465 - Selected default layer is not a span layer

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.wicket.Page;
@@ -350,7 +351,17 @@ public class AnnotatorStateImpl
         
         // Make sure the currently selected layer is actually visible/exists
         if (!annotationLayers.contains(selectedAnnotationLayer)) {
-            selectedAnnotationLayer = !annotationLayers.isEmpty() ? annotationLayers.get(0) : null;
+            if (!annotationLayers.isEmpty()) {
+                // Make sure that the selected layer is a span layer
+                for (AnnotationLayer layer : annotationLayers) {
+                    if (layer.getType().equals(WebAnnoConst.SPAN_TYPE)) {
+                        selectedAnnotationLayer = layer;
+                        break;
+                    }
+                }
+            } else {
+                selectedAnnotationLayer = null;
+            }
             defaultAnnotationLayer = selectedAnnotationLayer;
         }
     }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.wicket.Page;
@@ -36,6 +35,7 @@ import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.request.cycle.RequestCycle;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.PagingStrategy;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.Unit;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderSlotsEvent;
@@ -351,17 +351,10 @@ public class AnnotatorStateImpl
         
         // Make sure the currently selected layer is actually visible/exists
         if (!annotationLayers.contains(selectedAnnotationLayer)) {
-            if (!annotationLayers.isEmpty()) {
-                // Make sure that the selected layer is a span layer
-                for (AnnotationLayer layer : annotationLayers) {
-                    if (layer.getType().equals(WebAnnoConst.SPAN_TYPE)) {
-                        selectedAnnotationLayer = layer;
-                        break;
-                    }
-                }
-            } else {
-                selectedAnnotationLayer = null;
-            }
+            selectedAnnotationLayer = annotationLayers.stream()
+                .filter(layer -> layer.getType().equals(WebAnnoConst.SPAN_TYPE))
+                .findFirst()
+                .orElse(null);
             defaultAnnotationLayer = selectedAnnotationLayer;
         }
     }


### PR DESCRIPTION
**What's in the PR**
- when setting annotation layers check if the new selected annotation layer and default selected annotation layer is of type span

**How to test manually**
1. Create a fresh project
2. Disable all layers
3. Create a span layer, named for example `ASPAN`
4. Create a document layer, named fpr example `ADOC` (if sorted `ADOC` occurs before `ASPAN` in alphabet)
5. Add a document to the project
6. Open the editor and try to create a span

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
