### PR TITLE
#1587 - Several format examples cannot be used copy-paste

### DIFF
--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2000.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2000.adoc
@@ -49,22 +49,22 @@ Sentences are separated by a blank new line.
 |====
 
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-He        PRP  B-NP
-reckons   VBZ  B-VP
-the       DT   B-NP
-current   JJ   I-NP
-account   NN   I-NP
-deficit   NN   I-NP
-will      MD   B-VP
-narrow    VB   I-VP
-to        TO   B-PP
-only      RB   B-NP
-#         #    I-NP
-1.8       CD   I-NP
-billion   CD   I-NP
-in        IN   B-PP
-September NNP  B-NP
-.         .    O
+He PRP B-NP
+reckons VBZ B-VP
+the DT B-NP
+current JJ I-NP
+account NN I-NP
+deficit NN I-NP
+will MD B-VP
+narrow VB I-VP
+to TO B-PP
+only RB B-NP
+# # I-NP
+1.8 CD I-NP
+billion CD I-NP
+in IN B-PP
+September NNP B-NP
+. . O
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2002.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2002.adoc
@@ -45,32 +45,29 @@ Sentences are separated by a blank new line.
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-Wolff      B-PER
-,          O
-currently  O
-a          O
+Wolff B-PER
+, O
+currently O
+a O
 journalist O
-in         O
-Argentina  B-LOC
-,          O
-played     O
-with       O
-Del        B-PER
-Bosque     I-PER
-in         O
-the        O
-final      O
-years      O
-of         O
-the        O
-seventies  O
-in         O
-Real       B-ORG
-Madrid     I-ORG
-.          O
+in O
+Argentina B-LOC
+, O
+played O
+with O
+Del B-PER
+Bosque I-PER
+in O
+the O
+final O
+years O
+of O
+the O
+seventies O
+in O
+Real B-ORG
+Madrid I-ORG
+. O
 ----
-
-NOTE: For readability, the columns in the example above are aligned. In actual files, there is only
-      a single space separating the fields in each line.

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2003.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2003.adoc
@@ -51,16 +51,13 @@ category of the current span.
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-U.N.         NNP  I-NP  I-ORG 
-official     NN   I-NP  O 
-Ekeus        NNP  I-NP  I-PER 
-heads        VBZ  I-VP  O 
-for          IN   I-PP  O 
-Baghdad      NNP  I-NP  I-LOC 
-.            .    O     O 
+U.N. NNP I-NP I-ORG
+official NN I-NP O
+Ekeus NNP I-NP I-PER
+heads VBZ I-VP O
+for IN I-PP O
+Baghdad NNP I-NP I-LOC
+. . O O
 ----
