### PR TITLE
#1483 - Crash when modifying annotations while slot is armed

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -290,10 +290,12 @@ public class LinkFeatureEditor
             // If a slot is armed, then load the slot's role into the dropdown
             FeatureState featureState = LinkFeatureEditor.this.getModelObject();
             AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
+            List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) featureState.value;
+            
             if (state.isSlotArmed()
-                    && featureState.feature.equals(state.getArmedFeature().feature))
+                    && featureState.feature.equals(state.getArmedFeature().feature)
+                    && links.size() > state.getArmedSlot())
             {
-                List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) featureState.value;
                 field.setModelObject(links.get(state.getArmedSlot()).role);
             }
             else {

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
@@ -66,7 +66,7 @@ public class RatingFeatureEditor
     {
         return new ListView<Integer>("radios", range)
         {
-            private static final long serialVersionUID = -1139622234318691941L;
+            private static final long serialVersionUID = 6856342528153905386L;
             
             @Override
             protected void populateItem(ListItem<Integer> item)

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -27,7 +27,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.setFeature;
+
 import static java.util.Arrays.asList;
+
 import static org.apache.uima.fit.util.CasUtil.selectAt;
 
 import java.io.IOException;
@@ -59,6 +61,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormValidatingBehavior;
+import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -95,6 +98,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.LinkWithRoleModel;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.Selection;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderSlotsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.TypeUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.evaluator.Evaluator;
@@ -649,6 +653,9 @@ public abstract class AnnotationDetailEditorPanel
         internalCommitAnnotation(aTarget, aCas);
 
         internalCompleteAnnotation(aTarget, aCas);
+    
+        state.clearArmedSlot();    
+        send(getPage(), Broadcast.BREADTH, new RenderSlotsEvent(aTarget));
     }
     
     private Optional<AnnotationLayer> getRelationLayerFor(AnnotationLayer aSpanLayer)


### PR DESCRIPTION
**What's in the PR**
- clear slot and send RenderSlotsEvent when creating or updating a span annotation and send RenderSlotsEvent
- generated new random serialVersionUID for rating feature

**How to test manually**
1. Open a span annotation
2. Arm a slot in a link feature
3. Modify another feature like a string or number feature.
4. Slot should be disarmed and the other feature should be updated

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
