### PR TITLE
#1785 Feature Editor wrongly shown

### DIFF
--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
@@ -92,16 +92,21 @@ public class FeatureEditorListPanel
         featureEditorContainer.setOutputMarkupPlaceholderTag(true);
         featureEditorContainer.add(featureEditorPanelContent = new FeatureEditorPanelContent("featureEditors"));
         featureEditorContainer.add(createFocusResetHelper());
-        featureEditorContainer.add(visibleWhen(() -> !hasFeatures()));
+        featureEditorContainer.add(visibleWhen(() -> selectedLayerHasFeatures()));
         add(featureEditorContainer);
         
         noFeaturesWarning = new WebMarkupContainer("noFeaturesWarning");
         noFeaturesWarning.setOutputMarkupPlaceholderTag(true);
-        noFeaturesWarning.add(visibleWhen(() -> hasFeatures()));
+        noFeaturesWarning.add(visibleWhen(() -> selectedLayerHasNoFeatures()));
         add(noFeaturesWarning);
     }
     
-    private boolean hasFeatures() {
+    private boolean selectedLayerHasFeatures() {
+        return getModelObject().getSelection().getAnnotation().isSet() && 
+                !getModelObject().getFeatureStates().isEmpty();
+    }
+    
+    private boolean selectedLayerHasNoFeatures() {
         return getModelObject().getSelection().getAnnotation().isSet() && 
                 getModelObject().getFeatureStates().isEmpty();
     }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
@@ -92,21 +92,21 @@ public class FeatureEditorListPanel
         featureEditorContainer.setOutputMarkupPlaceholderTag(true);
         featureEditorContainer.add(featureEditorPanelContent = new FeatureEditorPanelContent("featureEditors"));
         featureEditorContainer.add(createFocusResetHelper());
-        featureEditorContainer.add(visibleWhen(() -> selectedLayerHasFeatures()));
+        featureEditorContainer.add(visibleWhen(() -> layerIsSelectedAndHasFeatures()));
         add(featureEditorContainer);
         
         noFeaturesWarning = new WebMarkupContainer("noFeaturesWarning");
         noFeaturesWarning.setOutputMarkupPlaceholderTag(true);
-        noFeaturesWarning.add(visibleWhen(() -> selectedLayerHasNoFeatures()));
+        noFeaturesWarning.add(visibleWhen(() -> layerIsSelectedButHasNoFeatures()));
         add(noFeaturesWarning);
     }
     
-    private boolean selectedLayerHasFeatures() {
+    private boolean layerIsSelectedAndHasFeatures() {
         return getModelObject().getSelection().getAnnotation().isSet() && 
                 !getModelObject().getFeatureStates().isEmpty();
     }
     
-    private boolean selectedLayerHasNoFeatures() {
+    private boolean layerIsSelectedButHasNoFeatures() {
         return getModelObject().getSelection().getAnnotation().isSet() && 
                 getModelObject().getFeatureStates().isEmpty();
     }


### PR DESCRIPTION
Sometimes features of previously selected annotations were still shown.

**What's in the PR**
*  Feature editor is not visible when no selected layer

**How to test manually**
* Select annotation
* Open AL session or re-merge from curations sidebar
* Right sidebar should show no layer selected and also no features
