### PR TITLE
Feature/1615 reduce time when importing a large number of documents via the ui

### DIFF
--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -80,13 +80,14 @@ public class DocumentServiceImplTest
 
         sut = new DocumentServiceImpl(repositoryProperties, userRepository, storageService,
                 importExportService, projectService, applicationEventPublisher, entityManager);
+        
+        when(importExportService.importCasFromFile(any(File.class), any(Project.class),
+                any(), any())).thenReturn(JCasFactory.createText("Test").getCas());
     }
 
     @Test
     public void thatCreatingOrReadingInitialCasForNewDocumentCreatesNewCas() throws Exception
     {
-        when(importExportService.importCasFromFile(any(File.class), any(Project.class),
-                any())).thenReturn(JCasFactory.createText("Test").getCas());
 
         SourceDocument doc = makeSourceDocument(1l, 1l, "test");
 
@@ -104,8 +105,6 @@ public class DocumentServiceImplTest
         User user = makeUser();
         when(userRepository.get(user.getUsername())).thenReturn(user);
         when(entityManager.createQuery(anyString(), any())).thenThrow(NoResultException.class);
-        when(importExportService.importCasFromFile(any(File.class), any(Project.class),
-                any())).thenReturn(JCasFactory.createText("Test").getCas());
 
         JCas cas = sut.readAnnotationCas(sourceDocument, user.getUsername()).getJCas();
 

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ImportExportServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/ImportExportServiceImplTest.java
@@ -86,8 +86,6 @@ public class ImportExportServiceImplTest
         sut.onContextRefreshedEvent();
         
         when(schemaService.listAnnotationLayer(any(Project.class))).thenReturn(emptyList());
-        // We don't want to re-write the prepareCasForExport method - call the original
-        when(schemaService.prepareCasForExport(any(), any())).thenCallRealMethod();
         // The prepareCasForExport method internally calls getFullProjectTypeSystem, so we need to
         // ensure this is actually callable and doesn't run into a mocked version which simply 
         // returns null.

--- a/webanno-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/webanno-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -21,6 +21,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -60,7 +61,7 @@ public interface FormatSupport
     /**
      * @return a UIMA reader description.
      */
-    default CollectionReaderDescription getReaderDescription()
+    default CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
         throw new UnsupportedOperationException("The format [" + getName() + "] cannot be read");
@@ -69,7 +70,8 @@ public interface FormatSupport
     /**
      * @return a UIMA reader description.
      */
-    default AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    default AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         throw new UnsupportedOperationException("The format [" + getName() + "] cannot be written");

--- a/webanno-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportDescription.java
+++ b/webanno-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportDescription.java
@@ -26,6 +26,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -72,7 +73,8 @@ public class FormatSupportDescription
 
     @SuppressWarnings("unchecked")
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         if (!isReadable()) {
             throw new UnsupportedOperationException("The format [" + getName() + "] cannot be read");
@@ -86,12 +88,13 @@ public class FormatSupportDescription
             throw new ResourceInitializationException(e);
         }
         
-        return createReaderDescription(readerClazz);
+        return createReaderDescription(readerClazz, aTSD);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         if (!isReadable()) {
@@ -106,6 +109,6 @@ public class FormatSupportDescription
             throw new ResourceInitializationException(e);
         }
 
-        return createEngineDescription(writerClazz);
+        return createEngineDescription(writerClazz, aTSD);
     }
 }

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -28,6 +28,7 @@ import javax.persistence.NoResultException;
 
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
@@ -137,10 +138,6 @@ public interface DocumentService
     void removeSourceDocument(SourceDocument document)
         throws IOException;
 
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER','ROLE_REMOTE')")
-    void uploadSourceDocument(File file, SourceDocument document)
-        throws IOException, UIMAException;
-
     /**
      * Upload a SourceDocument, obtained as Inputstream, such as from remote API Zip folder to a
      * repository directory. This way we don't need to create the file to a temporary folder
@@ -156,6 +153,27 @@ public interface DocumentService
      */
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER','ROLE_REMOTE')")
     void uploadSourceDocument(InputStream file, SourceDocument document)
