### PR TITLE
#1797 - Support for UIMA CAS XMI XML 1.1

### DIFF
--- a/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimaxmi.adoc
+++ b/webanno-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimaxmi.adoc
@@ -22,14 +22,25 @@ It is able to capture all the information contained in the CAS. This is the de-f
 
 The XMI format does not include type system information. When exporting files in the XMI format, a ZIP file is created for each document which contains the XMI file itself as well as an XML file containing the type system.
 
+There are two flavors of CAS XMI, namely link:http://www.w3.org/TR/2006/REC-xml-20060816/Overview.html[XML 1.0] and link:http://www.w3.org/TR/xml11/Overview.html[XML 1.1]. XML 1.0 is more widely supported in
+the world of XML parsers, so you may expect better interoperability with other programming languages
+(e.g. Python) with the XML 1.0 flavor. XML 1.1 has a support for a wider range of characters, despite 
+dating back to 2006, it is still not supported by all XML parsers.
+
 [cols="2,1,1,1,3"]
 |====
 | Format | Read | Write | Custom Layers | Description
 
-| link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.xmi[XMI]
+| link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.xmi[UIMA CAS XMI (XML 1.0)]
 | yes
 | yes
 | yes
-| UIMA XMI CAS
+| UIMA XMI CAS (XML 1.0)
+
+| link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.xmi[UIMA CAS XMI (XML 1.1)]
+| yes
+| yes
+| yes
+| UIMA XMI CAS (XML 1.1)
 |====
 

--- a/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiXml11FormatSupport.java
+++ b/webanno-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiXml11FormatSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018
+ * Copyright 2020
  * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
  * Technische Universität Darmstadt
  *
@@ -33,11 +33,11 @@ import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 @Component
-public class XmiFormatSupport
+public class XmiXml11FormatSupport
     implements FormatSupport
 {
-    public static final String ID = "xmi";
-    public static final String NAME = "UIMA CAS XMI (XML 1.0)";
+    public static final String ID = "xmi-xml1.1";
+    public static final String NAME = "UIMA CAS XMI (XML 1.1)";
     
     @Override
     public String getId()
@@ -77,6 +77,6 @@ public class XmiFormatSupport
         throws ResourceInitializationException
     {
         return createEngineDescription(XmiWriter.class, aTSD,
-                XmiWriter.PARAM_VERSION, "1.0");
+                XmiWriter.PARAM_VERSION, "1.1");
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added support for CAS XMI XML 1.1

**How to test manually**
* Try exporting a document containing characters that are supported in XML 1.1 but not in XML 1.0 (e.g. 0x0001).

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