-
-NOTE: For readability, the columns in the example above are aligned. In actual files, there is only
-      a single space separating the fields in each line.

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2006.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2006.adoc
@@ -77,7 +77,7 @@ The CoNLL 2006 (aka CoNLL-X) format targets dependency parsing. Columns are tab-
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-Heutzutage heutzutage ADV _ _ ADV _ _
+Heutzutage	heutzutage	ADV	_	_	ADV	_	_
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2009.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2009.adoc
@@ -101,21 +101,21 @@ The CoNLL 2009 format targets semantic role labeling. Columns are tab-separated.
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-1   The the the DT  DT  _   _   4   4   NMOD    NMOD    _   _   _   _
-2   most    most    most    RBS RBS _   _   3   3   AMOD    AMOD    _   _   _   _
-3   troublesome troublesome troublesome JJ  JJ  _   _   4   4   NMOD    NMOD    _   _   _   _
-4   report  report  report  NN  NN  _   _   5   5   SBJ SBJ _   _   _   _
-5   may may may MD  MD  _   _   0   0   ROOT    ROOT    _   _   _   _
-6   be  be  be  VB  VB  _   _   5   5   VC  VC  _   _   _   _
-7   the the the DT  DT  _   _   11  11  NMOD    NMOD    _   _   _   _
-8   August  august  august  NNP NNP _   _   11  11  NMOD    NMOD    _   _   _   AM-TMP
-9   merchandise merchandise merchandise NN  NN  _   _   10  10  NMOD    NMOD    _   _   A1  _
-10  trade   trade   trade   NN  NN  _   _   11  11  NMOD    NMOD    Y   trade.01    _   A1
-11  deficit deficit deficit NN  NN  _   _   6   6   PRD PRD Y   deficit.01  _   A2
-12  due due due JJ  JJ  _   _   13  11  AMOD    APPO    _   _   _   _
-13  out out out IN  IN  _   _   11  12  APPO    AMOD    _   _   _   _
-14  tomorrow    tomorrow    tomorrow    NN  NN  _   _   13  12  TMP TMP _   _   _   _
-15  .   .   .   .   .   _   _   5   5   P   P   _   _   _   _
+1	The	the	the	DT	DT	_	_	4	4	NMOD	NMOD	_	_	_	_
+2	most	most	most	RBS	RBS	_	_	3	3	AMOD	AMOD	_	_	_	_
+3	troublesome	troublesome	troublesome	JJ	JJ	_	_	4	4	NMOD	NMOD	_	_	_	_
+4	report	report	report	NN	NN	_	_	5	5	SBJ	SBJ	_	_	_	_
+5	may	may	may	MD	MD	_	_	0	0	ROOT	ROOT	_	_	_	_
+6	be	be	be	VB	VB	_	_	5	5	VC	VC	_	_	_	_
+7	the	the	the	DT	DT	_	_	11	11	NMOD	NMOD	_	_	_	_
+8	August	august	august	NNP	NNP	_	_	11	11	NMOD	NMOD	_	_	_	AM-TMP
+9	merchandise	merchandise	merchandise	NN	NN	_	_	10	10	NMOD	NMOD	_	_	A1	_
+10	trade	trade	trade	NN	NN	_	_	11	11	NMOD	NMOD	Y	trade.01	_	A1
+11	deficit	deficit	deficit	NN	NN	_	_	6	6	PRD	PRD	Y	deficit.01	_	A2
+12	due	due	due	JJ	JJ	_	_	13	11	AMOD	APPO	_	_	_	_
+13	out	out	out	IN	IN	_	_	11	12	APPO	AMOD	_	_	_	_
+14	tomorrow	tomorrow	tomorrow	NN	NN	_	_	13	12	TMP	TMP	_	_	_	_
+15	.	.	.	.	.	_	_	5	5	P	P	_	_	_	_
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2012.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conll2012.adoc
@@ -17,8 +17,7 @@
 [[sect_formats_conll2012]]
 = CoNLL 2012
 
-The CoNLL 2012 format targets semantic role labeling and coreference. Columns are space-separated. 
-Sentences are separated by a blank new line.
+The CoNLL 2012 format targets semantic role labeling and coreference. Columns are whitespace-separated (tabs or spaces). Sentences are separated by a blank new line.
 
 Note that this format cannot deal with the following situations:
 * An annotation has no label (e.g. a `SemPred` annotation has no category) - in such a case `null` is
@@ -27,7 +26,7 @@ Note that this format cannot deal with the following situations:
 * If a `SemPred` annotation is at the same position as a `SemArg` annotation linked to it, then only
   the `(V*)` representing the `SemPred` annotation will be written.
 * `SemPred` annotations spanning more than one token are not supported
-* If there are multilpe `SemPred` annotations on the same token, then only one of them is written.
+* If there are multiple `SemPred` annotations on the same token, then only one of them is written.
   This is because the `category` of the `SemPred` annotation goes to the  **Predicate Frameset ID** 
   and that can only hold one value which.
 
