### PR TITLE
#1757 - Re-Merge does not work anymore

### DIFF
--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
@@ -132,16 +132,9 @@ public class CuratorWorkflowActionBarItemGroup
     protected void actionResetDocument(AjaxRequestTarget aTarget, Form<MergeDialog.State> aForm)
         throws Exception
     {
-        AnnotatorState state = page.getModelObject();
-        
-        // Remove the current curation CAS
-        curationDocumentService.removeCurationDocumentContent(state.getDocument(),
-                state.getUser().getUsername());
-
-        // Initialize a new one ...
         ((CurationPage) page)
-                .prepareMergeCas(aForm.getModelObject().isMergeIncompleteAnnotations());
-
+                .readOrCreateMergeCas(aForm.getModelObject().isMergeIncompleteAnnotations(), true);
+        
         // ... and load it
         page.actionLoadDocument(aTarget);
 

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -567,7 +567,7 @@ public class CurationPage
                 currentprojectId = state.getProject().getId();
             }
             
-            CAS mergeCas = prepareMergeCas(false);
+            CAS mergeCas = readOrCreateMergeCas(false, false);
     
             // (Re)initialize brat model after potential creating / upgrading CAS
             state.reset();
@@ -601,13 +601,14 @@ public class CurationPage
         LOG.info("END LOAD_DOCUMENT_ACTION");
     }
     
-    public CAS prepareMergeCas(boolean aMergeIncompleteAnnotations)
+    public CAS readOrCreateMergeCas(boolean aMergeIncompleteAnnotations, boolean aForceRecreateCas)
         throws IOException, UIMAException, ClassNotFoundException, AnnotationException
     {
         AnnotatorState state = getModelObject();
         
         List<AnnotationDocument> finishedAnnotationDocuments = new ArrayList<>();
         
+        // FIXME: This is slow and should be done via a proper SQL query
         for (AnnotationDocument annotationDocument : documentService
                 .listAnnotationDocuments(state.getDocument())) {
             if (annotationDocument.getState().equals(FINISHED)) {
@@ -631,20 +632,14 @@ public class CurationPage
         }
 
         AnnotationDocument randomAnnotationDocument = finishedAnnotationDocuments.get(0);
-
-        // upgrade CASes for each user, what if new type is added once the user finished
-        // annotation
-        for (AnnotationDocument ad : finishedAnnotationDocuments) {
-            upgradeCasAndSave(ad.getDocument(), ad.getUser());
-        }
         
         SuggestionBuilder cb = new SuggestionBuilder(casStorageService, documentService,
                 correctionDocumentService, curationDocumentService, annotationService,
                 userRepository);
         Map<String, CAS> casses = cb.listCassesforCuration(finishedAnnotationDocuments,
-                randomAnnotationDocument, state.getMode());
+                state.getMode());
         CAS mergeCas = cb.getMergeCas(state, state.getDocument(), casses,
-                randomAnnotationDocument, true, aMergeIncompleteAnnotations);
+                randomAnnotationDocument, true, aMergeIncompleteAnnotations, aForceRecreateCas);
         return mergeCas;
     }
 


### PR DESCRIPTION
**What's in the PR**
- Add option to force-recreate the merge CAS when loading it
- Remove upgrade for all finished annotation documents when loading the merge CAS - IMHO that should not be necessary anymore
- Instead of deleting the curation CAS on disk and then re-create it implicitly (which currently does not work because we simply get the copy from memory when we try this), just create a new merge CAS and then overwrite the curation CAS with the new merged version.

**How to test manually**
* See (upstream) issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
