### PR TITLE
#1648 Opening the sidebar jumps document back to first page

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -538,7 +538,12 @@ public class AnnotationPage
                 StringValue project = aRequestParameters.getParameterValue(PAGE_PARAM_PROJECT_ID);
                 StringValue document = aRequestParameters.getParameterValue(PAGE_PARAM_DOCUMENT_ID);
                 StringValue focus = aRequestParameters.getParameterValue(PAGE_PARAM_FOCUS);
-
+                
+                // nothing changed, do not check for project, because inception always opens 
+                // on a project
+                if (document.isEmpty() && focus.isEmpty()) {
+                    return;
+                }
                 SourceDocument previousDoc = getModelObject().getDocument();
                 handleParameters(project, document, focus, false);
                 


### PR DESCRIPTION
See https://github.com/inception-project/inception/issues/1647

**What's in the PR**
* If no query params are given for request, do not go with default of opening at first page.

**How to test manually**
* Open a document to a later page
* Open the sidebar
* The document should not jump to the first page
* Please also test different variations of opening documents in different projects etc. to make sure, page navigations works otherwise.