@@ -101,12 +100,12 @@ Note that this format cannot deal with the following situations:
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-en-orig.conll   0   0       John   NNP   (TOP(S(NP*)      john   -   -          -   (PERSON)       (A0) (1)
-en-orig.conll   0   1       went   VBD         (VP*         go go.02   -          -         *        (V*) -
-en-orig.conll   0   2         to    TO         (PP*         to   -   -          -         *          *  -
-en-orig.conll   0   3        the    DT         (NP*        the   -   -          -         *          *  (2
-en-orig.conll   0   4     market    NN          *)))    market   -   -          -         *        (A1) 2)
-en-orig.conll   0   5          .     .           *))         .   -   -          -         *          *  -
+en-orig.conll	0	0	John	NNP	(TOP(S(NP*)	john	-	-	-	(PERSON)	(A0)	(1)
+en-orig.conll	0	1	went	VBD	(VP*	go	go.02	-	-	*	(V*)	-
+en-orig.conll	0	2	to	TO	(PP*	to	-	-	-	*	*	-
+en-orig.conll	0	3	the	DT	(NP*	the	-	-	-	*	*	(2
+en-orig.conll	0	4	market	NN	*)))	market	-	-	-	*	(A1)	2)
+en-orig.conll	0	5	.	.	*))	.	-	-	-	*	*	-
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conllcorenlp.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conllcorenlp.adoc
@@ -67,14 +67,14 @@ of the tokens simply carry the same label without (no sequence encoding).
 |====
 
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-1  Selectum          Selectum          NNP  O  _  _
-2  ,                 ,                 ,    O  _  _
-3  Société           Société           NNP  O  _  _
-4  d'Investissement  d'Investissement  NNP  O  _  _
-5  à                 à                 NNP  O  _  _
-6  Capital           Capital           NNP  O  _  _
-7  Variable          Variable          NNP  O  _  _
-8  .                 .                 .    O  _  _
+1	Selectum	Selectum	NNP	O	_	_
+2	,	,	,	O	_	_
+3	Société	Société	NNP	O	_	_
+4	d'Investissement	d'Investissement	NNP	O	_	_
+5	à	à	NNP	O	_	_
+6	Capital	Capital	NNP	O	_	_
+7	Variable	Variable	NNP	O	_	_
+8	.	.	.	O	_	_
 ----

--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conllu.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-conllu.adoc
@@ -78,12 +78,12 @@ separated by a blank new line.
 |====
  
 .Example
-[source,text]
+[source,text,tabsize=0]
 ----
-1   They    they    PRON    PRN Case=Nom|Number=Plur    2   nsubj   4:nsubj _
-2   buy buy VERB    VB  Number=Plur|Person=3|Tense=Pres 0   root    _   _
-3   and and CONJ    CC  _   2   cc  _   _
-4   sell    sell    VERB    VB  Number=Plur|Person=3|Tense=Pres 2   conj    0:root  _
-5   books   book    NOUN    NNS Number=Plur 2   dobj    4:dobj  SpaceAfter=No
-6   .   .   PUNCT   .   _   2   punct   _   _
+1	They	they	PRON	PRN	Case=Nom|Number=Plur	2	nsubj	4:nsubj	_
+2	buy	buy	VERB	VB	Number=Plur|Person=3|Tense=Pres	0	root	_	_
+3	and	and	CONJ	CC	_	2	cc	_	_
+4	sell	sell	VERB	VB	Number=Plur|Person=3|Tense=Pres	2	conj	0:root	_
+5	books	book	NOUN	NNS	Number=Plur	2	dobj	4:dobj	SpaceAfter=No
+6	.	.	PUNCT	.	_	2	punct	_	_
 ----

--- a/webanno-io-tsv/src/main/resources/META-INF/asciidoc/user-guide/webannotsv.adoc
+++ b/webanno-io-tsv/src/main/resources/META-INF/asciidoc/user-guide/webannotsv.adoc
@@ -52,14 +52,14 @@ by the Unicode character 😊 (U+1F60A) requires two 16bit units. Hence, the off
 by 2 for this character. So Unicode characters starting at U+10000 increase the offset count by 2.
 
 .Example: TSV sentence containing a Unicode character from the Supplementary Planes
-[source,text]
+[source,text,tabsize=0]
 ----
 #Text=I like it 😊 .
