### PR TITLE
#1561 - FeatureEditors should handle their updates themselves

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.java
@@ -34,6 +34,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.convert.ConversionException;
 import org.apache.wicket.util.convert.IConverter;
 
+import com.googlecode.wicket.jquery.core.JQueryBehavior;
+import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
 import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
 
@@ -104,6 +106,26 @@ public class KendoAutoCompleteTextFeatureEditor
         return new AutoCompleteTextField<Tag>("value") {
             private static final long serialVersionUID = 311286735004237737L;
 
+            @Override
+            public void onConfigure(JQueryBehavior behavior)
+            {
+                super.onConfigure(behavior);
+                
+                behavior.setOption("delay", 500);
+                behavior.setOption("animation", false);
+                behavior.setOption("footerTemplate",
+                        Options.asString("#: instance.dataSource.total() # items found"));
+                // Prevent scrolling action from closing the dropdown while the focus is on the
+                // input field
+                behavior.setOption("close", String.join(" ",
+                        "function(e) {",
+                        "  if (document.activeElement == e.sender.element[0]) {", 
+                        "    e.preventDefault();" + 
+                        "  }",
+                        "}"));
+                behavior.setOption("select", " function (e) { this.trigger('change'); }");
+            }
+            
             @Override
             protected List<Tag> getChoices(String aTerm)
             {

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -546,7 +547,7 @@ public class LinkFeatureEditor
             // trigger a reload of the feature editors from the CAS which makes the unfilled slots
             // disappear and leaves behind an armed slot pointing to a removed slot.
             if (m.targetAddr != -1) {
-                send(this, Broadcast.BUBBLE, new FeatureEditorValueChangedEvent(fs, aTarget));
+                send(this, Broadcast.BUBBLE, new FeatureEditorValueChangedEvent(this, aTarget));
             }
         }
     }
@@ -565,8 +566,7 @@ public class LinkFeatureEditor
 
         aTarget.add(content);
         
-        send(this, Broadcast.BUBBLE, 
-                new LinkFeatureDeletedEvent(fs, aTarget, linkWithRoleModel));
+        send(this, BUBBLE, new LinkFeatureDeletedEvent(this, aTarget, linkWithRoleModel));
     }
 
     private void actionToggleArmedState(AjaxRequestTarget aTarget, Item<LinkWithRoleModel> aItem)

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RatingFeatureEditor.java
@@ -17,9 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
+import static org.apache.wicket.event.Broadcast.BUBBLE;
+
 import java.util.List;
 
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -28,6 +34,7 @@ import org.apache.wicket.model.PropertyModel;
 
 import com.googlecode.wicket.kendo.ui.form.Radio;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 
 public class RatingFeatureEditor
@@ -67,5 +74,31 @@ public class RatingFeatureEditor
                 item.add(radio, label);
             }
         };