+        throws IOException, UIMAException;
+
+    /**
+     * Upload a SourceDocument, obtained as Inputstream, such as from remote API Zip folder to a
+     * repository directory. This way we don't need to create the file to a temporary folder
+     *
+     * @param file
+     *            the file.
+     * @param document
+     *            the source document.
+     * @param aFullProjectTypeSystem
+     *            the project type system. If this parameter is {@code null}, then the method will
+     *            try to resolve the type system itself. 
+     * @throws IOException
+     *             if an I/O error occurs.
+     * @throws UIMAException
+     *             if a conversion error occurs.
+     */
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER','ROLE_REMOTE')")
+    void uploadSourceDocument(InputStream file, SourceDocument document,
+            TypeSystemDescription aFullProjectTypeSystem)
         throws IOException, UIMAException;
 
     /**
@@ -402,6 +420,25 @@ public interface DocumentService
      *             if there was a problem loading the CAS.
      */
     CAS createOrReadInitialCas(SourceDocument aDocument, CasUpgradeMode aUpgradeMode)
+        throws IOException;
+
+    /**
+     * Read the initial CAS for the given document. If the CAS does not exist then it is created.
+     * This method is good for bulk-importing because it accepts the project type system as a
+     * parameter instead of collecting it on every call.
+     * 
+     * @param aDocument
+     *            the source document.
+     * @param aUpgradeMode
+     *            whether to upgrade the type system in the CAS.
+     * @param aFullProjectTypeSystem
+     *            the project type system.
+     * @return the CAS.
+     * @throws IOException
+     *             if there was a problem loading the CAS.
+     */
+    CAS createOrReadInitialCas(SourceDocument aDocument, CasUpgradeMode aUpgradeMode,
+            TypeSystemDescription aFullProjectTypeSystem)
         throws IOException;
 
     /**

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ImportExportService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ImportExportService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
@@ -86,7 +87,9 @@ public interface ImportExportService
     // --------------------------------------------------------------------------------------------
     
     /**
-     * Convert a file to a CAS.
+     * Convert a file to a CAS. This method collects the project's type system as part of the call.
+     * It is not well-suited for bulk-imports. For these, use 
+     * {@link #importCasFromFile(File, Project, String, TypeSystemDescription)} instead.
      *
      * @param aFile
      *            the file.
@@ -102,6 +105,29 @@ public interface ImportExportService
      */
     CAS importCasFromFile(File aFile, Project aProject, String aFormatId)
         throws UIMAException, IOException;
