### PR TITLE
#1629 - Hide/Invisible Link Feature in annotation view

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -307,12 +307,12 @@ public interface AnnotationSchemaService
      * List all the features in a {@link AnnotationLayer} for this {@link Project}. This includes
      * disabled features.
      * 
-     * @param type
+     * @param aLayer
      *            the layer.
      * 
      * @return the features.
      */
-    List<AnnotationFeature> listAnnotationFeature(AnnotationLayer type);
+    List<AnnotationFeature> listAnnotationFeature(AnnotationLayer aLayer);
 
     /**
      * List all features in the project. This includes disabled features.
@@ -326,7 +326,7 @@ public interface AnnotationSchemaService
     /**
      * List enabled features in a {@link AnnotationLayer} for this {@link Project}.
      * 
-     * @param type
+     * @param aLayer
      *            the layer.
      * 
      * @return the features.

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -304,7 +304,8 @@ public interface AnnotationSchemaService
     List<AnnotationFeature> listAttachedLinkFeatures(AnnotationLayer layer);
      
     /**
-     * List all the features in a {@link AnnotationLayer} for this {@link Project}
+     * List all the features in a {@link AnnotationLayer} for this {@link Project}. This includes
+     * disabled features.
      * 
      * @param type
      *            the layer.
@@ -314,7 +315,7 @@ public interface AnnotationSchemaService
     List<AnnotationFeature> listAnnotationFeature(AnnotationLayer type);
 
     /**
-     * List all features in the project
+     * List all features in the project. This includes disabled features.
      * 
      * @param project
      *            the project.
@@ -322,6 +323,16 @@ public interface AnnotationSchemaService
      */
     List<AnnotationFeature> listAnnotationFeature(Project project);
 
+    /**
+     * List enabled features in a {@link AnnotationLayer} for this {@link Project}.
+     * 
+     * @param type
+     *            the layer.
+     * 
+     * @return the features.
+     */
+    List<AnnotationFeature> listEnabledFeatures(AnnotationLayer aLayer);
+    
     /**
      * list all {@link Tag} in the system
      *

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
+import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
 import static java.util.Collections.emptyList;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.selectCovered;
@@ -45,8 +47,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VRange;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VSpan;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.TypeUtil;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
-import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 
 /**
  * Render spans.
@@ -106,9 +106,13 @@ public class SpanRenderer
 
             // Render slots
             int fi = 0;
-            for (AnnotationFeature feat : typeAdapter.listFeatures()) {
-                if (MultiValueMode.ARRAY.equals(feat.getMultiValueMode())
-                        && LinkMode.WITH_ROLE.equals(feat.getLinkMode())) {
+            nextFeature: for (AnnotationFeature feat : typeAdapter.listFeatures()) {
+                if (!feat.isEnabled()) {
+                    continue nextFeature;
+                }
+                
+                if (ARRAY.equals(feat.getMultiValueMode())
+                        && WITH_ROLE.equals(feat.getLinkMode())) {
                     List<LinkWithRoleModel> links = typeAdapter.getFeatureValue(feat, fs);
                     for (int li = 0; li < links.size(); li++) {
                         LinkWithRoleModel link = links.get(li);

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -644,9 +644,33 @@ public class AnnotationSchemaServiceImpl
             return new ArrayList<>();
         }
 
-        return entityManager
-                .createQuery("FROM AnnotationFeature  WHERE layer =:layer ORDER BY uiName",
-                        AnnotationFeature.class).setParameter("layer", aLayer).getResultList();
+        String query = String.join("\n",
+                "FROM AnnotationFeature",
+                "WHERE layer = :layer",
+                "ORDER BY uiName");
+        
+        return entityManager.createQuery(query, AnnotationFeature.class)
+                .setParameter("layer", aLayer)
+                .getResultList();
+    }
+
+    @Override
+    @Transactional
+    public List<AnnotationFeature> listEnabledFeatures(AnnotationLayer aLayer)
+    {
+        if (isNull(aLayer) || isNull(aLayer.getId())) {
+            return new ArrayList<>();
+        }
+
+        String query = String.join("\n",
+                "FROM AnnotationFeature",
+                "WHERE layer = :layer",
+                "AND enabled = true",
+                "ORDER BY uiName");
+        
+        return entityManager.createQuery(query, AnnotationFeature.class)
+                .setParameter("layer", aLayer)
+                .getResultList();
     }
 
     @Override
@@ -844,7 +868,7 @@ public class AnnotationSchemaServiceImpl
         // Types declared within the project
         typeSystems.add(getCustomProjectTypes(aProject));
 
-        return (TypeSystemDescription_impl) mergeTypeSystems(typeSystems);
+        return mergeTypeSystems(typeSystems);
     }
     
     @Override


### PR DESCRIPTION
**What's in the PR**
- Skip disabled link features during rendering

**How to test manually**
* Create an annotation of type **SemPred** and link to a **SemArg**
* Enter project settings and disable **arguments** feature on the **SemPred** layer
* View again on the annotation page and see that there is no link rendered anymore

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
