### PR TITLE
#1727 Add messages to empty spaces

### DIFF
--- a/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
+++ b/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
@@ -20,8 +20,8 @@
   <div class="flex-content card">
     <div class="card-header">
       <wicket:message key="agreement" />
-      <span class="pull-right">
-        <a wicket:id="legend"><wicket:message key="legend"/></a> 
+      <span class="float-right btn btn-link">
+        <a wicket:id="legend" ><wicket:message key="legend"/></a> 
       </span>
     </div>
     <div class="scrolling card-body fit-child-snug" style="padding: 0px;">

--- a/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
+++ b/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementReportExportF
 import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
 
 import java.io.ByteArrayInputStream;
@@ -212,6 +213,8 @@ public class PairwiseCodingAgreementTable
                         : "even"));
             }
         };
+        this.add(visibleWhen(
+            () -> (getModelObject() != null && !getModelObject().getRaters().isEmpty())));
         add(rows);
     }
     

--- a/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.html
+++ b/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.html
@@ -20,8 +20,8 @@
   <div class="flex-content card">
     <div class="card-header">
       <wicket:message key="agreement" />
-      <span class="float-right">
-        <a wicket:id="legend"><wicket:message key="legend"/></a> 
+      <span class="float-right btn btn-link">
+        <a wicket:id="legend"><wicket:message key="legend" /></a> 
       </span>
     </div>
     <div class="scrolling card-body fit-child-snug" style="padding: 0px;">

--- a/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
+++ b/webanno-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
@@ -17,8 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -162,6 +165,10 @@ public class PairwiseUnitizingAgreementTable
                         : "even"));
             }
         };
+        
+        Set<String> raters = getModelObject().getRaters();
+        this.add(visibleWhen(
+            () -> (getModelObject() != null && !getModelObject().getRaters().isEmpty())));
         add(rows);
     }
     

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -154,7 +154,7 @@ public class OpenDocumentDialogPanel
             docListChoice.setModelObject(docListChoice.getChoices().get(0));
         }
         
-        docListChoice.setHasEmptyChoice(true);
+        docListChoice.setDisplayMessageOnEmptyChoice(true);
         return docListChoice;
     }
 

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -154,6 +154,7 @@ public class OpenDocumentDialogPanel
             docListChoice.setModelObject(docListChoice.getChoices().get(0));
         }
         
+        docListChoice.setHasEmptyChoice(true);
         return docListChoice;
     }
 

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.properties
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/open/OpenDocumentDialogPanel.properties
@@ -17,3 +17,5 @@
 users=Users
 docs=Documents
 projects=Projects
