### PR TITLE
#1749 Really destroy cas when deleting cas

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
@@ -740,7 +740,7 @@ public class CasStorageServiceImpl
             sharedAccessCache.invalidate(key);
             
             try {
-                exclusiveAccessPool.clear(new CasKey(aDocument, aUsername));
+                exclusiveAccessPool.clear(key);
                 access.invalidateOnClose();
             }
             catch (Exception e) {

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImpl.java
@@ -577,6 +577,11 @@ public class CasStorageServiceImpl
         }
     }
     
+    /**
+     * Returns a borrowed CAS to the exclusive access pool. This method is not called directly
+     * when a CAS needs to be returned. Rather, it is registered as a "CAS owner" in CAS instances
+     * such that it is called when {@link CAS#release()} is called.
+     */
     private void returnBorrowedCas(AbstractCas cas, CasKey aKey, CasHolder aHolder)
     {
         try {
@@ -736,33 +741,29 @@ public class CasStorageServiceImpl
         try (WithExclusiveAccess access = new WithExclusiveAccess(aDocument, aUsername)) {
             boolean fileWasDeleted = new File(getAnnotationFolder(aDocument), aUsername + ".ser")
                     .delete();
-            
-            // Drop the CAS from the shared CAS it doesn't ghost around
+
+            // Drop the CAS from the shared CAS it doesn't ghost around. Also set the deleted flag
+            // in the holder in case anybody might still be holding on to the holder and needs to 
+            // know that CAS was deleted.
             CasKey key = new CasKey(aDocument, aUsername);
+            CasHolder sharedCasHolder = sharedAccessCache.getIfPresent(key);
+            if (sharedCasHolder != null) {
+                sharedCasHolder.setDeleted(true);
+            }
             sharedAccessCache.invalidate(key);
-            
-            try {
-                Long docId = aDocument.getId();
-                CasStorageSession session = CasStorageSession.get();
-                Optional<SessionManagedCas> managedCas = session.getManagedState(docId, aUsername);
-                
-                if (!managedCas.isPresent()) {
-                    return fileWasDeleted;
-                }
 
-                CasHolder holder = managedCas.get().getCasHolder();
-                if (holder != null) {
-                    holder.setDeleted(true);
-                    access.setCas(null);
-                }
+            // Drop the CAS from the exclusive access pool. This is done my marking it as deleted
+            // and then releasing it (returning it to the pool). Upon return, the deleted flag
+            // causes the CAS to be invalidated and dropped from the pool.
+            exclusiveAccessHolders.stream()
+                .filter(h -> Objects.equals(h.getKey(), key))
+                .forEach(h -> h.setDeleted(true));
+            access.release();
 
-                managedCas.get().getCas().release();
-
-                session.remove(docId, aUsername);
-            }
-            catch (Exception e) {
-                throw new IOException(e);
-            }
+            // Drop the CAS from the current session
+            // This must happen after the call to access.release() because access.release() tries
+            // to fetch the CAS from the session if WithExclusiveAccess did not borrow it itself
+            CasStorageSession.get().remove(aDocument.getId(), aUsername);
 
             return fileWasDeleted;
         }
@@ -1015,18 +1016,34 @@ public class CasStorageServiceImpl
             return holder;
         }
         
+        /**
+         * Releases the CAS prior to closing the exclusive access context. This is used if the CAS
+         * must be released irrespective of whether it was borrowed by {@link WithExclusiveAccess}
+         * or exclusive access already existed before. Such is the case specifically when the CAS
+         * is deleted.
+         * <p>
+         * <b>NOTE:</b> If this is used, it should be the last action in the {@link 
+         * WithExclusiveAccess} context because as a side effect, it sets clears the internal CAS
+         * holder.
+         */
+        public void release()
+        {
+            if (holder != null) {
+                exclusiveAccessPool.returnObject(key, holder);
+                holder = null;
+            }
+            else {
+                getCas().release();
+            }
+        }
+        
         @Override
         public void close()
         {
             if (holder != null) {
-                try {
-                    log.trace("Returning briefly borrowed CAS [{}]@[{}]({})", username,
-                            documentName, documentId);
-                    exclusiveAccessPool.returnObject(key, holder);
-                }
-                catch (Exception e) {
-                    log.error("Unable to return CAS to exclusive access pool", e);
-                }
+                log.trace("Returning briefly borrowed CAS [{}]@[{}]({})", username,
+                        documentName, documentId);
+                exclusiveAccessPool.returnObject(key, holder);
             }
         }
     }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasHolder.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasHolder.java
