### PR TITLE
#1635 - Guidelines and project log not properly reimported

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/GuildelinesExporter.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/GuildelinesExporter.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao.export.exporters;
 
+import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
+import static org.apache.commons.io.FileUtils.forceMkdir;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
@@ -91,16 +94,15 @@ public class GuildelinesExporter
             // Strip leading "/" that we had in ZIP files prior to 2.0.8 (bug #985)
             String entryName = ZipUtils.normalizeEntryName(entry);
             
-            if (entryName.startsWith(GUIDELINES_FOLDER + "/")) {
+            if (entryName.startsWith(GUIDELINE + "/")) {
                 String fileName = FilenameUtils.getName(entry.getName());
                 if (fileName.trim().isEmpty()) {
                     continue;
                 }
                 File guidelineDir = projectService.getGuidelinesFolder(aProject);
-                FileUtils.forceMkdir(guidelineDir);
-                FileUtils.copyInputStreamToFile(aZip.getInputStream(entry), new File(guidelineDir,
-                        fileName));
-                
+                forceMkdir(guidelineDir);
+                copyInputStreamToFile(aZip.getInputStream(entry), new File(guidelineDir, fileName));
+ 
                 log.info("Imported guideline [" + fileName + "] for project [" + aProject.getName()
                         + "] with id [" + aProject.getId() + "]");
             }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/ProjectLogExporter.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/ProjectLogExporter.java
@@ -42,7 +42,8 @@ import de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils;
 public class ProjectLogExporter
     implements ProjectExporter
 {
-    private static final String LOG_FOLDER = "/" + ProjectService.LOG_FOLDER;
+    private static final String LOG = ProjectService.LOG_FOLDER;
+    private static final String LOG_FOLDER = "/" + LOG;
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -83,7 +84,7 @@ public class ProjectLogExporter
             // Strip leading "/" that we had in ZIP files prior to 2.0.8 (bug #985)
             String entryName = ZipUtils.normalizeEntryName(entry);
 
-            if (entryName.startsWith(LOG_FOLDER + "/")) {
+            if (entryName.startsWith(LOG + "/")) {
                 FileUtils.copyInputStreamToFile(aZip.getInputStream(entry),
                         projectService.getProjectLogFile(aProject));
                 log.info("Imported log for project [" + aProject.getName() + "] with id ["


### PR DESCRIPTION
**What's in the PR**
- Fix ZIP entry names where code looks for project log and guidelines

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
