### PR TITLE
#1589 Changing order of Tabs in Settings

### DIFF
--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPage.html
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/ProjectPage.html
@@ -25,7 +25,7 @@
         <wicket:container wicket:id="projects" />
         <wicket:container wicket:id="importPanel" />
       </div>
-      <div wicket:id ="tabContainer" class="flex-content flex-v-container flex-gutter">
+      <div wicket:id ="tabContainer" class="flex-content flex-v-container flex-gutter" name="tabContainer">
         <div class="page-header flex-h-container">
           <div class="flex-content">
             <h1><wicket:container wicket:id="projectName"/></h1>

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UsersProjectSettingsPanelFactory.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UsersProjectSettingsPanelFactory.java
@@ -26,7 +26,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelFactory;
 
 @Component
-@Order(200)
+@Order(250)
 public class UsersProjectSettingsPanelFactory
     implements ProjectSettingsPanelFactory
 {


### PR DESCRIPTION
**What's in the PR**
Changed component order of *Users* tab on *Settings Page*. Also gave the tabcontainer on the page a name, so I can reference it in js.

**How to test manually**
* Look at Settings page and make sure that all tabs are still there and the Documents tab comes before the Users tab.
