### PR TITLE
Bugfix/1623 exporting xmi creates two kinds of document meta data

### DIFF
--- a/webanno-api-annotation/pom.xml
+++ b/webanno-api-annotation/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-document-annotation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
     </dependency>
     <dependency>

--- a/webanno-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtilTest.java
+++ b/webanno-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtilTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.util;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.createCas;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.getRealCas;
+import static org.apache.uima.cas.CAS.TYPE_NAME_DOCUMENT_ANNOTATION;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.jcas.tcas.DocumentAnnotation;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.junit.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class WebAnnoCasUtilTest
+{
+    @Test
+    public void thatCreateDocumentMetadataUpgradesExistingDocumentAnnotation() throws Exception
+    {
+        TypeSystemDescription tsd = createTypeSystemDescription();
+        
+        CAS cas = getRealCas(createCas(tsd));
+        
+        assertThat(cas.select(DocumentAnnotation.class).asList())
+                .as("CAS has no DocumentAnnotation")
+                .isEmpty();
+        
+        cas.setDocumentLanguage("en");
+        
+        assertThat(cas.select(DocumentAnnotation.class).asList())
+                .as("CAS initialized with DocumentAnnotation")
+                .extracting(fs -> fs.getType().getName())
+                .containsExactly(TYPE_NAME_DOCUMENT_ANNOTATION);
+        assertThat(cas.select(DocumentAnnotation.class).asList())
+                .as("Language has been set")
+                .extracting(DocumentAnnotation::getLanguage)
+                .containsExactly("en");
+
+        WebAnnoCasUtil.createDocumentMetadata(cas);
+
+        assertThat(cas.select(DocumentAnnotation.class).asList())
+                .as("DocumentAnnotation has been upgraded to DocumentMetaData")
+                .extracting(fs -> fs.getType().getName())
+                .containsExactly(DocumentMetaData.class.getName());
+        assertThat(cas.select(DocumentAnnotation.class).asList())
+                .as("Language survived upgrade")
+                .extracting(DocumentAnnotation::getLanguage)
+                .containsExactly("en");
+    }
+}

--- a/webanno-api-dao/pom.xml
+++ b/webanno-api-dao/pom.xml
@@ -125,6 +125,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-document-annotation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
     </dependency>
 

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasPersistenceUtilsTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasPersistenceUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.jcas.tcas.DocumentAnnotation;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class CasPersistenceUtilsTest
+{
+    public @Rule TemporaryFolder testFolder = new TemporaryFolder();
+    
+    {
+        System.setProperty(CASImpl.ALWAYS_HOLD_ONTO_FSS, "true");
+    }
+    
+    @Test
+    public void thatDocumentAnnotationIsNotDuplicatedDuringLoad() throws Exception
+    {
+        CAS cas = CasFactory.createCas();
+        
+        cas.setDocumentLanguage("en");
+        
+        DocumentMetaData dmd = DocumentMetaData.create(cas);
+        dmd.setLanguage("en");
+        
+        File file = testFolder.newFile();
+        
+        CasPersistenceUtils.writeSerializedCas(cas, file);
+        
+        CAS cas2 = CasCreationUtils.createCas((TypeSystemDescription) null, null, null);
+        
+        CasPersistenceUtils.readSerializedCas(cas2, file);
+        
+        assertThat(cas2.select(DocumentAnnotation.class).asList())
+                .extracting(fs -> fs.getType().getName())
+                .containsExactly(DocumentMetaData.class.getName());
+    }
+
+//    @Test
+//    public void importExportService() throws Exception
+//    {
+//        TypeSystemDescription tsd = createTypeSystemDescriptionFromPath(
+//                "src/test/resources/xmi/test-types.xml");
+//        
+//        File inFile = new File("src/test/resources/xmi/rdxruC2B.xmi");
+//        
+//        
+//        ImportExportServiceImpl imExSrv = new ImportExportServiceImpl(null,
+//                asList(new XmiFormatSupport()), null, null);
+//        imExSrv.init();
+//        imExSrv.importCasFromFile(inFile, null, XmiFormatSupport.ID, tsd);
+//    }
+    
+}

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasPersistenceUtilsTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasPersistenceUtilsTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.jcas.tcas.DocumentAnnotation;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -58,25 +59,12 @@ public class CasPersistenceUtilsTest
         CAS cas2 = CasCreationUtils.createCas((TypeSystemDescription) null, null, null);
         
         CasPersistenceUtils.readSerializedCas(cas2, file);
-        
+
+        assertThat((AnnotationFS) cas2.getDocumentAnnotation())
+                .isInstanceOf(DocumentMetaData.class);
+
         assertThat(cas2.select(DocumentAnnotation.class).asList())
                 .extracting(fs -> fs.getType().getName())
                 .containsExactly(DocumentMetaData.class.getName());
     }
-
-//    @Test
-//    public void importExportService() throws Exception
-//    {
-//        TypeSystemDescription tsd = createTypeSystemDescriptionFromPath(
-//                "src/test/resources/xmi/test-types.xml");
-//        
-//        File inFile = new File("src/test/resources/xmi/rdxruC2B.xmi");
-//        
-//        
-//        ImportExportServiceImpl imExSrv = new ImportExportServiceImpl(null,
-//                asList(new XmiFormatSupport()), null, null);
-//        imExSrv.init();
-//        imExSrv.importCasFromFile(inFile, null, XmiFormatSupport.ID, tsd);
-//    }
-    
 }

--- a/webanno-diag/pom.xml
+++ b/webanno-diag/pom.xml
@@ -36,6 +36,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-document-annotation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
     </dependency>
     <dependency>

--- a/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/UniqueDocumentAnnotationCheck.java
+++ b/webanno-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/UniqueDocumentAnnotationCheck.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.jcas.tcas.DocumentAnnotation;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.logging.LogMessage;
+
+/**
+ * Checks that there is only a single {@link DocumentAnnotation} (or subclass) in the CAS.
+ */
+public class UniqueDocumentAnnotationCheck
+    implements Check
+{
+    @Override
+    public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages)
+    {
+        if (aCas.select(DocumentAnnotation.class).count() > 1) {
+            aMessages.add(LogMessage.error(this, "There is more than one document annotation!"));
+            return false;
+        }
+        
+        return true;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added workaround for bug / upstream bug
- Added unit test

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
