### PR TITLE
#1776 - Unable to use remote API when external authentication is enabled (master)

### DIFF
--- a/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/WebAnnoDaoAuthenticationProvider.java
+++ b/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/WebAnnoDaoAuthenticationProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.security;
+
+import static de.tudarmstadt.ukp.clarin.webanno.security.preauth.ShibbolethRequestHeaderAuthenticationFilter.EMPTY_PASSWORD;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class WebAnnoDaoAuthenticationProvider extends DaoAuthenticationProvider
+{
+    @Override
+    protected void additionalAuthenticationChecks(UserDetails aUserDetails,
+            UsernamePasswordAuthenticationToken aAuthentication)
+        throws AuthenticationException
+    {
+        String presentedPassword = aAuthentication.getCredentials().toString();
+
+        // Users which are created through the pre-auth mechanism end up with an empty password. 
+        // So we do not want to accept these blank passwords when we have a non-preauth login.
+        if (EMPTY_PASSWORD.equals(presentedPassword)) {
+
+            throw new BadCredentialsException(messages.getMessage(
+                    "AbstractUserDetailsAuthenticationProvider.badCredentials",
+                    "Bad credentials"));
+        }
+        
+        super.additionalAuthenticationChecks(aUserDetails, aAuthentication);
+    }
+}

--- a/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilter.java
+++ b/webanno-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilter.java
@@ -39,6 +39,8 @@ public class ShibbolethRequestHeaderAuthenticationFilter
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    public static final String EMPTY_PASSWORD = "";
+    
     private UserDetailsManager userDetailsManager;
     private UserDao userRepository;
 
@@ -46,7 +48,7 @@ public class ShibbolethRequestHeaderAuthenticationFilter
     {
         User u = new User();
         u.setUsername((String) super.getPreAuthenticatedPrincipal(aRequest));
-        u.setPassword("");
+        u.setPassword(EMPTY_PASSWORD);
         u.setEnabled(true);
         
         Set<Role> s = new HashSet<>();

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -273,7 +273,7 @@ public class ManageUsersPage
             selectedUser.setObject(null);
         }
 
-        info("User details have been saved.");
+        info("Details for user [" + user.getUsername() + "] have been saved.");
         
         aTarget.add(detailForm);
         aTarget.add(users);

--- a/webanno-webapp/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/WebAnno.java
+++ b/webanno-webapp/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/WebAnno.java
@@ -114,11 +114,9 @@ public class WebAnno
         if (ajpPort > 0) {
             Connector ajpConnector = new Connector(PROTOCOL);
             ajpConnector.setPort(ajpPort);
-            ajpConnector.setProperty("secretRequired", ajpSecretRequired);
-            if (Boolean.valueOf(ajpSecretRequired)) {
-                ajpConnector.setProperty("secret", ajpSecret);
-            }
-            ajpConnector.setProperty("address", ajpAddress);
+            ajpConnector.setAttribute("secretRequired", ajpSecretRequired);
+            ajpConnector.setAttribute("secret", ajpSecret);
+            ajpConnector.setAttribute("address", ajpAddress);
             factory.addAdditionalTomcatConnectors(ajpConnector);
         }
         return factory;

--- a/webanno-webapp/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/WebAnno.java
+++ b/webanno-webapp/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/WebAnno.java
@@ -114,9 +114,11 @@ public class WebAnno
         if (ajpPort > 0) {
             Connector ajpConnector = new Connector(PROTOCOL);
             ajpConnector.setPort(ajpPort);
-            ajpConnector.setAttribute("secretRequired", ajpSecretRequired);
-            ajpConnector.setAttribute("secret", ajpSecret);
-            ajpConnector.setAttribute("address", ajpAddress);
+            ajpConnector.setProperty("secretRequired", ajpSecretRequired);
+            if (Boolean.valueOf(ajpSecretRequired)) {
+                ajpConnector.setProperty("secret", ajpSecret);
+            }
+            ajpConnector.setProperty("address", ajpAddress);
             factory.addAdditionalTomcatConnectors(ajpConnector);
         }
         return factory;


### PR DESCRIPTION
**What's in the PR**
- Extra guard against users with emtpy passwords (i.e. those created by pre-auth) trying to access the remote API
- Allow the remote API to authenticate against the internal user DB even if external authentication is enabled
- Include username in message when saving user details

**How to test manually**
* Enable the remote API in the `settings.properties` file: `remote-api.enabled=true`
* Create a user `jack` with `ROLE_REMOTE`, `ROLE_USER`, and `ROLE_PROJECT_CREATOR`
* Log in as `jack` and create a project
* Enable external authentication in `settings.properties`:
```
auth.mode                     = preauth
auth.preauth.header.principal = remote_user
```
* Restart
* Try accessing the remote API as `jack` at `curl -k -X GET "http://jack:JACKS-PASSWORD@localhost:8080/webanno-webapp/api/aero/v1/projects" -H "accept: application/json;charset=UTF-8"` - should give you a list of projects that jack has access to
* Try accessing the same location as another user or with a wrong PW
* Install some browser plugin which allows you to set the the `remote_user` variable and set it to `jill`
* Access the WebAnno UI with the header plugin enabled (you should be automatically logged in as that user)
* Comment out the external auth in the `settings.properties` file and restart
* Give the user `jill` the `ROLE_REMOTE` in addition to the permissions the user already has
* Comment in the external auth in the `settings.properties` file and restart
* Try accessing the remote API as `jack` at `curl -k -X GET "http://jack:JACKS-PASSWORD@localhost:8080/webanno-webapp/api/aero/v1/projects" -H "accept: application/json;charset=UTF-8"` - should give you a list of projects that jack has access to
Try accessing the remote API as `jill` at `curl -k -X GET "http://jill:@localhost:8080/webanno-webapp/api/aero/v1/projects" -H "accept: application/json;charset=UTF-8"` - that should be rejected
* .... well, try out any other combinations you can imagine with and without external auth enables

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
