### PR TITLE
#1496 - Focusing Rating Editor breaks updating of other features

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/BooleanFeatureEditor.java
@@ -17,10 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 
@@ -56,7 +56,7 @@ public class BooleanFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return field;
     }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/FeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/FeatureEditor.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 
@@ -79,5 +80,5 @@ public abstract class FeatureEditor
         return new Label(MID_FEATURE, getModelObject().feature.getUiName());
     }
     
-    abstract public Component getFocusComponent();
+    abstract public FormComponent getFocusComponent();
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -43,6 +43,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RefreshingView;
 import org.apache.wicket.markup.repeater.util.ModelIteratorAdapter;
@@ -473,7 +474,7 @@ public class LinkFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return field;
     }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.html
@@ -20,13 +20,11 @@
 <wicket:panel>
   <div class="form-group">
     <label wicket:for="group" class="col-sm-3 control-label"><span wicket:id="feature"/></label>
-    <div id="rating" class="col-sm-9">
-      <div wicket:id="group">
-        <span wicket:id="radios">
-          <input wicket:id="radio" type="radio"/>
-          <label wicket:id="label" style="margin-right: 5%; padding-left: 20px;"></label>
-        </span>
-      </div>
+    <div class="col-sm-9" wicket:id="group">
+      <span wicket:id="radios">
+        <input wicket:id="radio" type="radio"/>
+        <label wicket:id="label" style="margin-right: 5%; padding-left: 20px;"></label>
+      </span>
     </div>
   </div>
 </wicket:panel>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
@@ -20,19 +20,14 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 import java.util.List;
 
 import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.ajax.AjaxEventBehavior;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 
 import com.googlecode.wicket.kendo.ui.form.Radio;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 
 public class RatingFeatureEditor
@@ -40,24 +35,20 @@ public class RatingFeatureEditor
 {
     private static final long serialVersionUID = 9112762779124263198L;
     
-    @SuppressWarnings("rawtypes")
     private final RadioGroup<Integer> field;
-    private IModel<FeatureState> model;
     
     public RatingFeatureEditor(String aId, MarkupContainer aItem, IModel<FeatureState> aModel,
             List<Integer> aRange)
     {
         super(aId, aItem, aModel);
-        model = aModel;
         
         field = new RadioGroup<>("group", new PropertyModel<>(aModel, "value"));
         field.add(createFeaturesList(aRange));
         add(field);
     }
     
-    @SuppressWarnings("rawtypes")
     @Override
-    public RadioGroup getFocusComponent()
+    public RadioGroup<Integer> getFocusComponent()
     {
         return field;
     }
@@ -71,25 +62,10 @@ public class RatingFeatureEditor
             @Override
             protected void populateItem(ListItem<Integer> item)
             {
-                Radio<Integer> radio =
-                        new Radio<>("radio", new Model(item.getModelObject()), field);
-                radio.add(new AjaxEventBehavior("click")
-                {
-                    @Override protected void onEvent(AjaxRequestTarget aTarget)
-                    {
-                        model.getObject().value = item.getModelObject();
-                        update(aTarget);
-                    }
-                });
-                Radio.Label label = new Radio.Label("label", item.getModelObject(), radio);
+                Radio<Integer> radio = new Radio<>("radio", item.getModel(), field);
+                Radio.Label label = new Radio.Label("label", item.getModel(), radio);
                 item.add(radio, label);
             }
         };
     }
-    
-    private void update(AjaxRequestTarget aTarget) {
-        send(this, Broadcast.BUBBLE,
-                new FeatureEditorValueChangedEvent(model.getObject(), aTarget));
-    }
-    
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextFeatureEditorBase.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextFeatureEditorBase.java
@@ -100,7 +100,7 @@ public abstract class TextFeatureEditorBase
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return field;
     }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -52,9 +52,13 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.CheckBoxMultipleChoice;
+import org.apache.wicket.markup.html.form.CheckGroup;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.RadioChoice;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RefreshingView;
@@ -849,8 +853,15 @@ public class AnnotationFeatureForm
 
         private void addAnnotateActionBehavior(final FeatureEditor aFrag)
         {
-            if (aFrag.getFocusComponent() instanceof RadioGroup) {
-                aFrag.getFocusComponent().add(new AjaxFormChoiceComponentUpdatingBehavior()
+            FormComponent focusComponent = aFrag.getFocusComponent();
+            
+            if (
+                    (focusComponent instanceof RadioChoice) ||
+                    (focusComponent instanceof CheckBoxMultipleChoice) || 
+                    (focusComponent instanceof RadioGroup) ||
+                    (focusComponent instanceof CheckGroup)
+            ) {
+                focusComponent.add(new AjaxFormChoiceComponentUpdatingBehavior()
                 {
                     private static final long serialVersionUID = -5058365578109385064L;
 
@@ -869,7 +880,7 @@ public class AnnotationFeatureForm
                 });
             }
             else {
-                aFrag.getFocusComponent().add(new AjaxFormComponentUpdatingBehavior("change")
+                focusComponent.add(new AjaxFormComponentUpdatingBehavior("change")
                 {
                     private static final long serialVersionUID = 5179816588460867471L;
 

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail.AnnotationD
 import static java.util.Objects.isNull;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 import static org.apache.wicket.util.string.Strings.escapeMarkup;
+import static org.apache.wicket.util.time.Duration.milliseconds;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -71,7 +72,6 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -888,7 +888,7 @@ public class AnnotationFeatureForm
                     protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
                     {
                         super.updateAjaxAttributes(aAttributes);
-                        addDelay(aFrag, aAttributes, 100);
+                        addDelay(aFrag, aAttributes, 250);
                     }
 
                     @Override
@@ -906,8 +906,7 @@ public class AnnotationFeatureForm
             // there is a race condition between the saving the value of the feature
             // editor and the loading of the new annotation. Delay the feature editor
             // save to give preference to loading the new annotation.
-            aAttributes.setThrottlingSettings(new ThrottlingSettings(getMarkupId(),
-                Duration.milliseconds(aDelay), true));
+            aAttributes.setThrottlingSettings(new ThrottlingSettings(milliseconds(aDelay), true));
             aAttributes.getAjaxCallListeners().add(new AjaxCallListener()
             {
                 private static final long serialVersionUID = 1L;


### PR DESCRIPTION
**What's in the PR**
- Allow the addAnnotateActionBehavior() to handle choice form components (i.e. RadioGroup)
- Simplify RatingFeatureEditor code and HTML
- Changed return type of getFocusComponent to FormComponent since the addAnnotateActionBehavior only works for FormComponents
- Handle all Wicket default choice component types
- Do not set the markup ID of the feature container as the throttling/timeout ID to avoid timers for different features cancelling each other out

**How to test manually**
1. Have a string feature
2. Have a rating feature
3. Edit the string feature text
4. Click on a value of the rating feature
5. String feature changes should be saved

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