@@ -31,6 +31,7 @@ public class CasHolder
     private CAS cas;
     private Exception exception;
     private boolean typeSystemOutdated;
+    private boolean deleted;
 
     public CasHolder(CasKey aKey)
     {
@@ -97,6 +98,16 @@ public class CasHolder
         typeSystemOutdated = aTypeSystemOutdated;
     }
 
+    public synchronized  void setDeleted(boolean aDeleted)
+    {
+        deleted = aDeleted;
+    }
+    
+    public synchronized  boolean isDeleted()
+    {
+        return deleted;
+    }
+    
     public static CasHolder of(CasKey aKey, SupplierThrowingException<CAS> aSupplier)
     {
         try {

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasStorageSession.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasStorageSession.java
@@ -221,6 +221,19 @@ public class CasStorageSession
                         .removeIf(metadata -> metadata.getCas() == aCas));
     }
 
+    /**
+     * Removed managed CAS from session for given document and username
+     */
+    public void remove(Long aDocumentId, String aUsername)
+    {
+        Map<String, SessionManagedCas> casByUser = managedCases.get(aDocumentId);
+        
+        if (casByUser == null) {
+            return;
+        }
+        
+        casByUser.remove(aUsername);
+    }
     
     /**
      * Register the given CAS into the session.

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/PooledCasHolderFactory.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/PooledCasHolderFactory.java
@@ -39,6 +39,6 @@ public class PooledCasHolderFactory
     @Override
     public boolean validateObject(CasKey aKey, PooledObject<CasHolder> aP)
     {
-        return !aP.getObject().isTypeSystemOutdated();
+        return !aP.getObject().isTypeSystemOutdated() && !aP.getObject().isDeleted();
     }
 }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/SessionManagedCas.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/SessionManagedCas.java
@@ -35,7 +35,7 @@ public class SessionManagedCas
     private final CasAccessMode mode;
     private final CAS cas;
     private final CasHolder casHolder;
-    
+
     private int readCount;
     private int writeCount;
 
@@ -64,6 +64,11 @@ public class SessionManagedCas
         mode = aMode;
         cas = null;
         casHolder = aCasHolder;
+    }
+    
+    public CasHolder getCasHolder()
+    {
+        return casHolder;
     }
     
     public long getSourceDocumentId()

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -93,6 +93,9 @@ public class CasStorageServiceImplTest
         sut.deleteCas(doc, user);
         assertThat(sut.getCasFile(doc, user)).doesNotExist();
         assertThat(sut.existsCas(doc, user)).isFalse();
+        
+        // check that cas is no longer in the active session
+        assertThat(casStorageSession.contains(cas.getCas())).isFalse();
     }
     
     @Test

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -126,10 +126,11 @@ public class CasStorageServiceImplTest
     @Test
     public void testReadOrCreateCas() throws Exception
     {
+        // Setup fixture
         SourceDocument doc = makeSourceDocument(2l, 2l);
         String user = "test";
         
-        JCas cas = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> {
+        JCas casTemplate = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> {
             try {
                 return JCasFactory.createText("This is a test").getCas();
             }
@@ -140,8 +141,9 @@ public class CasStorageServiceImplTest
         assertThat(sut.getCasFile(doc, user)).exists();
         assertThat(sut.existsCas(doc, user)).isTrue();
         
-        JCas cas2 = sut.readCas(doc, user).getJCas();
-        assertThat(cas2.getDocumentText()).isEqualTo(cas.getDocumentText());
+        // Actual test
+        JCas cas = sut.readCas(doc, user).getJCas();
+        assertThat(cas.getDocumentText()).isEqualTo(casTemplate.getDocumentText());
         
         sut.deleteCas(doc, user);
         assertThat(sut.getCasFile(doc, user)).doesNotExist();

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -78,24 +78,24 @@ public class CasStorageServiceImplTest
     @Test
     public void testWriteReadExistsDeleteCas() throws Exception
     {
+        // Setup fixture
         SourceDocument doc = makeSourceDocument(1l, 1l);
-        JCas cas = JCasFactory.createText("This is a test");
-        casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, cas.getCas());
+        JCas templateCas = JCasFactory.createText("This is a test");
+        casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, templateCas.getCas());
         String user = "test";
         
-        sut.writeCas(doc, cas.getCas(), user);
+        sut.writeCas(doc, templateCas.getCas(), user);
         assertThat(sut.getCasFile(doc, user)).exists();
         assertThat(sut.existsCas(doc, user)).isTrue();
         
-        CAS cas2 = sut.readCas(doc, user);
-        assertThat(cas2.getDocumentText()).isEqualTo(cas.getDocumentText());
+        // Actual test
+        CAS cas = sut.readCas(doc, user);
+        assertThat(cas.getDocumentText()).isEqualTo(templateCas.getDocumentText());
         
         sut.deleteCas(doc, user);
         assertThat(sut.getCasFile(doc, user)).doesNotExist();
         assertThat(sut.existsCas(doc, user)).isFalse();
-        
-        // check that cas is no longer in the active session
-        assertThat(casStorageSession.contains(cas.getCas())).isFalse();
+        assertThat(casStorageSession.contains(cas)).isFalse();
     }
     
     @Test

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasStorageService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/CasStorageService.java
@@ -117,7 +117,7 @@ public interface CasStorageService
         throws IOException, CasSessionException;
 
     /**
-     * Delete a CAS from the storage.
+     * Delete a CAS from the storage and also remove it from the active session.
      * 
      * @param aDocument
      *            the document to delete the CAS for.

--- a/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/CurationDocumentService.java
+++ b/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/CurationDocumentService.java
@@ -67,19 +67,6 @@ public interface CurationDocumentService
 
     void deleteCurationCas(SourceDocument document)
             throws IOException;
-
-    /**
-     * Remove a curation annotation document from the file system, for this {@link SourceDocument}
-     *
-     * @param sourceDocument
-     *            the source document.
-     * @param username
-     *            the username.
-     * @throws IOException
-     *             if an I/O error occurs.
-     */
-    void removeCurationDocumentContent(SourceDocument sourceDocument, String username)
-        throws IOException;
     
     List<SourceDocument> listCuratableSourceDocuments(Project aProject);
 

