### PR TITLE
#1553 - Navigation in annotation view skips sentences

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy.java
@@ -136,13 +136,13 @@ public interface PagingStrategy
     default void moveToPreviousPage(AnnotatorViewState aState, CAS aCas, FocusPosition aPos)
     {
         moveToUnit(aState, aCas,
-                aState.getFocusUnitIndex() - aState.getPreferences().getWindowSize(), aPos);
+                aState.getFirstVisibleUnitIndex() - aState.getPreferences().getWindowSize(), aPos);
     }
 
     default void moveToNextPage(AnnotatorViewState aState, CAS aCas, FocusPosition aPos)
     {
         moveToUnit(aState, aCas,
-                aState.getFocusUnitIndex() + aState.getPreferences().getWindowSize(), aPos);
+                aState.getFirstVisibleUnitIndex() + aState.getPreferences().getWindowSize(), aPos);
     }
 
     default void moveToFirstPage(AnnotatorViewState aState, CAS aCas, FocusPosition aPos)


### PR DESCRIPTION
**What's in the PR**
- Paging should be based on the first visible unit, not based on the focus unit.

**How to test manually**
* Open a document
* Annotate something in row 4
* Switch to the next page
* Page should start with 5 now, not with 9 as before

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
