### PR TITLE
#1472 - Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,35 +59,35 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
   
-    <mockito.version>2.28.2</mockito.version>
-    <assertj.version>3.14.0</assertj.version>
-    <spring.version>5.2.4.RELEASE</spring.version>
-    <spring.boot.version>2.2.4.RELEASE</spring.boot.version>
-    <spring.security.version>5.2.2.RELEASE</spring.security.version>
-    <wicket.version>8.6.1</wicket.version>
-    <wicketstuff.version>8.6.0</wicketstuff.version>
+    <mockito.version>3.3.3</mockito.version>
+    <assertj.version>3.15.0</assertj.version>
+    <spring.version>5.2.6.RELEASE</spring.version>
+    <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
+    <spring.security.version>5.2.3.RELEASE</spring.security.version>
+    <wicket.version>8.8.0</wicket.version>
+    <wicketstuff.version>8.8.0</wicketstuff.version>
     <wicket-jquery-ui.version>8.6.0</wicket-jquery-ui.version>
-    <wicket-bootstrap.version>3.0.0-M13</wicket-bootstrap.version>
+    <wicket-bootstrap.version>3.0.0-M15</wicket-bootstrap.version>
     <!-- 2.x is for Wicket 8; 3.x is for Wicket 9 -->
-    <wicket-jquery-selectors.version>2.0.8</wicket-jquery-selectors.version>
+    <wicket-jquery-selectors.version>2.0.9</wicket-jquery-selectors.version>
     <!-- 2.x is for Wicket 8; 3.x is for Wicket 9 -->
-    <wicket-webjars.version>2.0.17</wicket-webjars.version>    
+    <wicket-webjars.version>2.0.18</wicket-webjars.version>    
     <wicket-spring-boot.version>2.1.9</wicket-spring-boot.version>
     <bootstrap.version>4.4.1-1</bootstrap.version>
     <dkpro.version>2.1.0</dkpro.version>
     <uima.version>3.1.1</uima.version>
     <uimafit.version>3.0.0</uimafit.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>2.12.1</log4j.version>
-    <jboss.logging.version>3.3.1.Final</jboss.logging.version>
-    <hibernate.version>5.4.10.Final</hibernate.version>
-    <hibernate.validator.version>6.1.0.Final</hibernate.validator.version>
+    <log4j.version>2.13.2</log4j.version>
+    <jboss.logging.version>3.4.1.Final</jboss.logging.version>
+    <hibernate.version>5.4.15.Final</hibernate.version>
+    <hibernate.validator.version>6.1.4.Final</hibernate.validator.version>
     <springfox.version>2.9.2</springfox.version>
-    <batik.version>1.11</batik.version>
+    <batik.version>1.12</batik.version>
     <json.version>20180813</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.10.2</jackson.version>
-    <tomcat.version>9.0.33</tomcat.version>
+    <jackson.version>2.11.0</jackson.version>
+    <tomcat.version>9.0.34</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
   </properties>
   <repositories>
@@ -1166,7 +1166,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-maven</id>


### PR DESCRIPTION
**What's in the PR**
- Mockito 2.28.2 -> 3.3.3
- AssertJ 3.14.0 -> 3.15.0
- Spring 5.2.4 -> 5.2.6
- Spring Boot -> 2.2.4 -> 2.2.6
- Spring Security 5.2.2 -> 5.2.3
- Wicket 8.6.1 -> 8.8.0
- Wicketstuff 8.6.0 -> 8.8.0
- Wicket Bootstrap 3.0.0-M13 -> 3.0.0-M15
- Wicket JQuery Selectors 2.0.8 -> 2.0.9
- Wicket Webjars 2.0.17 -> 2.0.18
- Log4J 2.12.1 -> 2.13.2
- JBoss Logging 3.3.1 -> 3.4.1
- Hibernate 5.4.10 -> 5.4.15
- Hibernate Validator 6.1.0 -> 6.1.4
- Batik 1.11 -> 1.12
- Jackson 2.10.2 -> 2.11.0
- Tomcat 9.0.33 -> 9.0.34

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
