### PR TITLE
#1770 Adding features to layer should prompt other users to re-open

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/FeatureSupport.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/FeatureSupport.java
@@ -213,6 +213,9 @@ public interface FeatureSupport<T>
     default String renderFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
     {
         Feature labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
+        if (labelFeature == null) {
+            return null;
+        }
         return renderFeatureValue(aFeature, aFs.getFeatureValueAsString(labelFeature));
     }
     
@@ -220,7 +223,7 @@ public interface FeatureSupport<T>
     {
         Feature labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
         
-        if (labelFeature.getRange().isPrimitive()) {
+        if (labelFeature != null && labelFeature.getRange().isPrimitive()) {
             return getLazyDetails(aFeature, aFs.getFeatureValueAsString(labelFeature));
         }
         else {
@@ -283,7 +286,7 @@ public interface FeatureSupport<T>
         setFeature(fs, aFeature, value);
     }
 
-    default <V> V getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS)
+    default <V> V getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS) 
     {
         Object value;
         

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -1283,7 +1283,7 @@ public abstract class AnnotationDetailEditorPanel
                 // If the feature does not exist in the given Feature Structure, 
                 // then the typesystem might be out of date
                 error("The annotation typesystem might be out of date, "
-                        + "try re-loading the document!");
+                        + "try re-opening the document!");
                 LOG.error(String.format("Unable to find %s in the current cas typesystem",
                         feature.getName()));
                 return;

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -1279,6 +1279,16 @@ public abstract class AnnotationDetailEditorPanel
                 continue;
             }
 
+            if (aFS != null && aFS.getType().getFeatureByBaseName(feature.getName()) == null) {
+                // If the feature does not exist in the given Feature Structure, 
+                // then the typesystem might be out of date
+                error("The annotation typesystem might be out of date, "
+                        + "try re-loading the document!");
+                LOG.error(String.format("Unable to find %s in the current cas typesystem",
+                        feature.getName()));
+                return;
+            }
+            
             Serializable value = null;
             VID vid = null;
             if (aFS != null) {


### PR DESCRIPTION
Nullpointer exception was thrown during annotation when feature was added by another users.

**What's in the PR**
- null checks
- error message on EditorDetailPanel load if feature non-existent

**How to test manually**
- User 1: annotate with layer A
- User 2: add a feature to layer A in Settings
- User 1: try annotating

- Please also test that "nomal" annotation still works