--- a/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/CurationDocumentServiceImpl.java
+++ b/webanno-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/CurationDocumentServiceImpl.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.clarin.webanno.curation.storage;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CURATION_USER;
 
-import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
@@ -29,13 +28,9 @@ import java.util.Optional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
@@ -43,19 +38,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
-import de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging;
 
 @Component(CurationDocumentService.SERVICE_NAME)
 public class CurationDocumentServiceImpl
     implements CurationDocumentService
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
-
     private @Autowired CasStorageService casStorageService;
     private @Autowired AnnotationSchemaService annotationService;
 
@@ -65,25 +56,6 @@ public class CurationDocumentServiceImpl
     public CurationDocumentServiceImpl()
     {
         // Nothing to do
-    }
-
-    @Override
-    public void removeCurationDocumentContent(SourceDocument aSourceDocument, String aUsername)
-        throws IOException
-    {
-        if (new File(casStorageService.getAnnotationFolder(aSourceDocument),
-                WebAnnoConst.CURATION_USER + ".ser").exists()) {
-            FileUtils.forceDelete(new File(casStorageService.getAnnotationFolder(aSourceDocument),
-                    WebAnnoConst.CURATION_USER + ".ser"));
-
-            try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
-                    String.valueOf(aSourceDocument.getProject().getId()))) {
-                Project project = aSourceDocument.getProject();
-                log.info("Removed curation of source document [{}]({}) from project [{}]({})",
-                        aSourceDocument.getName(), aSourceDocument.getId(), project.getName(),
-                        project.getId());
-            }
-        }
     }
 
     @Override

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
@@ -135,8 +135,7 @@ public class CuratorWorkflowActionBarItemGroup
         AnnotatorState state = page.getModelObject();
         
         // Remove the current curation CAS
-        curationDocumentService.removeCurationDocumentContent(state.getDocument(),
-                state.getUser().getUsername());
+        curationDocumentService.deleteCurationCas(state.getDocument());
 
         // Initialize a new one ...
         ((CurationPage) page)


### PR DESCRIPTION
**What's in the PR**
* invalidate casholder object in exclusiveaccesspool when deleting a cas
* call method that removes cas from pools when re-merging

**How to test manually**
* Test that re-merging during curation will reset the curation document again
* Check annotation process for buggy behaviour
