### PR TITLE
#1714 - Document does not show after sidebar close

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRenderedMetaDataKey.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRenderedMetaDataKey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation;
+
+import java.util.Set;
+
+import org.apache.wicket.MetaDataKey;
+
+public class AnnotationEditorRenderedMetaDataKey
+    extends MetaDataKey<Set<String>>
+{
+    private static final long serialVersionUID = 102615176759478581L;
+    
+    public final static AnnotationEditorRenderedMetaDataKey INSTANCE = 
+            new AnnotationEditorRenderedMetaDataKey();
+}


### PR DESCRIPTION
**What's in the PR**
- Always use deferred rendering when the editor is part of a full or partial page update
- Detect if a partial page update is in scheduled for the editor and if that is the case, avoid adding a render JSON command to the current AJAX target

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
