### PR TITLE
#1558 - Opening the annotations of another user updates CAS

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -249,6 +249,15 @@ public class BratAnnotationEditor
                         }
                     }
                 }
+                catch (AnnotationException e) {
+                    // These are common exceptions happening as part of the user interaction. We do
+                    // not really need to log their stack trace to the log.
+                    error("Error: " + e.getMessage());
+                    // If debug is enabled, we'll also write the error to the log just in case.
+                    if (LOG.isDebugEnabled()) {
+                        LOG.error("Error: {}", e.getMessage(), e);
+                    }
+                }
                 catch (Exception e) {
                     error("Error: " + e.getMessage());
                     LOG.error("Error: {}", e.getMessage(), e);

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -417,8 +417,10 @@ public class AnnotationPage
         }
 
         // If we have a timestamp, then use it to detect if there was a concurrent access
-        verifyAndUpdateDocumentTimestamp(state, documentService
-                .getAnnotationCasTimestamp(state.getDocument(), state.getUser().getUsername()));
+        if (!isUserViewingOthersWork()) {
+            verifyAndUpdateDocumentTimestamp(state, documentService
+                    .getAnnotationCasTimestamp(state.getDocument(), state.getUser().getUsername()));
+        }
         
         return documentService.readAnnotationCas(state.getDocument(),
                 state.getUser().getUsername());
@@ -427,6 +429,10 @@ public class AnnotationPage
     @Override
     public void writeEditorCas(CAS aCas) throws IOException
     {
+        if (isUserViewingOthersWork()) {
+            throw new IOException("Viewing another users annotations - saving is not permitted!");
+        }
+        
         AnnotatorState state = getModelObject();
         documentService.writeAnnotationCas(aCas, state.getDocument(), state.getUser(), true);
 
@@ -548,14 +554,14 @@ public class AnnotationPage
             CAS editorCas = documentService.readAnnotationCas(annotationDocument,
                     FORCE_CAS_UPGRADE);
 
-            // After creating an new CAS or upgrading the CAS, we need to save it
-            documentService.writeAnnotationCas(editorCas, annotationDocument, false);
-
             // (Re)initialize brat model after potential creating / upgrading CAS
             state.reset();
-            
-            // Initialize timestamp in state
+
             if (!isUserViewingOthersWork()) {
+                // After creating an new CAS or upgrading the CAS, we need to save it
+                documentService.writeAnnotationCas(editorCas, annotationDocument, false);
+                
+                // Initialize timestamp in state
                 updateDocumentTimestampAfterWrite(state, documentService.getAnnotationCasTimestamp(
                         state.getDocument(), state.getUser().getUsername()));
             }
@@ -818,6 +824,4 @@ public class AnnotationPage
             super.loadPreferences();
         }
     }
-    
-    
 }


### PR DESCRIPTION
**What's in the PR**
- Avoid saving the upgraded CAS when viewing another user's data
- Avoid verifying the timestamp when viewing another user's data - no need to because we don't save anyway
- Add additional safeguard into writeEditorCas() to throw an exception if this method is invoked while viewing another user's data
- Avoid logging the rather common AnnotationException with full stack trace and unless in debug mode and just display the user message instead

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