-1-1 0-1 I _ 
-1-2 2-6 like  _ 
-1-3 7-9 it  _ 
-1-4 10-12 😊  * 
-1-5 13-14 . _ 
+1-1	0-1	I	_
+1-2	2-6	like	_
+1-3	7-9	it	_
+1-4	10-12	😊	*
+1-5	13-14	.	_
 ----
 
 NOTE: Since the character offsets are based on UTF-16 and the TSV file itself is encoded in UTF-8,
@@ -77,7 +77,7 @@ After the header, there must be **two** empty lines before the body part contain
 may start. 
 
 .Example: format in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #FORMAT=WebAnno TSV 3.2
 ----
@@ -87,7 +87,7 @@ If all layer type exists, first, all the span layers will be written, then the c
 Features are separated by the `|` character and only the short name of the feature is provided.
 
 .Example: Span layer with simple features in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=webanno.custom.Pred|bestSense|lemmaMapped|senseId|senseMapped
 ----
@@ -98,7 +98,7 @@ Slot features start with a prefix `ROLE_` followed by the name of the role and t
 The target of the slot feature always follows the role/link name
 
 .Example: Span layer with slot features in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=webanno.custom.SemPred|ROLE_webanno.custom.SemPred:RoleSet_webanno.custom.SemPredRoleSetLink|uima.tcas.Annotation|aFrame
 ----
@@ -108,7 +108,7 @@ Here the name of the role is *webanno.custom.SemPred:RoleSet* and the name of th
 Chain layers will have always two features, *referenceType* and *referenceRelation*.
 
 .Example: Chain layers in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_CH=de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceLink|referenceType|referenceRelation
 ----
@@ -116,7 +116,7 @@ Chain layers will have always two features, *referenceType* and *referenceRelati
 Relation layers will come at last in the list and the very last entry in the features will be the type of the base (governor or dependent) annotations with a prefix `BT_`.
 
 .Example: Relation layers in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_RL=de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency|DependencyType|BT_de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS
 ----
@@ -147,7 +147,7 @@ Sentence annotations are presented following the text marker `#Text=`, before th
 annotations. All text given here is inside the sentence boundaries.
 
 .Example: Original text sections
-[source,text]
+[source,text,tabsize=0]
 ----
 #Text=Bell , based in Los Angeles , makes and distributes electronic , computer and building products .
 ----
