### PR TITLE
#1783 'No layer is selected' when only one layer enabled

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.java
@@ -292,6 +292,11 @@ public class LayerSelectionPanel
             }
         }
         
+        // if there is only one layer, we use it to create new annotations
+        if (selectableLayers.size() == 1) {
+            state.setDefaultAnnotationLayer(selectableLayers.get(0));
+        }
+        
         if (state.getDefaultAnnotationLayer() != null) {
             state.setSelectedAnnotationLayer(state.getDefaultAnnotationLayer());
         }


### PR DESCRIPTION
**What's in the PR**
* Set layer as default when only one

**How to test manually**
* Create project, add document, disable all layers except for one
* Open annotation page
* Try to create a span annotation

* Enable more layers and test that we can still normally select annotations and select layers 
