### PR TITLE
Feature/1748 add abbreviation marks

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/script/ScriptDirectionActionBarItem.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/script/ScriptDirectionActionBarItem.html
@@ -21,7 +21,7 @@
   <wicket:panel>
     <div class="action-bar-group">
       <div class="btn-group">
-        <button wicket:id="toggleScriptDirection" class="btn btn-light" type="button">
+        <button wicket:id="toggleScriptDirection" class="btn btn-light" type="button" wicket:message="title:toggleScriptDirection">
           <i class="fas fa-text-width"></i>
         </button>
       </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/script/ScriptDirectionActionBarItem.properties
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/script/ScriptDirectionActionBarItem.properties
@@ -1,0 +1,17 @@
+# Copyright 2020
+# Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+# Technische Universität Darmstadt
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+# http://www.apache.org/licenses/LICENSE-2.0 
+#
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+#
+toggleScriptDirection=Switches between left-to-right and right-to-left text display

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/guidelines/GuidelinesActionBarItem.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/guidelines/GuidelinesActionBarItem.html
@@ -22,7 +22,7 @@
     <div class="action-bar-group">
       <div wicket:id="guidelinesDialog"></div>
       <div class="btn-group">
-        <button wicket:id="showGuidelinesDialog" class="btn btn-light" type="button">
+        <button wicket:id="showGuidelinesDialog" class="btn btn-light" type="button" title="Guidelines">
           <i class="fas fa-book" aria-hidden="true"></i>
         </button>
       </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/PreferencesActionBarItem.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/PreferencesActionBarItem.html
@@ -22,7 +22,7 @@
     <div class="action-bar-group">
       <div wicket:id="preferencesDialog"></div>
       <div class="btn-group">
-        <button wicket:id="showPreferencesDialog" class="btn btn-light" type="button">
+        <button wicket:id="showPreferencesDialog" class="btn btn-light" type="button" title="Preferences">
           <i class="fas fa-cog" aria-hidden="true"></i>
         </button>
       </div>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotatorWorkflowActionBarItemGroup.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotatorWorkflowActionBarItemGroup.html
@@ -23,10 +23,10 @@
       <div wicket:id="resetDocumentDialog"></div>
       <div wicket:id="finishDocumentDialog"></div>
       <div class="btn-group">
-        <button wicket:id="showResetDocumentDialog" class="btn btn-light" type="button">
+        <button wicket:id="showResetDocumentDialog" class="btn btn-light" type="button" title="Reset document">
           <i class="fas fa-recycle"></i>
         </button>
-        <button wicket:id="showFinishDocumentDialog" class="btn btn-light" type="button">
+        <button wicket:id="showFinishDocumentDialog" class="btn btn-light" type="button" title="Finish document">
           <i wicket:id="state"></i>
         </button>
       </div>


### PR DESCRIPTION
**What's in the PR**
*This is NOT abbreviation marks.

* Added mouseovers in the annotation page an the buttons: Toggle Script Direction; Guidelines; Preferences; Reset document; Finish document. Now, all of the buttons an the top have a mouseover.

**How to test manually**
* Point on one of the buttons (without clicking)

**Automatic testing**
* -

**Documentation**
* -
