### PR TITLE
#1521 - Upgrade to UDv2 POS and dependency tagsets

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/DefaultTagSetsInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/DefaultTagSetsInitializer.java
@@ -22,11 +22,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.JsonImportUtil;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 @Component
@@ -50,20 +48,20 @@ public class DefaultTagSetsInitializer
     @Override
     public void configure(Project aProject) throws IOException
     {
-        JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/de-pos-stts.json").getInputStream(),
-                annotationSchemaService);
-        JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/de-dep-tiger.json").getInputStream(),
-                annotationSchemaService);
-        JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/en-dep-sd.json").getInputStream(),
-                annotationSchemaService);
-        JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/en-pos-ptb-tt.json").getInputStream(),
-                annotationSchemaService);
-        JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/mul-pos-upos.json").getInputStream(),
-                annotationSchemaService);
+//        JsonImportUtil.importTagSetFromJson(aProject,
+//                new ClassPathResource("/tagsets/de-pos-stts.json").getInputStream(),
+//                annotationSchemaService);
+//        JsonImportUtil.importTagSetFromJson(aProject,
+//                new ClassPathResource("/tagsets/de-dep-tiger.json").getInputStream(),
+//                annotationSchemaService);
+//        JsonImportUtil.importTagSetFromJson(aProject,
+//                new ClassPathResource("/tagsets/en-dep-sd.json").getInputStream(),
+//                annotationSchemaService);
+//        JsonImportUtil.importTagSetFromJson(aProject,
+//                new ClassPathResource("/tagsets/en-pos-ptb-tt.json").getInputStream(),
+//                annotationSchemaService);
+//        JsonImportUtil.importTagSetFromJson(aProject,
+//                new ClassPathResource("/tagsets/mul-pos-upos.json").getInputStream(),
+//                annotationSchemaService);
     }
 }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/DependencyLayerInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/DependencyLayerInitializer.java
