### PR TITLE
#1571 - Forbid creating relation layers on layers that already have a defined relation

### DIFF
--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
@@ -20,7 +20,9 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.project.layers;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.RELATION_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -29,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -53,6 +56,8 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.resource.IResourceStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.TypeAdapter;
@@ -80,12 +85,16 @@ import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.InputStreamResourceStream;
 import de.tudarmstadt.ukp.clarin.webanno.ui.project.layers.ProjectLayersPanel.FeatureSelectionForm;
 import de.tudarmstadt.ukp.clarin.webanno.ui.project.layers.ProjectLayersPanel.LayerExportMode;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.SurfaceForm;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
 public class LayerDetailForm
     extends Form<AnnotationLayer>
 {
     private static final long serialVersionUID = -1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(LayerDetailForm.class);
 
     private static final String TYPE_PREFIX = "webanno.custom.";
 
@@ -93,8 +102,9 @@ public class LayerDetailForm
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean ApplicationEventPublisherHolder applicationEventPublisherHolder;
 
-    private DropDownChoice<LayerType> layerTypes;
-    private DropDownChoice<AnnotationLayer> attachTypes;
+    private DropDownChoice<LayerType> layerTypeSelect;
+    private DropDownChoice<AnnotationLayer> attachTypeSelect;
+    private Label effectiveAttachType;
 
     private DropDownChoice<AnchoringMode> anchoringMode;
     private DropDownChoice<OverlapMode> overlapMode;
@@ -137,17 +147,17 @@ public class LayerDetailForm
         });
 
         add(new CheckBox("enabled"));