@@ -162,7 +162,7 @@ multiple `#Text=` lines are generated. Note that carriage return characters (ASC
 as escaped characters (`\r`). 
 
 .Example: Original multi-line text
-[source,text]
+[source,text,tabsize=0]
 ----
 #Text=Bell , based in Los Angeles , makes and distributes
 #Text=electronic , computer and building products .
@@ -178,7 +178,7 @@ Token annotation starts with a `sentence-token` number marker followed by the be
 and the token itself, separated by a TAB characters. 
 
 .Example: Token position
-[source,text]
+[source,text,tabsize=0]
 ----
 1-2	4-8	Haag
 ----
@@ -190,7 +190,7 @@ token while `Haag` is the token.
 Sub-token representations are affixed with a `.` and a number starts from 1 to N. 
 
 .Example: Sub-token positions
-[source,text]
+[source,text,tabsize=0]
 ----
 1-3	9-14	plays
 1-3.1	9-13	play
@@ -203,11 +203,11 @@ indicated by `1-3.2`.
 While tokens may not overlap, sub-tokens may overlap.
 
 .Example: Overlapping sub-tokens
-[source,text]
+[source,text,tabsize=0]
 ----
-1-3 9-14  plays
-1-3.1 9-12  pla
-1-3.2 11-14 ays
+1-3	9-14	plays
+1-3.1	9-12	pla
+1-3.2	11-14	ays
 ----
 
 === Span Annotations
@@ -215,14 +215,14 @@ While tokens may not overlap, sub-tokens may overlap.
 For every features of a span Annotation, annotation value will be presented in the same row as the token/sub-token annotation, separated by a TAB character. If there is no annotation for the given span layer, a `_` character is placed in the column. If the feature has no/null annotation or if the span layer do not have a feature at all, a `*` character represents the annotation.
 
 .Example: Span layer declaration in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue
 #T_SP=webanno.custom.Sentiment|Category|Opinion
 ----
 
 .Example: Span annotations in file body
-[source,text]
+[source,text,tabsize=0]
 ----
 1-9	36-43	unhappy	JJ	abstract	negative
 ----
@@ -253,14 +253,14 @@ reason, disambiguation IDs are introduced in potentially problematic cases:
 The disambiguation ID is attached as a suffix `[N]` to the annotation value. Stacked annotations are separated by `|` character.
 
 .Example: Span layer declaration in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue
 #T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
 ----
 
 .Example: Multi-token span annotations and stacked span annotations
-[source,text]
+[source,text,tabsize=0]
 ----
 1-1	0-3	Ms.	NNP	PER[1]|PERpart[2]
 1-2	4-8	Haag	NNP	PER[1]
@@ -277,14 +277,14 @@ Slot features and the target annotations are separated by TAB character (first t
 Unlike other span layer features (which are separated by `|` character), multiple annotations for a slot feature are separated by the `;` character.
 
 .Example: Span layer declaration in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=webanno.custom.Frame|FE|ROLE_webanno.custom.Frame:Roles_webanno.custom.FrameRolesLink|webanno.custom.Lu
 #T_SP=webanno.custom.Lu|luvalue
 ----
 
 .Example: Span annotations and slot features
-[source,text]
+[source,text,tabsize=0]
 ----
 2-1	27-30	Bob	_	_	_	bob
 2-2	31-40	auctioned	transaction	seller;goods;buyer	2-1;2-3[4];2-6
@@ -308,7 +308,7 @@ In the Chain annotation, two columns (TAB separated) are used to represent the `
 ----
 
 .Example: Chain annotations
-[source,text]
+[source,text,tabsize=0]
 ----
 1-1	0-2	He	pr[1]	coref->1-1
 1-2	3-7	shot	_	_
@@ -326,14 +326,14 @@ In this example, token `1-3` is marked as `pr[1]` which indicates that the *refe
 Relation annotations comes to the last columns of the TSV file format. Just like the span annotations, every feature of the relation layers are represented in a separate TAB. Besides, one extra column (after all feature values) is used to write the token id from which token/sub-token this arc of a relation annotation is drawn.
 
 .Example: Span and relation layer declaration in file header
-[source,text]
+[source,text,tabsize=0]
 ----
 #T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue
 #T_RL=de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency|DependencyType|BT_de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS
 ----
 
 .Example: Span and relation annotations
-[source,text]
+[source,text,tabsize=0]
 ----
 1-1	0-3	Ms.	NNP	SUBJ	1-3
 1-2	4-8	Haag	NNP	SBJ	1-3
@@ -351,7 +351,7 @@ appears with the ID `0`. E.g. in the example below, the annotation on token `1-5
 but the annotation on token `1-1` is not.
 
 .Example: Disambiguation IDs in relations
-[source,text]
+[source,text,tabsize=0]
 ----
 #FORMAT=WebAnno TSV 3.2
 #T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
@@ -359,10 +359,9 @@ but the annotation on token `1-1` is not.
 
 
 #Text=This is a test .
-1-1 0-4 This  * _ _ 
-1-2 5-7 is  _ _ _ 
-1-3 8-9 a _ _ _ 
-1-4 10-14 test  _ _ _ 
-1-5 15-16 . *[1]|*[2] * 1-1[0_1]
+1-1	0-4	This	*	_	_
+1-2	5-7	is	_	_	_
+1-3	8-9	a	_	_	_
+1-4	10-14	test	_	_	_
+1-5	15-16	.	*[1]|*[2]	*	1-1[0_1]
 ----
-  


### PR DESCRIPTION
**What's in the PR**
- Disable auto-conversion of tabs to spaces
- Fix examples

**How to test manually**
* Copy-paste some of the CoNLL examples to files and then try to import them.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
