### PR TITLE
#1795 - WebAnno versions compiled on recent JDKs do not run on JDK 8

### DIFF
--- a/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/io/FastIOUtils.java
+++ b/webanno-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/io/FastIOUtils.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -63,11 +64,15 @@ public final class FastIOUtils
         ) {
             final ByteBuffer buffer = allocateDirect(8192);
             while (in.read(buffer) != -1) {
-                buffer.flip();
+                // Cast to buffer to permit code to run on Java 8.
+                // See: https://github.com/inception-project/inception/issues/1828#issuecomment-717047584
+                ((Buffer) buffer).flip();
                 out.write(buffer);
                 buffer.compact();
             }
-            buffer.flip();
+            // Cast to buffer to permit code to run on Java 8.
+            // See: https://github.com/inception-project/inception/issues/1828#issuecomment-717047584
+            ((Buffer) buffer).flip();
             while (buffer.hasRemaining()) {
                 out.write(buffer);
             }


### PR DESCRIPTION
**What's in the PR**
- Add explicit type cast to avoid linking to a non-Java-8 version of the flip() method
- Fixes #1795

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