-        add(layerTypes = new BootstrapSelect<>("type"));
-        layerTypes.setChoices(layerSupportRegistry::getAllTypes);
-        layerTypes.add(LambdaBehavior
+        add(layerTypeSelect = new BootstrapSelect<>("type"));
+        layerTypeSelect.setChoices(layerSupportRegistry::getAllTypes);
+        layerTypeSelect.add(LambdaBehavior
                 .enabledWhen(() -> isNull(LayerDetailForm.this.getModelObject().getId())));
-        layerTypes.setRequired(true);
-        layerTypes.setNullValid(false);
-        layerTypes.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
-        layerTypes.setModel(LambdaModelAdapter.of(
+        layerTypeSelect.setRequired(true);
+        layerTypeSelect.setNullValid(false);
+        layerTypeSelect.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
+        layerTypeSelect.setModel(LambdaModelAdapter.of(
             () -> layerSupportRegistry.getLayerType(LayerDetailForm.this.getModelObject()), 
             (v) -> LayerDetailForm.this.getModelObject().setType(v.getName())));
-        layerTypes.add(new AjaxFormComponentUpdatingBehavior("change")
+        layerTypeSelect.add(new AjaxFormComponentUpdatingBehavior("change")
         {
             private static final long serialVersionUID = 6790949494089940303L;
 
@@ -157,75 +167,28 @@ public class LayerDetailForm
                 target.add(crossSentence);
                 target.add(showTextInHover);
                 target.add(linkedListBehavior);
-                target.add(attachTypes);
+                target.add(attachTypeSelect);
                 target.add(anchoringMode);
                 target.add(overlapMode);
             }
         });
 
-        attachTypes = new BootstrapSelect<AnnotationLayer>("attachType")
-        {
-            private static final long serialVersionUID = -6705445053442011120L;
+        attachTypeSelect = new BootstrapSelect<AnnotationLayer>("attachType",
+                LoadableDetachableModel.of(this::getAttachLayerChoices),
+                new ChoiceRenderer<>("uiName"));
+        attachTypeSelect.setNullValid(true);
+        attachTypeSelect.add(visibleWhen(() -> isNull(getModelObject().getId())
+                && RELATION_TYPE.equals(getModelObject().getType())));
+        attachTypeSelect.setOutputMarkupPlaceholderTag(true);
+        add(attachTypeSelect);
 
-            {
-                setChoices(new LoadableDetachableModel<List<AnnotationLayer>>()
-                {
-                    private static final long serialVersionUID = 1784646746122513331L;
-
-                    @Override
-                    protected List<AnnotationLayer> load()
-                    {
-                        AnnotationLayer layer = LayerDetailForm.this.getModelObject();
-                        
-                        List<AnnotationLayer> allLayers = annotationService.listAnnotationLayer(
-                                LayerDetailForm.this.getModelObject().getProject());
-
-                        if (layer.getId() != null) {
-                            if (layer.getAttachType() == null) {
-                                return new ArrayList<>();
-                            }
-
-                            return Arrays.asList(layer.getAttachType());
-                        }
-                        if (!RELATION_TYPE.equals(layer.getType())) {
-                            return new ArrayList<>();
-                        }
-
-                        List<AnnotationLayer> attachTypes = new ArrayList<>();
-                        // remove a span layer which is already used as attach type for the
-                        // other
-                        List<AnnotationLayer> usedLayers = new ArrayList<>();
-                        for (AnnotationLayer l : allLayers) {
-                            if (l.getAttachType() != null) {
-                                usedLayers.add(l.getAttachType());
-                            }
-                        }
-                        allLayers.removeAll(usedLayers);
-
-                        for (AnnotationLayer l : allLayers) {
-                            if (l.getType().equals(SPAN_TYPE)) {
-                                attachTypes.add(l);
-                            }
-                        }
-
-                        return attachTypes;
-                    }
-                });
-                setChoiceRenderer(new ChoiceRenderer<>("uiName"));
-            }
-
-            @Override
-            protected void onConfigure()
-            {
-                super.onConfigure();
-                
-                setEnabled(isNull(LayerDetailForm.this.getModelObject().getId()));
-                setNullValid(isVisible());
-            }
-        };
-        attachTypes.setOutputMarkupPlaceholderTag(true);
-        add(attachTypes);
-
+        effectiveAttachType = new Label("effectiveAttachType",
+                LoadableDetachableModel.of(this::getEffectiveAttachTypeName));
+        effectiveAttachType.setOutputMarkupPlaceholderTag(true);
+        effectiveAttachType.add(visibleWhen(() -> !isNull(getModelObject().getId())
+                && RELATION_TYPE.equals(getModelObject().getType())));
+        add(effectiveAttachType);
+        
         // Behaviors of layers
         add(new CheckBox("readonly"));
 
@@ -324,6 +287,90 @@ public class LayerDetailForm
 
         add(new LambdaAjaxButton<>("save", this::actionSave));
         add(new LambdaAjaxLink("cancel", this::actionCancel));
+    }
+    
+    private String getEffectiveAttachTypeName()
+    {
+        AnnotationLayer layer = LayerDetailForm.this.getModelObject();
+        
+        if (layer.getAttachType() == null) {
+            return null;
+        }
+        
+        
+        if (layer.getAttachFeature() != null) {
+            Project project = getModelObject().getProject();
+            AnnotationLayer actualAttachLayer = annotationService.findLayer(project,
+                    layer.getAttachFeature().getType());
+            return String.format("%s :: %s -> %s", layer.getAttachType().getUiName(),
+                    layer.getAttachFeature().getUiName(), actualAttachLayer.getUiName());
+        }
+        else {
+            return layer.getAttachType().getUiName();
+        }
+    }
+    
+    /**
+     * Gets the list of annotation layers to which a relation layer may attach.
+     */
+    private List<AnnotationLayer> getAttachLayerChoices()
+    {
+        Project project = getModelObject().getProject();
+        AnnotationLayer layer = LayerDetailForm.this.getModelObject();
+
+        // If the layer has already been created, the attach layer cannot be changed anymore. 
+        // So in this case, we return either an empty list of a list with exactly the configured
+        // attach layer in it.
+        if (layer.getId() != null) {
+            if (layer.getAttachType() == null) {
+                return emptyList();
+            }
+
+            if (layer.getAttachFeature() != null) {
+                AnnotationLayer actualAttachLayer = annotationService.findLayer(project,
+                        layer.getAttachFeature().getType());
+                return asList(actualAttachLayer);
+            }
+            else {
+                return asList(layer.getAttachType());
+            }
+        }
+        
+        // Attach layers are only valid for relation layers.
+        if (!RELATION_TYPE.equals(layer.getType())) {
+            return emptyList();
+        }
+
+        // Get all the layers
+        List<AnnotationLayer> allLayers = annotationService.listAnnotationLayer(project);
+        
+        // Candidates for attach-layers are only span layers, so lets filter these
+        List<AnnotationLayer> candidateLayers = allLayers.stream()
+                .filter(l -> SPAN_TYPE.equals(l.getType()))
+                .filter(l -> !Token.class.getName().equals(l.getName())
+                        && !Sentence.class.getName().equals(l.getName()))
+                .collect(Collectors.toCollection(ArrayList::new));
+        
+        // Further narrow down the candidates by removing all layers which are already the target
+        // of an attachment
+        for (AnnotationLayer l : allLayers) {
+            if (l.getAttachType() != null) {
+                // If an attach-feature is configured, then remove the layer to which this feature
+                // points from the candidate list
+                if (l.getAttachFeature() != null) {
+                    AnnotationLayer actualAttachLayer = annotationService.findLayer(project,
+                            l.getAttachFeature().getType());
+                    candidateLayers.remove(actualAttachLayer);
+                }
+                // If no attach-feature is configured, the the attach-layer is the target layer of
+                // the attachment, so remove it from the candidate list
+                else {
+                    candidateLayers.remove(l.getAttachType());
+                }
+            }
+        }
+
+        return candidateLayers;
     }
 
     private void actionSave(AjaxRequestTarget aTarget, Form<?> aForm)

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
@@ -144,12 +144,20 @@
                       <select wicket:id="type" class="form-control" data-container="body"></select>
                     </div>
                   </div>
-                  <div class="form-group">
+                  <div class="form-group" wicket:enclosure="attachType">
                     <label wicket:for="attachType" class="col-sm-4 control-label"> <wicket:label
                         key="attachToLayer" />
                     </label>
                     <div class="col-sm-8">
                       <select wicket:id="attachType" class="form-control" data-container="body"></select>
+                    </div>
+                  </div>
+                  <div class="form-group" wicket:enclosure="effectiveAttachType">
+                    <label class="col-sm-4 control-label"> 
+                      <wicket:message key="attachToLayer" />
+                    </label>
+                    <div class="col-sm-8">
+                      <span wicket:id="effectiveAttachType" class="form-control" readonly/>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
**What's in the PR**
- Take attach-feature into account when offering layers to attach to on relation creation
- Hide attach feature field when not using a relation
- Add a display-only widget which shows the attach layer + attach feature + attach feature target layer for comprehensive information
- Don't allow attaching to the Token or Sentence layers
- Use a more modern lambda-aware code style for building the UI elements in Java

**How to test manually**
* View **Dependency** layer in project settings and see the full attach-layer + attach-feature info
* Go through the different layers and see the attach-feature info appearing and disappearing
* Create a custom relation layer attaching to some other layer - make sure you cannot attach to a layer which has already another relation attached to it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