+    }
+    
+    @Override
+    public void addFeatureUpdateBehavior()
+    {
+        // Need to use a AjaxFormChoiceComponentUpdatingBehavior here since we use a RadioGroup
+        // here.
+        FormComponent focusComponent = getFocusComponent();
+        focusComponent.add(new AjaxFormChoiceComponentUpdatingBehavior()
+        {
+            private static final long serialVersionUID = -5058365578109385064L;
+
+            @Override
+            protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
+            {
+                super.updateAjaxAttributes(aAttributes);
+                addDelay(aAttributes, 300);
+            }
+
+            @Override
+            protected void onUpdate(AjaxRequestTarget aTarget)
+            {
+                send(focusComponent, BUBBLE,
+                        new FeatureEditorValueChangedEvent(RatingFeatureEditor.this, aTarget));
+            }
+        });
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/FeatureEditorEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/FeatureEditorEvent.java
@@ -19,27 +19,33 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 
 public abstract class FeatureEditorEvent
 {
-    private final FeatureState fs;
+    private final FeatureEditor editor;
     
     private final AjaxRequestTarget target;
     
-    public FeatureEditorEvent(FeatureState aFs, AjaxRequestTarget aTarget)
+    public FeatureEditorEvent(FeatureEditor aEditor, AjaxRequestTarget aTarget)
     {
-        fs = aFs;
+        editor = aEditor;
         target = aTarget;
     }
     
     public FeatureState getFeatureState()
     {
-        return fs;
+        return editor.getModelObject();
     }
     
     public AjaxRequestTarget getTarget()
     {
         return target;
+    }
+    
+    public FeatureEditor getEditor()
+    {
+        return editor;
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/FeatureEditorValueChangedEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/FeatureEditorValueChangedEvent.java
@@ -19,14 +19,14 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 
 public class FeatureEditorValueChangedEvent
     extends FeatureEditorEvent
 {
     
-    public FeatureEditorValueChangedEvent(FeatureState aFs, AjaxRequestTarget aTarget)
+    public FeatureEditorValueChangedEvent(FeatureEditor aEditor, AjaxRequestTarget aTarget)
     {
-        super(aFs, aTarget);
+        super(aEditor, aTarget);
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/LinkFeatureDeletedEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/LinkFeatureDeletedEvent.java
@@ -19,15 +19,15 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.LinkWithRoleModel;
 
 public class LinkFeatureDeletedEvent
     extends LinkFeatureEvent
 {
-    public LinkFeatureDeletedEvent(FeatureState aFs, AjaxRequestTarget aTarget,
+    public LinkFeatureDeletedEvent(FeatureEditor aEditor, AjaxRequestTarget aTarget,
             LinkWithRoleModel aLinkWithRoleModel)
     {
-        super(aFs, aTarget, aLinkWithRoleModel);
+        super(aEditor, aTarget, aLinkWithRoleModel);
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/LinkFeatureEvent.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/event/LinkFeatureEvent.java
@@ -19,7 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.LinkWithRoleModel;
 
 public abstract class LinkFeatureEvent
@@ -27,10 +27,10 @@ public abstract class LinkFeatureEvent
 {
     private final LinkWithRoleModel linkWithRoleModel;
     
-    public LinkFeatureEvent(FeatureState aFs, AjaxRequestTarget aTarget,
+    public LinkFeatureEvent(FeatureEditor aEditor, AjaxRequestTarget aTarget,
             LinkWithRoleModel aLinkWithRoleModel)
     {
-        super(aFs, aTarget);
+        super(aEditor, aTarget);
         linkWithRoleModel = aLinkWithRoleModel;
     }
     

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -114,7 +114,7 @@
             <div class="col-sm-12" wicket:id="infoContainer">
               <div class="form-horizontal" wicket:id="selectedAnnotationInfoContainer">
                 <div wicket:enclosure="selectedAnnotationType" style="position: relative; height: 5em; margin-bottom: 5px;">
-                  <div class="form-control" style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0;" readonly>
+                  <div class="form-control" style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 0px; right: 0px;" readonly>
                     <wicket:container wicket:id="selectedAnnotationType"/>
                   </div>
                 </div>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -27,9 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.setFeature;
-
 import static java.util.Arrays.asList;
-
 import static org.apache.uima.fit.util.CasUtil.selectAt;
 
 import java.io.IOException;
@@ -72,7 +70,6 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wicketstuff.event.annotation.OnEvent;
 
 import com.googlecode.wicket.kendo.ui.form.TextField;
 
@@ -90,8 +87,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.AnnotationCreatedE
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.NotEditableException;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.LinkFeatureDeletedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.LinkWithRoleModel;
@@ -1715,31 +1710,5 @@ public abstract class AnnotationDetailEditorPanel
     public static class AttachStatus {
         boolean readOnlyAttached;
         int attachCount;
-    }
-    
-    @OnEvent(stop = true)
-    public void onLinkFeatureDeletedEvent(LinkFeatureDeletedEvent aEvent)
-    {
-        AjaxRequestTarget target = aEvent.getTarget();
-        // Auto-commit if working on existing annotation
-        if (getModelObject().getSelection().getAnnotation().isSet()) {
-            try {
-                actionCreateOrUpdate(target, getEditorCas());
-            }
-            catch (Exception e) {
-                handleException(this, target, e);
-            }
-        }
-    }
-    
-    @OnEvent(stop = true)
-    public void onFeatureUpdatedEvent(FeatureEditorValueChangedEvent aEvent) {
-        AjaxRequestTarget target = aEvent.getTarget();
-        try {
-            actionCreateOrUpdate(target, getEditorCas());
-        }
-        catch (Exception e) {
-            handleException(this, target, e);
-        }
     }
 }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationFeatureForm.java
@@ -27,7 +27,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail.AnnotationD
 import static java.util.Objects.isNull;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 import static org.apache.wicket.util.string.Strings.escapeMarkup;
-import static org.apache.wicket.util.time.Duration.milliseconds;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,24 +42,15 @@ import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.attributes.AjaxCallListener;
-import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
-import org.apache.wicket.ajax.attributes.ThrottlingSettings;
-import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
-import org.apache.wicket.markup.html.form.CheckBoxMultipleChoice;
-import org.apache.wicket.markup.html.form.CheckGroup;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.form.FormComponent;
-import org.apache.wicket.markup.html.form.RadioChoice;
-import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RefreshingView;
 import org.apache.wicket.markup.repeater.util.ModelIteratorAdapter;
@@ -74,6 +64,7 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wicketstuff.event.annotation.OnEvent;
 
 import com.googlecode.wicket.kendo.ui.form.TextField;
 
@@ -87,6 +78,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.LinkFeatureEditor;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.LinkFeatureDeletedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.Selection;
@@ -858,145 +851,7 @@ public class AnnotationFeatureForm
 
         private void addAnnotateActionBehavior(final FeatureEditor aFrag)
         {
-            FormComponent focusComponent = aFrag.getFocusComponent();
-            
-            if (
-                    (focusComponent instanceof RadioChoice) ||
-                    (focusComponent instanceof CheckBoxMultipleChoice) || 
-                    (focusComponent instanceof RadioGroup) ||
-                    (focusComponent instanceof CheckGroup)
-            ) {
-                focusComponent.add(new AjaxFormChoiceComponentUpdatingBehavior()
-                {
-                    private static final long serialVersionUID = -5058365578109385064L;
-
-                    @Override
-                    protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
-                    {
-                        super.updateAjaxAttributes(aAttributes);
-                        addDelay(aFrag, aAttributes, 300);
-                    }
-
-                    @Override
-                    protected void onUpdate(AjaxRequestTarget aTarget)
-                    {
-                        actionFeatureUpdate(getComponent(), aTarget);
-                    }
-                });
-            }
-            else {
-                focusComponent.add(new AjaxFormComponentUpdatingBehavior("change")
-                {
-                    private static final long serialVersionUID = 5179816588460867471L;
-
-                    @Override
-                    protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
-                    {
-                        super.updateAjaxAttributes(aAttributes);
-                        addDelay(aFrag, aAttributes, 250);
-                    }
-
-                    @Override
-                    protected void onUpdate(AjaxRequestTarget aTarget)
-                    {
-                        actionFeatureUpdate(getComponent(), aTarget);
-                    }
-                });
-            }
-        }
-
-        private void addDelay(FeatureEditor aFrag, AjaxRequestAttributes aAttributes, int aDelay)
-        {
-            // When focus is on a feature editor and the user selects a new annotation,
-            // there is a race condition between the saving the value of the feature
-            // editor and the loading of the new annotation. Delay the feature editor
-            // save to give preference to loading the new annotation.
-            aAttributes.setThrottlingSettings(new ThrottlingSettings(milliseconds(aDelay), true));
-            aAttributes.getAjaxCallListeners().add(new AjaxCallListener()
-            {
-                private static final long serialVersionUID = 1L;
-
-                @Override
-                public CharSequence getPrecondition(Component aComponent)
-                {
-                    // If the panel refreshes because the user selects a new annotation,
-                    // the annotation editor panel is updated for the new annotation
-                    // first (before saving values) because of the delay set above. When
-                    // the delay is over, we can no longer save the value because the
-                    // old component is no longer there. We use the markup id of the
-                    // editor fragments to check if the old component is still there
-                    // (i.e. if the user has just tabbed to a new field) or if the old
-                    // component is gone (i.e. the user selected/created another
-                    // annotation). If the old component is no longer there, we abort
-                    // the delayed save action.
-                    return "return $('#" + aFrag.getMarkupId() + "').length > 0;";
-                }
-            }); 
-        }
-        
-        private void actionFeatureUpdate(Component aComponent, AjaxRequestTarget aTarget)
-        {
-            try {
-                AnnotatorState state = getModelObject();
-
-                if (state.getConstraints() != null) {
-                    // Make sure we update the feature editor panel because due to
-                    // constraints the contents may have to be re-rendered
-                    AnnotationFeatureForm.this.refresh(aTarget);
-                }
-                
-                // When updating an annotation in the sidebar, we must not force a
-                // re-focus after rendering
-                getRequestCycle().setMetaData(IsSidebarAction.INSTANCE, true);
-                
-                CAS cas = editorPanel.getEditorCas();
-                AnnotationLayer layer = state.getSelectedAnnotationLayer();
-                if (
-                        state.isForwardAnnotation() &&
-                        layer != null &&
-                        layer.equals(state.getDefaultAnnotationLayer())
-                ) {
-                    editorPanel.actionCreateForward(aTarget, cas);
-                } else {
-                    editorPanel.actionCreateOrUpdate(aTarget, cas);
-                }
-                
-                // If the focus was lost during the update, then try force-focusing the
-                // next editor or the first one if we are on the last one.
-                if (aTarget.getLastFocusedElementId() == null) {
-                    List<FeatureEditor> allEditors = new ArrayList<>();
-                    featureEditorPanelContent.visitChildren(FeatureEditor.class,
-                        (editor, visit) -> {
-                            allEditors.add((FeatureEditor) editor);
-                            visit.dontGoDeeper();
-                        });
-
-                    if (!allEditors.isEmpty()) {
-                        FeatureEditor currentEditor = aComponent.findParent(FeatureEditor.class);
-                        
-                        int i = allEditors.indexOf(currentEditor);
-                        
-                        // If the current editor cannot be found then move the focus to the
-                        // first editor
-                        if (i == -1) {
-                            autoFocus(aTarget, allEditors.get(0).getFocusComponent());
-                        }
-                        // ... if it is the last one, say at the last one
-                        else if (i >= (allEditors.size() - 1)) {
-                            autoFocus(aTarget, allEditors.get(allEditors.size() - 1)
-                                    .getFocusComponent());
-                        }
-                        // ... otherwise move the focus to the next editor
-                        else {
-                            autoFocus(aTarget, allEditors.get(i + 1).getFocusComponent());
-                        }
-                    }
-                }
-            }
-            catch (Exception e) {
-                handleException(AnnotationFeatureForm.FeatureEditorPanelContent.this,
-                    aTarget, e);
-            }
+            aFrag.addFeatureUpdateBehavior();
         }
         
         @Override
@@ -1013,6 +868,72 @@ public class AnnotationFeatureForm
                     return FeatureStateModel.of(getModel(), aObject);
                 }
             };
+        }
+    }
+
+    private void actionFeatureUpdate(Component aComponent, AjaxRequestTarget aTarget)
+    {
+        try {
+            AnnotatorState state = getModelObject();
+
+            if (state.getConstraints() != null) {
+                // Make sure we update the feature editor panel because due to
+                // constraints the contents may have to be re-rendered
+                AnnotationFeatureForm.this.refresh(aTarget);
+            }
+            
+            // When updating an annotation in the sidebar, we must not force a
+            // re-focus after rendering
+            getRequestCycle().setMetaData(IsSidebarAction.INSTANCE, true);
+            
+            CAS cas = editorPanel.getEditorCas();
+            AnnotationLayer layer = state.getSelectedAnnotationLayer();
+            if (
+                    state.isForwardAnnotation() &&
+                    layer != null &&
+                    layer.equals(state.getDefaultAnnotationLayer())
+            ) {
+                editorPanel.actionCreateForward(aTarget, cas);
+            } else {
+                editorPanel.actionCreateOrUpdate(aTarget, cas);
+            }
+            
+            // If the focus was lost during the update, then try force-focusing the
+            // next editor or the first one if we are on the last one.
+            if (aTarget.getLastFocusedElementId() == null) {
+                List<FeatureEditor> allEditors = new ArrayList<>();
+                featureEditorPanelContent.visitChildren(FeatureEditor.class,
+                    (editor, visit) -> {
+                        allEditors.add((FeatureEditor) editor);
+                        visit.dontGoDeeper();
+                    });
+
+                if (!allEditors.isEmpty()) {
+                    FeatureEditor currentEditor = aComponent instanceof FeatureEditor
+                            ? (FeatureEditor) aComponent
+                            : aComponent.findParent(FeatureEditor.class);
+                    
+                    int i = allEditors.indexOf(currentEditor);
+                    
+                    // If the current editor cannot be found then move the focus to the
+                    // first editor
+                    if (i == -1) {
+                        autoFocus(aTarget, allEditors.get(0).getFocusComponent());
+                    }
+                    // ... if it is the last one, say at the last one
+                    else if (i >= (allEditors.size() - 1)) {
+                        autoFocus(aTarget, allEditors.get(allEditors.size() - 1)
+                                .getFocusComponent());
+                    }
+                    // ... otherwise move the focus to the next editor
+                    else {
+                        autoFocus(aTarget, allEditors.get(i + 1).getFocusComponent());
+                    }
+                }
+            }
+        }
+        catch (Exception e) {
+            handleException(this, aTarget, e);
         }
     }
 
@@ -1050,5 +971,27 @@ public class AnnotationFeatureForm
         }
         
         aTarget.focusComponent(aComponent);
+    }
+    
+    @OnEvent(stop = true)
+    public void onFeatureUpdatedEvent(FeatureEditorValueChangedEvent aEvent)
+    {
+        AjaxRequestTarget target = aEvent.getTarget();
+        actionFeatureUpdate(aEvent.getEditor(), target);
+    }
+    
+    @OnEvent(stop = true)
+    public void onLinkFeatureDeletedEvent(LinkFeatureDeletedEvent aEvent)
+    {
+        AjaxRequestTarget target = aEvent.getTarget();
+        // Auto-commit if working on existing annotation
+        if (getModelObject().getSelection().getAnnotation().isSet()) {
+            try {
+                editorPanel.actionCreateOrUpdate(target, editorPanel.getEditorCas());
+            }
+            catch (Exception e) {
+                handleException(this, target, e);
+            }
+        }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Extended FeatureEditorEvent to allow access to the sending editor
- Move updating code into the feature editors
- Send events when an update has happened
- Move event handlers from ADEP into AnnotationFeatureForm

**How to test manually**
* Annotate some text with different types of features, also multiple features of different types in a single layer

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