+emptyChoiceMsg=None
+emptyChoiceExplanation=No suitable documents were found

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/OverviewListChoice.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/OverviewListChoice.java
@@ -112,7 +112,7 @@ public class OverviewListChoice<T>
     @Override
     public void onComponentTagBody(MarkupStream aMarkupStream, ComponentTag aOpenTag)
     {
-        if (emptyChoice && this.getChoices().isEmpty()) {
+        if (emptyChoice && getChoices().isEmpty()) {
             replaceComponentTagBody(aMarkupStream, aOpenTag,
                     "<option style=\"color:red;\" title=\"" + getString("emptyChoiceExplanation")
                             + "\">" + getString("emptyChoiceMsg") + "</option>");
@@ -122,13 +122,13 @@ public class OverviewListChoice<T>
         }
     }
     
-    /***
-     * If this flag is set, an empty choice-list will display a message given in 
-     * property key <b>emptyChoiceMsg</> with mouse over explanation <b>emptyChoiceExplanation</b>
+    /**
+     * If this flag is set, an empty choice-list will display a message given in property key
+     * {@code emptyChoiceMsg} with mouse over explanation {@code emptyChoiceExplanation}
      */
-    public void setHasEmptyChoice(boolean aHasEmpty)
+    public void setDisplayMessageOnEmptyChoice(boolean aHasEmpty)
     {
-        this.emptyChoice = aHasEmpty;
+        emptyChoice = aHasEmpty;
     }
 
     @Override

--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/OverviewListChoice.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/OverviewListChoice.java
@@ -21,6 +21,8 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 import java.util.List;
 
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.MarkupStream;
 import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.markup.html.form.ListChoice;
 import org.apache.wicket.model.IModel;
@@ -30,6 +32,7 @@ public class OverviewListChoice<T>
     extends ListChoice<T>
 {
     private static final long serialVersionUID = 1L;
+    private boolean emptyChoice;
 
     public OverviewListChoice(String aId, IModel<? extends List<? extends T>> aChoices,
             IChoiceRenderer<? super T> aRenderer)
@@ -104,6 +107,28 @@ public class OverviewListChoice<T>
     protected CharSequence getDefaultChoice(String aSelectedValue)
     {
         return "";
+    }
+
+    @Override
+    public void onComponentTagBody(MarkupStream aMarkupStream, ComponentTag aOpenTag)
+    {
+        if (emptyChoice && this.getChoices().isEmpty()) {
+            replaceComponentTagBody(aMarkupStream, aOpenTag,
+                    "<option style=\"color:red;\" title=\"" + getString("emptyChoiceExplanation")
+                            + "\">" + getString("emptyChoiceMsg") + "</option>");
+        }
+        else {
+            super.onComponentTagBody(aMarkupStream, aOpenTag);
+        }
+    }
+    
+    /***
+     * If this flag is set, an empty choice-list will display a message given in 
+     * property key <b>emptyChoiceMsg</> with mouse over explanation <b>emptyChoiceExplanation</b>
+     */
+    public void setHasEmptyChoice(boolean aHasEmpty)
+    {
+        this.emptyChoice = aHasEmpty;
     }
 
     @Override

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.properties
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.properties
@@ -23,3 +23,6 @@ ResetDocumentDialog.text=This action will revert the document to its initial sta
 
 FinishDocumentDialog.title=Finish Document
 FinishDocumentDialog.text=This action will mark the document as <b>Finished</b>. You can no longer make changes to the document after this step. Only a project manager or curator can put the document back into editing mode.
+
+emptyChoiceExplanation=The project has no documents yet or none were assigned.
+emptyChoiceMsg=None

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.properties
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.properties
@@ -27,3 +27,6 @@ FinishDocumentDialog.text=This action will mark the document as <b>Finished</b>.
 showResetDocumentDialog.label=Re-Merge
 showResetDocumentDialog.tooltip=Re-merge annotations
 showResetDocumentDialog.icon=images/recycle.png
+
+emptyChoiceExplanation=There are no documents to curate yet. None of the annotators have marked their documents as finished.
+emptyChoiceMsg=None

--- a/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.java
+++ b/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.java
@@ -42,6 +42,7 @@ import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.fit.util.FSUtil;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
@@ -257,12 +258,19 @@ public class AgreementPage
                     (DefaultAgreementTraits) traitsContainer.get(MID_TRAITS)
                             .getDefaultModelObject());
             
-            Serializable result = measure.getAgreement(getCasMap());
+            Map<String, List<CAS>> casMap = getCasMap();
             
-            resultsContainer.addOrReplace(ams.createResultsPanel(MID_RESULTS, Model.of(result),
-                    AgreementPage.this::getCasMap));
-            
-            aTarget.add(resultsContainer);
+            if (casMap.values().stream().allMatch(list -> list == null || list.isEmpty())) {
+                error("No documents with annotations were found.");
+                aTarget.addChildren(getPage(), IFeedback.class);
+            }
+            else {
+                Serializable result = measure.getAgreement(casMap);
+                resultsContainer.addOrReplace(ams.createResultsPanel(MID_RESULTS, Model.of(result),
+                        AgreementPage.this::getCasMap));
+                aTarget.add(resultsContainer);
+            }
+                        
         }
         
         List<Pair<String, String>> listMeasures()

--- a/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.properties
+++ b/webanno-ui-monitoring/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/monitoring/page/AgreementPage.properties
@@ -30,7 +30,10 @@ legend.content = <ul>\n\
                    <li>Lower triangle: Positions included in agreement / total number of \
                  positions</li>\n\
                    <li>Upper triangle: Agreement score - click on cell to export agreement \
-                 report</li>\n\
+                 report</li>\n\n\
+                 <li><i>No positions</i>: No annotations from the annotators.</li>\n\
+                 <li>Only zeros and <i>No positions</i>: Annotators might need to mark documents as finished or\n \
+                 you need to uncheck <i>Limit to finished documents</i>.</li>\n\
                  </ul>
 
 measure = Measure


### PR DESCRIPTION
Add some explanations to empty (or confusing) spaces.

**What's in the PR**
* AgreementPage: 
  * added explanation on what to do when table is empty (only zeros and no positions) to the legend
  * do not show table if there are no raters/documents, show an error message instead
* AnnotationPage and CurationPage: added message and popover explanation if document list is empty in LoadDocumentDialog

**How to test manually**
* Check agreement table for no documents and if it works as expected otherwise
* Try out load document dialog on annotation and curation page

