### PR TITLE
#1539 - WebAnnoTsv3XWriter does not support elevated types

### DIFF
--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XCasDocumentBuilder.java
@@ -121,7 +121,8 @@ public class Tsv3XCasDocumentBuilder
             boolean addDisambiguationIdIfStacked = SPAN.equals(layerType);
             
             for (AnnotationFS annotation : CasUtil.select(aJCas.getCas(), type)) {
-                doc.activateType(annotation.getType());
+                // Mind that we might actually get an annotation here which is a subtype of `type`!
+                doc.activateType(type);
                 
                 // Get the relevant begin and end offsets for the current annotation
                 int begin = annotation.getBegin();
@@ -348,7 +349,8 @@ public class Tsv3XCasDocumentBuilder
                                 .getType(POS.class.getName()));
                     }
                     else {
-                        col.setTargetTypeHint(target.getType());
+                        TsvSchema schema = aUnit.getDocument().getSchema();
+                        col.setTargetTypeHint(schema.getEffectiveType(target));
                     }
                 }
             }

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/model/TsvUnit.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/model/TsvUnit.java
@@ -98,9 +98,10 @@ public abstract class TsvUnit
      */
     public void addUimaAnnotation(AnnotationFS aFS, boolean aAddDisambiguationIfStacked)
     {
-        uimaAnnotations.putIfAbsent(aFS.getType(), new ArrayList<>());
+        Type effectiveType = getDocument().getSchema().getEffectiveType(aFS);
+        uimaAnnotations.putIfAbsent(effectiveType, new ArrayList<>());
         
-        List<AnnotationFS> annotations = uimaAnnotations.get(aFS.getType());
+        List<AnnotationFS> annotations = uimaAnnotations.get(effectiveType);
         
         // If we already have annotations of this type, then we need to add disambiguation IDs.
         boolean alreadyHaveAnnotationsOfSameType = !annotations.isEmpty();

--- a/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTest.java
+++ b/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTest.java
@@ -48,6 +48,7 @@ public class WebAnnoTsv3WriterTest extends WebAnnoTsv3WriterTestBase
         failingTests.add("testAnnotationWithLeadingWhitespaceAtStart");
         failingTests.add("testAnnotationWithTrailingWhitespace");
         failingTests.add("testAnnotationWithTrailingWhitespaceAtEnd");
+        failingTests.add("testElevatedType");
         failingTests.add("testSubtokenChain");
         failingTests.add("testStackedSubMultiTokenSpanWithFeatureValue");
         failingTests.add("testSubMultiTokenSpanWithFeatureValue");

--- a/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTestBase.java
+++ b/webanno-io-tsv/src/test/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3WriterTestBase.java
@@ -59,6 +59,7 @@ import org.junit.Test;
 
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.MorphologicalFeatures;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS_NOUN;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
@@ -1816,6 +1817,29 @@ public abstract class WebAnnoTsv3WriterTestBase
         // otherwise it could not be represented in the TSV3 format.
         new NamedEntity(jcas, 1, 1).addToIndexes();
         
+        writeAndAssertEquals(jcas);
+    }
+    
+    @Test
+    public void testElevatedType() throws Exception {
+        JCas jcas = JCasFactory.createJCas();
+        
+        DocumentMetaData.create(jcas).setDocumentId("doc");
+        jcas.setDocumentText("John");
+        
+        // Add an elevated type which is not a direct subtype of Annotation. This type not be picked
+        // up by the schema analyzer but should still be serialized as the POS type which is in fact
+        // picked up.
+        POS_NOUN pos = new POS_NOUN(jcas, 0, 4);
+        pos.setPosValue("NN");
+        pos.setCoarseValue("NOUN");
+        pos.addToIndexes();
+        
+        Token t = new Token(jcas, 0, 4);
+        t.setPos(pos);
+        t.addToIndexes();
+        new Sentence(jcas, 0, 4).addToIndexes();
+                
         writeAndAssertEquals(jcas);
     }
 

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testElevatedType/reference.tsv
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testElevatedType/reference.tsv
@@ -1,0 +1,6 @@
+#FORMAT=WebAnno TSV 3.2
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue|coarseValue
+
+
+#Text=John
+1-1	0-4	John	NN	NOUN	

--- a/webanno-io-tsv/src/test/resources/tsv3-suite/testElevatedType/reference.xmi
+++ b/webanno-io-tsv/src/test/resources/tsv3-suite/testElevatedType/reference.xmi
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?><xmi:XMI xmlns:pos="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos.ecore" xmlns:tcas="http:///uima/tcas.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:cas="http:///uima/cas.ecore" xmlns:tweet="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/pos/tweet.ecore" xmlns:morph="http:///de/tudarmstadt/ukp/dkpro/core/api/lexmorph/type/morph.ecore" xmlns:dependency="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/dependency.ecore" xmlns:type6="http:///de/tudarmstadt/ukp/dkpro/core/api/semantics/type.ecore" xmlns:type="http:///de/tudarmstadt/ukp/dkpro/core/api/anomaly/type.ecore" xmlns:type7="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type.ecore" xmlns:type3="http:///de/tudarmstadt/ukp/dkpro/core/api/metadata/type.ecore" xmlns:type4="http:///de/tudarmstadt/ukp/dkpro/core/api/ner/type.ecore" xmlns:type5="http:///de/tudarmstadt/ukp/dkpro/core/api/segmentation/type.ecore" xmlns:type2="http:///de/tudarmstadt/ukp/dkpro/core/api/coref/type.ecore" xmlns:constituent="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/constituent.ecore" xmlns:chunk="http:///de/tudarmstadt/ukp/dkpro/core/api/syntax/type/chunk.ecore" xmi:version="2.0">
+    <cas:NULL xmi:id="0"/>
+    <type3:DocumentMetaData xmi:id="1" sofa="2" begin="0" end="4" documentId="doc" isLastSegment="false"/>
+    <pos:POS_NOUN xmi:id="3" sofa="2" begin="0" end="4" PosValue="NN" coarseValue="NOUN"/>
+    <type5:Token xmi:id="4" sofa="2" begin="0" end="4" pos="3" order="0"/>
+    <type5:Sentence xmi:id="5" sofa="2" begin="0" end="4"/>
+    <cas:Sofa xmi:id="2" sofaNum="1" sofaID="_InitialView" mimeType="text" sofaString="John"/>
+    <cas:View sofa="2" members="1 3 4 5"/>
+</xmi:XMI>


### PR DESCRIPTION
**What's in the PR**
- Export elevated types as whichever of their supertypes is actually part of the TsvSchema (i.e. a subtype of Annotation)
- Added unit test

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