+
+    /**
+     * Convert a file to a CAS. This method is good for bulk-importing because it accepts the 
+     * project type system as a parameter instead of collecting it on every call.
+     *
+     * @param aFile
+     *            the file.
+     * @param aProject
+     *            the project to which this file belongs (required to get the type system).
+     * @param aFormatId
+     *            ID of a supported file format
+     * @param aFullProjectTypeSystem
+     *            the project type system. If this parameter is {@code null}, then the method will
+     *            try to resolve the type system itself. 
+     * @return the CAS.
+     * @throws UIMAException
+     *             if a conversion error occurs.
+     * @throws IOException
+     *             if an I/O error occurs.
+     */    
+    CAS importCasFromFile(File aFile, Project aProject, String aFormatId,
+            TypeSystemDescription aFullProjectTypeSystem)
+                    throws UIMAException, IOException;
 
     /**
      * Exports the given CAS to a file on disk. 

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2002Reader;
 import org.dkpro.core.io.conll.Conll2002Writer;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class Conll2000FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2002Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2002Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2000Reader;
 import org.dkpro.core.io.conll.Conll2000Writer;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class Conll2002FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2000Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2000Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2003FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2003FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2003Reader;
 import org.dkpro.core.io.conll.Conll2003Writer;
 import org.springframework.stereotype.Component;
@@ -64,13 +65,15 @@ public class Conll2003FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2003Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2003Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2006FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2006FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2006Reader;
 import org.dkpro.core.io.conll.Conll2006Writer;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class Conll2006FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2006Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2006Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2009FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2009FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2009Reader;
 import org.dkpro.core.io.conll.Conll2009Writer;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class Conll2009FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2009Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2009Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2012FormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2012FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2012Reader;
 import org.dkpro.core.io.conll.Conll2012Writer;
 import org.springframework.stereotype.Component;
@@ -63,7 +64,8 @@ public class Conll2012FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(Conll2012Reader.class,
                 // Constituents are not supported by WebAnno and trying to read a file which does
@@ -72,7 +74,8 @@ public class Conll2012FormatSupport
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(Conll2012Writer.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpFormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.ConllCoreNlpReader;
 import org.dkpro.core.io.conll.ConllCoreNlpWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class ConllCoreNlpFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(ConllCoreNlpReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(ConllCoreNlpWriter.class);

--- a/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
+++ b/webanno-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.ConllUReader;
 import org.dkpro.core.io.conll.ConllUWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class ConllUFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(ConllUReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         // TODO: The backported ConllUWriter should be removed again when DKPro Core 2.0.1 or higher

--- a/webanno-io-json/src/main/java/de/tudarmstadt/ukp/clarin/webanno/json/JsonFormatSupport.java
+++ b/webanno-io-json/src/main/java/de/tudarmstadt/ukp/clarin/webanno/json/JsonFormatSupport.java
@@ -22,6 +22,7 @@ import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDesc
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.json.JsonWriter;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +55,8 @@ public class JsonFormatSupport
     }
 
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(JsonWriter.class);

--- a/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfFormatSupport.java
+++ b/webanno-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.tcf.TcfReader;
 import org.dkpro.core.io.tcf.TcfWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class TcfFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(TcfReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(TcfWriter.class);

--- a/webanno-io-tei/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tei/TeiFormatSupport.java
+++ b/webanno-io-tei/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tei/TeiFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -51,7 +52,8 @@ public class TeiFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(TeiReader.class);
     }

--- a/webanno-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextFormatSupport.java
+++ b/webanno-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -51,7 +52,8 @@ public class LineOrientedTextFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(LineOrientedTextReader.class);
     }

--- a/webanno-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
+++ b/webanno-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.text.TextReader;
 import org.dkpro.core.io.text.TextWriter;
 import org.springframework.stereotype.Component;
@@ -63,15 +64,17 @@ public class TextFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
-        return createReaderDescription(TextReader.class);
+        return createReaderDescription(TextReader.class, aTSD);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(TextWriter.class);
+        return createEngineDescription(TextWriter.class, aTSD);
     }
 }

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -51,7 +52,8 @@ public class WebAnnoTsv1FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(WebannoTsv1Reader.class);
     }

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -51,7 +52,8 @@ public class WebAnnoTsv2FormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(WebannoTsv2Reader.class);
     }

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -61,13 +62,15 @@ public class WebAnnoTsv3FormatSupport
     }
     
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(WebannoTsv3XReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(WebannoTsv3XWriter.class);

--- a/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3LegacyFormatSupport.java
+++ b/webanno-io-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3LegacyFormatSupport.java
@@ -31,6 +31,7 @@ import org.apache.uima.cas.Type;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
@@ -85,13 +86,15 @@ public class WebAnnoTsv3LegacyFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(WebannoTsv3Reader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         List<AnnotationLayer> layers = annotationService.listAnnotationLayer(aProject);

--- a/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/BinaryCasFormatSupport.java
+++ b/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/BinaryCasFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.bincas.BinaryCasReader;
 import org.dkpro.core.io.bincas.BinaryCasWriter;
 import org.springframework.stereotype.Component;
@@ -37,7 +38,7 @@ public class BinaryCasFormatSupport
 {
     public static final String ID = "bin";
     public static final String NAME = "UIMA binary CAS";
-    
+
     @Override
     public String getId()
     {
@@ -55,7 +56,7 @@ public class BinaryCasFormatSupport
     {
         return true;
     }
-    
+
     @Override
     public boolean isWritable()
     {
@@ -63,15 +64,17 @@ public class BinaryCasFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
-    {
-        return createReaderDescription(BinaryCasReader.class);
-    }
-    
-    @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createEngineDescription(BinaryCasWriter.class);
+        return createReaderDescription(BinaryCasReader.class, aTSD);
+    }
+
+    @Override
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        return createEngineDescription(BinaryCasWriter.class, aTSD);
     }
 }

--- a/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiFormatSupport.java
+++ b/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xmi.XmiReader;
 import org.dkpro.core.io.xmi.XmiWriter;
 import org.springframework.stereotype.Component;
@@ -63,14 +64,16 @@ public class XmiFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(XmiReader.class,
                 XmiReader.PARAM_LENIENT, true);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(XmiWriter.class);

--- a/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
+++ b/webanno-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
@@ -19,12 +19,16 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.project.documents;
 
 import static java.util.Objects.isNull;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -39,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -56,6 +61,7 @@ public class ImportDocumentsPanel extends Panel
     
     private @SpringBean DocumentService documentService;
     private @SpringBean ImportExportService importExportService;
+    private @SpringBean AnnotationSchemaService annotationService;
     
     private FileUploadField fileUpload;
 
@@ -105,23 +111,47 @@ public class ImportDocumentsPanel extends Panel
         
         List<FileUpload> uploadedFiles = fileUpload.getFileUploads();
         Project project = projectModel.getObject();
+        
         if (isEmpty(uploadedFiles)) {
             error("No document is selected to upload, please select a document first");
             return;
         }
+        
         if (isNull(project.getId())) {
             error("Project not yet created, please save project details!");
             return;
         }
 
+        TypeSystemDescription fullProjectTypeSystem;
+        try {
+            fullProjectTypeSystem = annotationService
+                    .getFullProjectTypeSystem(project);
+        }
+        catch (Exception e) {
+            error("Unable to acquire the type system for project: " + getRootCauseMessage(e));
+            LOG.error("Unable to acquire the type system for project [{}]({})", project.getName(),
+                    project.getId(), e);
+            return;
+        }
+        
+        // Fetching all documents at once here is faster than calling existsSourceDocument() for
+        // every imported document
+        Set<String> existingDocuments = documentService.listSourceDocuments(project).stream()
+                .map(SourceDocument::getName)
+                .collect(Collectors.toCollection(HashSet::new));
+        
         for (FileUpload documentToUpload : uploadedFiles) {
             String fileName = documentToUpload.getClientFileName();
 
-            if (documentService.existsSourceDocument(project, fileName)) {
-                error("Document " + fileName + " already uploaded ! Delete "
+            if (existingDocuments.contains(fileName)) {
+                error("Document [" + fileName + "] already uploaded ! Delete "
                         + "the document if you want to upload again");
                 continue;
             }
+
+            // Add the imported document to the set of existing documents just in case the user
+            // somehow manages to upload two files with the same name...
+            existingDocuments.add(fileName);
 
             try {
                 SourceDocument document = new SourceDocument();
@@ -131,9 +161,9 @@ public class ImportDocumentsPanel extends Panel
                         .get().getId());
                 
                 try (InputStream is = documentToUpload.getInputStream()) {
-                    documentService.uploadSourceDocument(is, document);
+                    documentService.uploadSourceDocument(is, document, fullProjectTypeSystem);
                 }
-                info("File [" + fileName + "] has been imported successfully!");
+                info("Document [" + fileName + "] has been imported successfully!");
             }
             catch (Exception e) {
                 error("Error while uploading document " + fileName + ": "

--- a/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_documents.adoc
+++ b/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_documents.adoc
@@ -4,6 +4,13 @@ To add or delete documents, you have to click on the tab *Documents* in the proj
 
 image::project6.jpg[align="center"]
 
-Choose a document by clicking on *Choose Files*. Please mind the format, which you have to choose above. Then click on *Import Document*. 
-The imported documents can be seen in the frame below.
+Open the upload dialog by on *Choose Files*. If you browser supports uploading multiple documents, you can usually either select a range of files or multiple files individually. To select a range, click on the fist document, press *SHIFT* and then clicking on the last document in the desired range. To (de)select individual files, press *CTRL* and then the file you want to (de)select.
+
+Select the *Format* corresponding to the documents you upload. If you are uploading multiple documents at once, the all must have the same format.
+
+Then click on *Import Document*. 
+The imported documents can be seen in the list below.
 To delete a document from the project, you have to click on it and then click on *Delete* in the right lower corner.
+
+.Uploading large numbers of documents
+While it is possible to upload multiple documents at once, there are limits to how many documents can be uploaded in a single upload operation. For a start, it can take quite some time to upload thousands of documents. Also, the server configuration limits the individual file size and total batch size (the default limit is 100MB for both). Finally, browsers differ in their capability of dealing with large numbers of documents in an upload. In a test with 5000 documents of each ca. 2.5kb size including Chrome, Safari and Firebird, only Chrome (80.0.3987.122) completed the operation successfully. Safari (13.0.5) was only able to do upload about 3400 documents. Firebird (73.0.1) froze during the upload and was unable to deliver anything to the server. With a lower number of documents (e.g. 500), none of the browsers had any problems.


### PR DESCRIPTION
**What's in the PR**
- Introduce additional signatures for import-relevant methods which accept the project's type system thus not requiring them to always aquire it themselves
- Aquire the project type system once during upload in ImportDocumentsPanel
- Avoid asking uimaFIT to collect the type system from the classpath when creating importer / exporter components
- Add information about uploading many documents to the documentation
- Improve import speed in ImportDocumentsPanel by checking once for the existing documents instead of repeatedly hitting the DB

**How to test manually**
* Upload like 5000 documents of 2k using Chrome (works best)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
