### PR TITLE
#1551 - "AUTO" format always exports curated documents as TSV3

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentExporter.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentExporter.java
@@ -172,10 +172,12 @@ public class AnnotationDocumentExporter
             
             FormatSupport format = importExportService.getWritableFormatById(formatId)
                     .orElseGet(() -> {
-                        aRequest.addMessage(LogMessage.error(this,"[%s] No writer found for "
-                                + "format [%s] - exporting as WebAnno TSV instead.",
-                                sourceDocument.getName(), aRequest.getFormat()));
-                        return new WebAnnoTsv3FormatSupport();
+                        FormatSupport fallbackFormat = new WebAnnoTsv3FormatSupport();
+                        aRequest.addMessage(LogMessage.error(this,"Annotation: [%s] No writer "
+                                + "found for original format [%s] - exporting as [%s] "
+                                + "instead.",
+                                sourceDocument.getName(), formatId, fallbackFormat.getName()));
+                        return fallbackFormat;
                     });
 
             // Export annotations from regular users

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
@@ -94,21 +94,6 @@ public class CuratedDocumentsExporter
         // Get all the source documents from the project
         List<SourceDocument> documents = documentService.listSourceDocuments(project);
 
-        // Determine which format to use for export
-        FormatSupport format;
-        if (FORMAT_AUTO.equals(aRequest.getFormat())) {
-            format = new WebAnnoTsv3FormatSupport();
-        }
-        else {
-            format = importExportService.getWritableFormatById(aRequest.getFormat())
-                    .orElseGet(() -> {
-                        aRequest.addMessage(LogMessage.error(this, "No writer found for format "
-                                + "[%s] - exporting as WebAnno TSV instead.", 
-                                aRequest.getFormat()));
-                        return new WebAnnoTsv3FormatSupport();
-                    });
-        }
-        
         int initProgress = aRequest.progress - 1;
         int i = 1;
         for (SourceDocument sourceDocument : documents) {
@@ -130,6 +115,21 @@ public class CuratedDocumentsExporter
                     // Copy CAS - this is used when importing the project again
                     FileUtils.copyFileToDirectory(curationCasFile, curationCasDir);
 
+                    // Determine which format to use for export
+                    String formatId = FORMAT_AUTO.equals(aRequest.getFormat())
+                            ? sourceDocument.getFormat()
+                            : aRequest.getFormat();
+                    
+                    FormatSupport format = importExportService.getWritableFormatById(formatId)
+                            .orElseGet(() -> {
+                                FormatSupport fallbackFormat = new WebAnnoTsv3FormatSupport();
+                                aRequest.addMessage(LogMessage.error(this,"Curation: [%s] No writer"
+                                        + " found for original format [%s] - exporting as [%s] "
+                                        + "instead.", sourceDocument.getName(), formatId, 
+                                        fallbackFormat.getName()));
+                                return fallbackFormat;
+                            });
+                    
                     // Copy secondary export format for convenience - not used during import
                     try {
                         File curationFile = importExportService.exportAnnotationDocument(

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
@@ -30,7 +30,7 @@ public class WebAnnoTsv1FormatSupport
     implements FormatSupport
 {
     public static final String ID = "tsv";
-    public static final String NAME = "WebAnno TSV1 (WebAnno v1)";
+    public static final String NAME = "WebAnno TSV v1 (WebAnno v1.x)";
     
     @Override
     public String getId()

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
@@ -30,7 +30,7 @@ public class WebAnnoTsv2FormatSupport
     implements FormatSupport
 {
     public static final String ID = "ctsv";
-    public static final String NAME = "WebAnno TSV2 (WebAnno v2)";
+    public static final String NAME = "WebAnno TSV v2 (WebAnno v2.x)";
     
     @Override
     public String getId()

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
@@ -34,7 +34,7 @@ public class WebAnnoTsv3FormatSupport
     implements FormatSupport
 {
     public static final String ID = "ctsv3";
-    public static final String NAME = "WebAnno TSV3 (WebAnno v3)";
+    public static final String NAME = "WebAnno TSV v3.2 (WebAnno v3.x)";
     
     @Override
     public String getId()

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
@@ -28,6 +28,7 @@ import java.net.URLEncoder;
 import java.nio.channels.ClosedByInterruptException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Queue;
@@ -146,8 +147,8 @@ public class ProjectExportPanel
             });
             format.setChoices(LoadableDetachableModel.of(() -> {
                 List<String> formats = importExportService.getWritableFormats().stream()
+                        .sorted(Comparator.comparing(FormatSupport::getName))
                         .map(FormatSupport::getId)
-                        .sorted()
                         .collect(Collectors.toCollection(ArrayList::new));
                 formats.add(0, ProjectExportRequest.FORMAT_AUTO);
                 return formats;


### PR DESCRIPTION
**What's in the PR**
- Fix issue that curation is always exported as TSV in AUTO mode
- Give WebAnno TSV formats better names
- Improve info messages when falling back to TSV3
- Sort list of formats on the project export page properly

**How to test manually**
* Export a project with non-TSV original file format as AUTO

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