@@ -66,7 +66,7 @@ public class DependencyLayerInitializer
     public void configure(Project aProject) throws IOException
     {
         TagSet depTagSet = JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/mul-dep-ud.json").getInputStream(),
+                new ClassPathResource("/tagsets/mul-dep-ud2.json").getInputStream(),
                 annotationSchemaService);
         
         // Dependency Layer

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/PartOfSpeechLayerInitializer.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/initializers/PartOfSpeechLayerInitializer.java
@@ -62,7 +62,7 @@ public class PartOfSpeechLayerInitializer
     public void configure(Project aProject) throws IOException
     {
         TagSet posTagSet = JsonImportUtil.importTagSetFromJson(aProject,
-                new ClassPathResource("/tagsets/mul-pos-ud.json").getInputStream(),
+                new ClassPathResource("/tagsets/mul-pos-ud2.json").getInputStream(),
                 annotationSchemaService);
 
         AnnotationLayer tokenLayer = annotationSchemaService.findLayer(aProject,

--- a/webanno-api-dao/src/main/resources/tagsets/mul-dep-ud2.json
+++ b/webanno-api-dao/src/main/resources/tagsets/mul-dep-ud2.json
@@ -1,7 +1,7 @@
 {
-  "name" : "UD Universal Dependencies",
+  "name" : "UD Universal Dependencies (v2)",
   "typeUiName" : null,
-  "description" : "The idea of universal dependencies is to propose a set of universal grammatical relations which can be used with relative fidelity to capture any dependency relation between words in any language. Each dependency relation should be typed with one of the relations in the table below.\r\n\r\nThe table is adapted from Universal Stanford Dependencies: A cross-linguistic typology (de Marneffe et al. 2014). There have been modifications in the relations: we now have 40 universal relations (instead of the 42 ones proposed in the paper).\r\n\r\nNote: nmod, neg, and punct appear in two places.\r\n\r\n© 2014 Universal Dependencies contributors.\r\n\r\nSee also: http://universaldependencies.org/u/dep/index.html",
+  "description" : "The idea of universal dependencies is to propose a set of universal grammatical relations which can be used with relative fidelity to capture any dependency relation between words in any language. Each dependency relation should be typed with one of the relations in the table below.\r\n\r\nThe following table lists the 37 universal syntactic relations used in UD v2. It is a revised version of the relations originally described in Universal Stanford Dependencies: A cross-linguistic typology (de Marneffe et al. 2014).\r\n\r\n© 2014-2017 Universal Dependencies contributors.\r\n\r\nSee also: https://universaldependencies.org/u/dep/index.html",
   "language" : "mul",
   "type" : null,
   "type_name" : null,
@@ -25,9 +25,6 @@
     "tag_name" : "aux",
     "tag_description" : "auxiliary"
   }, {
-    "tag_name" : "auxpass",
-    "tag_description" : "passive auxiliary"
-  }, {
     "tag_name" : "case",
     "tag_description" : "case marking"
   }, {
@@ -36,6 +33,9 @@
   }, {
     "tag_name" : "ccomp",
     "tag_description" : "clausal complement"
+  }, {
+    "tag_name" : "clf",
+    "tag_description" : "classifier"
   }, {
     "tag_name" : "compound",
     "tag_description" : "compound"
@@ -49,9 +49,6 @@
     "tag_name" : "csubj",
     "tag_description" : "clausal subject"
   }, {
-    "tag_name" : "csubjpass",
-    "tag_description" : "clausal passive subject"
-  }, {
     "tag_name" : "dep",
     "tag_description" : "unspecified dependency"
   }, {
@@ -64,14 +61,14 @@
     "tag_name" : "dislocated",
     "tag_description" : "dislocated elements"
   }, {
-    "tag_name" : "dobj",
-    "tag_description" : "direct object"
-  }, {
     "tag_name" : "expl",
     "tag_description" : "expletive"
   }, {
-    "tag_name" : "foreign",
-    "tag_description" : "foreign words"
+    "tag_name" : "fixed",
+    "tag_description" : "fixed multiword expression"
+  }, {
+    "tag_name" : "flat",
+    "tag_description" : "flat multiword expression"
   }, {
     "tag_name" : "goeswith",
     "tag_description" : "goes with"
@@ -85,35 +82,29 @@
     "tag_name" : "mark",
     "tag_description" : "marker"
   }, {
-    "tag_name" : "mwe",
-    "tag_description" : "multi-word expression"
-  }, {
-    "tag_name" : "name",
-    "tag_description" : "name"
-  }, {
-    "tag_name" : "neg",
-    "tag_description" : "negation modifier"
-  }, {
     "tag_name" : "nmod",
     "tag_description" : "nominal modifier"
   }, {
     "tag_name" : "nsubj",
     "tag_description" : "nominal subject"
   }, {
-    "tag_name" : "nsubjpass",
-    "tag_description" : "passive nominal subject"
-  }, {
     "tag_name" : "nummod",
     "tag_description" : "numeric modifier"
+  }, {
+    "tag_name" : "obj",
+    "tag_description" : "object"
+  }, {
+    "tag_name" : "obl",
+    "tag_description" : "oblique nominal"
+  }, {
+    "tag_name" : "orphan",
+    "tag_description" : "orphan"
   }, {
     "tag_name" : "parataxis",
     "tag_description" : "parataxis"
   }, {
     "tag_name" : "punct",
     "tag_description" : "punctuation"
-  }, {
-    "tag_name" : "remnant",
-    "tag_description" : "remnant in ellipsis"
   }, {
     "tag_name" : "reparandum",
     "tag_description" : "overridden disfluency"

--- a/webanno-api-dao/src/main/resources/tagsets/mul-pos-ud2.json
+++ b/webanno-api-dao/src/main/resources/tagsets/mul-pos-ud2.json
@@ -1,7 +1,7 @@
 {
-  "name" : "UD Universal POS tags",
+  "name" : "UD Universal POS tags (v2)",
   "typeUiName" : null,
-  "description" : "These tags mark the core part-of-speech categories from the Universal Dependencies project. To distinguish additional lexical and grammatical properties of words, use the universal features.\r\n\r\n© 2014 Universal Dependencies contributors\r\n\r\nSee: http://universaldependencies.org/u/pos/index.html",
+  "description" : "These tags mark the core part-of-speech categories from the Universal Dependencies project. To distinguish additional lexical and grammatical properties of words, use the universal features.\r\n\r\n© 2017 Universal Dependencies contributors\r\n\r\nSee: https://universaldependencies.org/u/pos/index.html",
   "language" : "mul",
   "type" : null,
   "type_name" : null,
@@ -17,9 +17,9 @@
     "tag_description" : "adverb"
   }, {
     "tag_name" : "AUX",
-    "tag_description" : "auxiliary verb"
+    "tag_description" : "auxiliary"
   }, {
-    "tag_name" : "CONJ",
+    "tag_name" : "CCONJ",
     "tag_description" : "coordinating conjunction"
   }, {
     "tag_name" : "DET",

--- a/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagEditorPanel.html
+++ b/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagEditorPanel.html
@@ -38,7 +38,7 @@
               <wicket:label key="description"/>
             </label>
             <div class="col-sm-9">
-              <textarea wicket:id="description" rows="5" class="form-control"></textarea>
+              <textarea wicket:id="description" rows="5" class="form-control" style="resize: vertical;"></textarea>
             </div>
           </div>
         </div>

--- a/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.html
+++ b/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.html
@@ -47,7 +47,7 @@
               <wicket:label key="description"/>
             </label>
             <div class="col-sm-10">
-              <textarea wicket:id="description" class="form-control"></textarea>
+              <textarea wicket:id="description" class="form-control" style="resize: vertical;"></textarea>
             </div>
           </div>
           <div class="form-group">


### PR DESCRIPTION
**What's in the PR**
- Upgrade default POS and dependency tagsets to UDv2
- Do not install unused tagsets
- Prevent resizing tagset and tag description text areas horizontally

**How to test manually**
* Create a project and check the layers are there and the tagsets are there

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
