### PR TITLE
#1809 - Navigate to relation endpoints

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/AnnotationActionHandler.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.action;
 import java.io.IOException;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
@@ -41,6 +42,24 @@ public interface AnnotationActionHandler
      * Load the annotation pointed to in {@link AnnotatorState#getSelection()} in the detail panel.
      */
     void actionSelect(AjaxRequestTarget aTarget)
+        throws IOException, AnnotationException;
+    
+    void actionSelect(AjaxRequestTarget aTarget, AnnotationFS aAnnoFs)
+            throws IOException, AnnotationException;
+
+    void actionSelect(AjaxRequestTarget aTarget, VID aVid)
+            throws IOException, AnnotationException;
+
+    void actionSelectAndJump(AjaxRequestTarget aTarget, VID aVid)
+        throws IOException, AnnotationException;
+
+    void actionJump(AjaxRequestTarget aTarget, VID aVid)
+        throws IOException, AnnotationException;
+
+    void actionSelectAndJump(AjaxRequestTarget aTarget, AnnotationFS aFS)
+        throws IOException, AnnotationException;
+
+    void actionJump(AjaxRequestTarget aTarget, AnnotationFS aFS)
         throws IOException, AnnotationException;
 
     /**

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ChainAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/ChainAdapter.java
@@ -47,6 +47,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.ChainSpanDeletedEv
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.AnnotationComparator;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
@@ -516,5 +517,11 @@ public class ChainAdapter
                     getLayer().getUiName(), currentTimeMillis() - startTime);
         }
         return messages;
+    }
+    
+    @Override
+    public void select(AnnotatorState aState, AnnotationFS aAnno)
+    {
+        aState.getSelection().selectSpan(aAnno);
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/RelationAdapter.java
@@ -43,6 +43,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationExce
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -205,5 +206,12 @@ public class RelationAdapter
                     getLayer().getUiName(), currentTimeMillis() - startTime);
         }
         return messages;
+    }
+    
+    @Override
+    public void select(AnnotatorState aState, AnnotationFS aAnno)
+    {
+        aState.getSelection().selectArc(new VID(aAnno), getSourceAnnotation(aAnno),
+                getTargetAnnotation(aAnno));
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/SpanAdapter.java
@@ -43,6 +43,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationExce
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -177,5 +178,11 @@ public class SpanAdapter
                     getLayer().getUiName(), currentTimeMillis() - startTime);
         }
         return messages;
+    }
+    
+    @Override
+    public void select(AnnotatorState aState, AnnotationFS aAnno)
+    {
+        aState.getSelection().selectSpan(aAnno);
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter.java
@@ -198,6 +198,8 @@ public interface TypeAdapter
      */
     void silenceEvents();
     
+    void select(AnnotatorState aState, AnnotationFS aAnnotation);
+    
     /**
      * @return the encoded type name sent to the browser.
      * @see #decodeTypeName(String)

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
@@ -32,9 +32,10 @@
             <div class="form-group form-row">
               <label class="feature-editor-label col-form-label">
                 <span wicket:id="role"></span>	
+                <a wicket:id="jumpToAnnotation" class="float-right"><i class="fas fa-crosshairs"></i></a>
               </label>
               <div class="feature-editor-value">
-                <span wicket:id="label" class="scrolling form-control" style="flex: 0 0 100%; max-height: 4.5rem;"></span>
+                <span wicket:id="label" class="scrolling form-control" style="flex: 0 0 100%; max-height: 4.5rem; cursor: pointer;"></span>
               </div>
             </div>
           </div>

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -166,7 +166,7 @@ public class LinkFeatureEditor
                 AnnotatorState state = stateModel.getObject();
 
                 if (aModel.targetAddr <= -1) {
-                    return "";
+                    return aModel.role;
                 }
 
                 CAS cas;
@@ -213,7 +213,8 @@ public class LinkFeatureEditor
                         LoadableDetachableModel.of(() -> getRole(aItem.getModelObject()))));
 
                 aItem.add(new LambdaAjaxLink("jumpToAnnotation", _target -> actionHandler
-                        .actionSelectAndJump(_target, new VID(aItem.getModelObject().targetAddr))));
+                        .actionSelectAndJump(_target, new VID(aItem.getModelObject().targetAddr)))
+                        .add(visibleWhen(() -> aItem.getModelObject().targetAddr != -1)));
 
                 final Label label;
                 if (aItem.getModelObject().targetAddr == -1

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.io.IOException;
@@ -50,6 +51,7 @@ import org.apache.wicket.markup.repeater.RefreshingView;
 import org.apache.wicket.markup.repeater.util.ModelIteratorAdapter;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.request.cycle.RequestCycle;
@@ -78,6 +80,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegist
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.LinkWithRoleModel;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.Renderer;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderSlotsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.TypeUtil;
@@ -158,40 +161,59 @@ public class LinkFeatureEditor
                 };
             }
 
+            private String getRole(LinkWithRoleModel aModel)
+            {
+                AnnotatorState state = stateModel.getObject();
+
+                if (aModel.targetAddr <= -1) {
+                    return "";
+                }
+
+                CAS cas;
+                try {
+                    cas = actionHandler.getEditorCas();
+                }
+                catch (IOException e) {
+                    handleException(this, null, e);
+                    return "";
+                }
+
+                FeatureStructure fs = selectFsByAddr(cas, aModel.targetAddr);
+                AnnotationLayer layer = annotationService.findLayer(state.getProject(), fs);
+
+                if (!traits.isEnableRoleLabels()) {
+                    return layer.getUiName();
+                }
+
+                TypeAdapter adapter = annotationService.getAdapter(layer);
+                Renderer renderer = layerSupportRegistry.getLayerSupport(layer).createRenderer(
+                        layer, () -> annotationService.listAnnotationFeature(layer));
+                List<AnnotationFeature> features = annotationService.listAnnotationFeature(layer);
+                Map<String, String> renderedFeatures = renderer.renderLabelFeatureValues(adapter,
+                        fs, features);
+
+                String roleLabel = TypeUtil.getUiLabelText(adapter, renderedFeatures);
+                if (isEmpty(roleLabel)) {
+                    roleLabel = aModel.role + ": " + layer.getUiName();
+                }
+                else {
+                    roleLabel = aModel.role + ": " + layer.getUiName() + ": " + roleLabel;
+                }
+
+                return roleLabel;
+            }
+            
             @Override
             protected void populateItem(final Item<LinkWithRoleModel> aItem)
             {
                 AnnotatorState state = stateModel.getObject();
 
                 aItem.setModel(new CompoundPropertyModel<>(aItem.getModelObject()));
-                Label role;
-                if (!traits.isEnableRoleLabels() && aItem.getModelObject().targetAddr > -1) {
-                    try {
-                        CAS cas = actionHandler.getEditorCas();
-                        FeatureStructure fs =
-                                selectFsByAddr(cas, aItem.getModelObject().targetAddr);
-                        AnnotationLayer layer =
-                                annotationService.findLayer(state.getProject(),  fs);
-                        TypeAdapter adapter =
-                                annotationService.getAdapter(layer);
-                        Renderer renderer = layerSupportRegistry.getLayerSupport(layer)
-                                .createRenderer(layer,
-                                    () -> annotationService.listAnnotationFeature(layer));
-                        List<AnnotationFeature> features =
-                                annotationService.listAnnotationFeature(layer);
-                        Map<String, String> renderedFeatures =
-                                renderer.renderLabelFeatureValues(adapter, fs, features);
-                        String labelText = TypeUtil.getUiLabelText(adapter, renderedFeatures);
-                        role = new Label("role", labelText);
-                    }
-                    catch (IOException e) {
-                        handleException(this, null, e);
-                        role = new Label("role");
-                    }
-                } else {
-                    role = new Label("role");
-                }
-                aItem.add(role);
+                aItem.add(new Label("role",
+                        LoadableDetachableModel.of(() -> getRole(aItem.getModelObject()))));
+
+                aItem.add(new LambdaAjaxLink("jumpToAnnotation", _target -> actionHandler
+                        .actionSelectAndJump(_target, new VID(aItem.getModelObject().targetAddr))));
 
                 final Label label;
                 if (aItem.getModelObject().targetAddr == -1

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/Selection.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/Selection.java
@@ -59,6 +59,9 @@ public class Selection
     // selected span text
     private String text;
     
+    private String originText;
+    private String targetText;
+    
     public Selection()
     {
         // Nothing to do
@@ -68,6 +71,8 @@ public class Selection
     {
         selectedAnnotationId = aVid;
         text = "[" + aOriginFs.getCoveredText() + "] - [" + aTargetFs.getCoveredText() + "]";
+        originText = aOriginFs.getCoveredText();
+        targetText = aTargetFs.getCoveredText();
         beginOffset = Math.min(aOriginFs.getBegin(), aTargetFs.getBegin());
         endOffset = Math.max(aOriginFs.getEnd(), aTargetFs.getEnd());
         
@@ -95,6 +100,8 @@ public class Selection
         // Properties used when an arc is selected
         originSpanId = -1;
         targetSpanId = -1;
+        originText = null;
+        targetText = null;
         
         LOG.debug("Span: {}", this);
         
@@ -169,7 +176,22 @@ public class Selection
     {
         return text;
     }
+    
+    public String getOriginText()
+    {
+        return originText;
+    }
+    
+    public String getTargetText()
+    {
+        return targetText;
+    }
 
+    /**
+     * @deprecated Should no longer be used. Instead, text is set implicitly through
+     * {@link #selectSpan} and {@code #selectArc}.
+     */
+    @Deprecated
     public void setText(String aText)
     {
         text = aText;
@@ -180,6 +202,8 @@ public class Selection
      * have to point at an existing annotation. It can also point just at a span of text or at the
      * endpoints of a relation. In this case, the enpoints or begin/end offsets are set, but not the
      * annotation ID.
+     * 
+     * @return  the VID;
      */
     public VID getAnnotation()
     {
@@ -196,6 +220,10 @@ public class Selection
         int tempSpanId = originSpanId;
         originSpanId = targetSpanId;
         targetSpanId = tempSpanId;
+        
+        String tempText = originText;
+        originText = targetText;
+        targetText = tempText;
         
         fireSelectionChanged();
     }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -165,7 +165,8 @@ public abstract class AnnotationDetailEditorPanel
                 new StringResourceModel("ReplaceDialog.title", this, null),
                 new StringResourceModel("ReplaceDialog.text", this, null)));
         add(layerSelectionPanel = new LayerSelectionPanel("layerContainer", getModel(), this));
-        add(selectedAnnotationInfoPanel = new AnnotationInfoPanel("infoContainer", getModel()));
+        add(selectedAnnotationInfoPanel = new AnnotationInfoPanel("infoContainer", getModel(),
+                this));
         add(featureEditorListPanel = new FeatureEditorListPanel("featureEditorContainer",
                 getModel(), this));
         add(relationListPanel = new AttachedAnnotationListPanel("relationListContainer", aPage,
@@ -560,6 +561,59 @@ public abstract class AnnotationDetailEditorPanel
 
         // Ensure we re-render and update the highlight
         onChange(aTarget);
+    }
+    
+    @Override
+    public void actionSelect(AjaxRequestTarget aTarget, AnnotationFS annoFs)
+        throws IOException, AnnotationException
+    {
+        AnnotatorState state = getModelObject();
+        
+        TypeAdapter adapter = annotationService
+                .getAdapter(annotationService.findLayer(state.getProject(), annoFs));
+        
+        adapter.select(getModelObject(), annoFs);
+        actionSelect(aTarget);
+    }
+
+    @Override
+    public void actionSelect(AjaxRequestTarget aTarget, VID aVid)
+        throws IOException, AnnotationException
+    {
+        actionSelect(aTarget, selectAnnotationByAddr(editorPage.getEditorCas(), aVid.getId()));
+    }
+    
+    @Override
+    public void actionJump(AjaxRequestTarget aTarget, AnnotationFS aFS)
+        throws IOException, AnnotationException
+    {
+        editorPage.actionShowSelectedDocument(aTarget, getModelObject().getDocument(),
+                aFS.getBegin(), aFS.getEnd());
+    }
+    
+    @Override
+    public void actionJump(AjaxRequestTarget aTarget, VID aVid)
+        throws IOException, AnnotationException
+    {
+        actionJump(aTarget, selectAnnotationByAddr(editorPage.getEditorCas(), aVid.getId()));
+    }
+    
+    @Override
+    public void actionSelectAndJump(AjaxRequestTarget aTarget, AnnotationFS annoFs)
+        throws IOException, AnnotationException
+    {
+        actionSelect(aTarget, annoFs);
+        editorPage.actionShowSelectedDocument(aTarget, getModelObject().getDocument(),
+                annoFs.getBegin(), annoFs.getEnd());
+    }
+    
+    @Override
+    public void actionSelectAndJump(AjaxRequestTarget aTarget, VID aVid)
+        throws IOException, AnnotationException
+    {
+        CAS cas = editorPage.getEditorCas();
+        AnnotationFS annoFs = selectAnnotationByAddr(cas, aVid.getId());
+        actionSelectAndJump(aTarget, annoFs);
     }
 
     @Override

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.properties
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.properties
@@ -16,6 +16,8 @@
 defaultAnnotationLayer.null=-NONE-
 
 text=Text
+origin=From
+target=To
 
 DeleteDialog.title=Delete Annotation
 DeleteDialog.text=You are about to delete a <b>${uiName}</b> annotation and <b>{0} relation(s)/link(s)</b> attached to it. Are you sure?

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.html
@@ -35,16 +35,7 @@
             <span class="form-control" readonly><wicket:container wicket:id="selectedAnnotationLayer"/></span>
           </div>
         </div>
-        <div class="form-group form-row">
-          <label class="feature-editor-label col-form-label">
-            <wicket:message key="text"/> 
-            <a wicket:id="jumpToAnnotation" class="float-right"><i class="fas fa-crosshairs"></i></a>
-          </label>
-          
-          <div class="feature-editor-value form-control scrolling" style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly>
-            <wicket:container wicket:id="selectedText"/>
-          </div>
-        </div>
+        <wicket:container wicket:id="annotationText"/>
       </div>
     </div>
   </wicket:panel>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.java
@@ -23,20 +23,16 @@ import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
 import java.io.IOException;
 
-import org.apache.wicket.Component;
-import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.model.PropertyModel;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 
 public class AnnotationInfoPanel extends Panel
 {
@@ -44,10 +40,15 @@ public class AnnotationInfoPanel extends Panel
 
     private final WebMarkupContainer noAnnotationWarning;
     private final WebMarkupContainer annotationInfo;
+    
+    private final AnnotationDetailEditorPanel actionHandler;
 
-    public AnnotationInfoPanel(String aId, IModel<AnnotatorState> aModel)
+    public AnnotationInfoPanel(String aId, IModel<AnnotatorState> aModel,
+            AnnotationDetailEditorPanel aOwner)
     {
         super(aId, aModel);
+        
+        actionHandler = aOwner;
 
         setOutputMarkupPlaceholderTag(true);
         
@@ -66,8 +67,7 @@ public class AnnotationInfoPanel extends Panel
         annotationInfo.setOutputMarkupPlaceholderTag(true);
         annotationInfo.add(visibleWhen(this::isAnnotationSelected));
         annotationInfo.add(createSelectedAnnotationTypeLabel());
-        annotationInfo.add(createSelectedTextLabel());
-        annotationInfo.add(createJumpToAnnotationLink());
+        annotationInfo.add(new AnnotationTextPanel("annotationText", actionHandler, aModel));
         annotationInfo.add(createSelectedAnnotationLayerLabel());
         add(annotationInfo);
     }
@@ -113,27 +113,5 @@ public class AnnotationInfoPanel extends Panel
         label.add(visibleWhen(() -> getModelObject().getSelection().getAnnotation().isSet()
                 && DEVELOPMENT.equals(getApplication().getConfigurationType())));
         return label;
-    }
-
-
-    
-    private Component createSelectedTextLabel()
-    {
-        return new Label("selectedText", PropertyModel.of(getModelObject(), "selection.text"))
-                .setOutputMarkupId(true);
-    }
-    
-    private Component createJumpToAnnotationLink()
-    {
-        return new LambdaAjaxLink("jumpToAnnotation", this::actionJumpToAnnotation)
-                .setOutputMarkupId(true);
-    }
-    
-    private void actionJumpToAnnotation(AjaxRequestTarget aTarget) throws IOException
-    {
-        AnnotatorState state = getModelObject();
-        
-        getEditorPage().actionShowSelectedDocument(aTarget, state.getDocument(),
-                state.getSelection().getBegin(), state.getSelection().getEnd());
     }
 }

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+#Copyright 2020
+#Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+#Technische Universität Darmstadt
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="form-group form-row" wicket:enclosure="selectedText">
+      <label class="feature-editor-label col-form-label">
+        <wicket:message key="text"/> 
+        <a wicket:id="jumpToAnnotation" class="float-right"><i class="fas fa-crosshairs"></i></a>
+      </label>
+      
+      <div class="feature-editor-value form-control scrolling" style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly>
+        <wicket:container wicket:id="selectedText"/>
+      </div>
+    </div>
+    
+    <div class="form-group form-row" wicket:enclosure="originText">
+      <label class="feature-editor-label col-form-label">
+        <wicket:message key="origin"/> 
+        <a wicket:id="jumpToOrigin" class="float-right"><i class="fas fa-crosshairs"></i></a>
+      </label>
+      
+      <div class="feature-editor-value form-control scrolling" style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly>
+        <wicket:container wicket:id="originText"/>
+      </div>
+    </div>
+    
+    <div class="form-group form-row" wicket:enclosure="targetText">
+      <label class="feature-editor-label col-form-label">
+        <wicket:message key="target"/> 
+        <a wicket:id="jumpToTarget" class="float-right"><i class="fas fa-crosshairs"></i></a>
+      </label>
+      
+      <div class="feature-editor-value form-control scrolling" style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly>
+        <wicket:container wicket:id="targetText"/>
+      </div>
+    </div>
+  </wicket:panel>
+</body>
+</html>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+
+import java.io.IOException;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+
+public class AnnotationTextPanel
+    extends Panel
+{
+    private static final long serialVersionUID = -7722700418471642307L;
+
+    private @SpringBean AnnotationSchemaService annotationService;
+    
+    private final AnnotationActionHandler actionHandler;
+
+    public AnnotationTextPanel(String aId, AnnotationActionHandler aActionHandler,
+            IModel<AnnotatorState> aModel)
+    {
+        super(aId, aModel);
+
+        actionHandler = aActionHandler;
+
+        add(new Label("selectedText", PropertyModel.of(getModelObject(), "selection.text"))
+                .add(visibleWhen(() -> !isRelationSelected())));
+        add(new LambdaAjaxLink("jumpToAnnotation", this::actionJumpToAnnotation)
+                .add(visibleWhen(() -> !isRelationSelected())));
+        
+        add(new Label("originText", PropertyModel.of(getModelObject(), "selection.originText"))
+                .add(visibleWhen(() -> isRelationSelected())));
+        add(new Label("targetText", PropertyModel.of(getModelObject(), "selection.targetText"))
+                .add(visibleWhen(() -> isRelationSelected())));
+        add(new LambdaAjaxLink("jumpToOrigin", this::actionJumpToOrigin)
+                .add(visibleWhen(() -> isRelationSelected())));
+        add(new LambdaAjaxLink("jumpToTarget", this::actionJumpToTarget)
+                .add(visibleWhen(() -> isRelationSelected())));
+    }
+
+    private boolean isRelationSelected()
+    {
+        return getModelObject().getSelection().isArc();
+    }
+    
+    public AnnotatorState getModelObject()
+    {
+        return (AnnotatorState) getDefaultModelObject();
+    }
+
+    public AnnotationPageBase getEditorPage()
+    {
+        return (AnnotationPageBase) getPage();
+    }
+    
+    private void actionJumpToAnnotation(AjaxRequestTarget aTarget)
+        throws IOException, AnnotationException
+    {
+        actionHandler.actionSelectAndJump(aTarget, getModelObject().getSelection().getAnnotation());
+    }
+
+    private void actionJumpToOrigin(AjaxRequestTarget aTarget)
+        throws IOException, AnnotationException
+    {
+        RelationAdapter typeAdapter = (RelationAdapter) annotationService
+                .getAdapter(getModelObject().getSelectedAnnotationLayer());
+
+        if (typeAdapter.getAttachFeatureName() == null) {
+            actionHandler.actionSelectAndJump(aTarget,
+                    new VID(getModelObject().getSelection().getOrigin()));
+            return;
+        }
+        
+        CAS cas = getEditorPage().getEditorCas();
+        AnnotationFS fs = selectAnnotationByAddr(cas, getModelObject().getSelection().getOrigin());
+        fs = FSUtil.getFeature(fs, typeAdapter.getAttachFeatureName(), AnnotationFS.class);
+        actionHandler.actionSelectAndJump(aTarget, new VID(fs));
+    }
+
+    private void actionJumpToTarget(AjaxRequestTarget aTarget)
+        throws IOException, AnnotationException
+    {
+        RelationAdapter typeAdapter = (RelationAdapter) annotationService
+                .getAdapter(getModelObject().getSelectedAnnotationLayer());
+
+        if (typeAdapter.getAttachFeatureName() == null) {
+            actionHandler.actionSelectAndJump(aTarget,
+                    new VID(getModelObject().getSelection().getTarget()));
+            return;
+        }
+        
+        CAS cas = getEditorPage().getEditorCas();
+        AnnotationFS fs = selectAnnotationByAddr(cas, getModelObject().getSelection().getTarget());
+        fs = FSUtil.getFeature(fs, typeAdapter.getAttachFeatureName(), AnnotationFS.class);
+        actionHandler.actionSelectAndJump(aTarget, new VID(fs));
+    }
+}

--- a/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_link-features.adoc
+++ b/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_link-features.adoc
@@ -25,11 +25,18 @@ button to create the slot. Next, click on field in the newly created slot to *ar
 color will change to indicate that it is armed. Now you can fill the slot by double-clicking on a 
 span annotation. To remove a slot, arm it and then press the *del* button.
 
-== Role labels
+.Navigating along links
+Once a slot has been filled, there is a cross-hair icon in the slot field header which can be used
+to navigate to the slot filler.
 
-If role labels are disabled for the link feature layer they cannot be manually set by the user.
-Instead the UI label of the linked annotation is displayed.
+When a span annotation is selected which acts as a slot filler in any link feature, then the 
+annotation owning the slow is shown in the annotation detail panel. Here, the cross-hair icon can be used to jump to the slot owner.
+
+.Role labels
 If role labels are enabled they can be changed by the user at any time.
 To change a previously selected role label, no prior deletion is needed.
 Just double-click on the instance you want to change, it will be highlighted in orange, and chose
 another role label.
+
+If role labels are disabled for the link feature layer they cannot be manually set by the user.
+Instead the UI label of the linked annotation is displayed.

--- a/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_relation.adoc
+++ b/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_relation.adoc
@@ -34,6 +34,17 @@ the source and target spans. If this is the case, there are two ways of creating
   simultaneously visible (i.e. on the same "page" of the document). So you may have to increase the
   number of visible rows in the settings dialog to make them visible.
 
+.Navigating along relations
+When a relation annotation is selected, the annotation detail panel includes two fields **From** and
+**To** which indicate the origin and target annotations of the relation. These fields include a small
+cross-hair icon which can be used to jump to the respective annotations.
+
+When a span annotation is selected, and incoming or outgoing relations are also shown in the
+annotation detail panel. Here, the cross-hair icon can be used to jump to the other endpoint of the
+relation (i.e. to the other span annotation). There is also an icon indicating whether the relation
+is incoming to the selected span annotation or whether it is outgoing from the current span.
+Clicking on this icon will select the relation annotation itself.
+
 Depending on the layer behavior configuration, relation annotations can stack, can cross each other,
 and can cross sentence boundaries.
 
@@ -48,7 +59,7 @@ NOTE: Currently, there can be at most one relation layer per span layer. Relatio
 NOTE: Not all arcs displayed in the annotation view are belonging to chain or relation layers. Some
       are induced by <<sect_annotation_link_features>>.
 
-When moving the mouse over an annotation with outgoing relations, the info popup includes the
+When moving the mouse over an annotation with outgoing relations, the info pop-up includes the
 *yield* of the relations. This is the text transitively covered by the outgoing relations. This
 is useful e.g. in order to see all text governed the head of a particular dependency relation.
 The text may be abbreviated.

--- a/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/AnnotationSelection.java
+++ b/webanno-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/AnnotationSelection.java
@@ -34,7 +34,7 @@ public class AnnotationSelection
 
     public AnnotationSelection()
     {
-        // TODO Auto-generated constructor stub
+        // Nothing to do
     }
     
     public Map<String, Integer> getAddressByUsername()

--- a/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects.adoc
+++ b/webanno-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects.adoc
@@ -25,8 +25,6 @@ NOTE: This functionality is only available to *managers* of existing projects,
 This is the place to specify/edit annotation projects.  
 You can either select one of the existing projects for editing, or click *Create Project* to add a project.
 
-Although correction and automation projects function similarly, the management differs after the creation of the document. For further description, look at the corresponding chapters <<sect_automation>> and <<sect_correction>>.
-
 Click on *Create Project* to create a new project. 
 
 image::project1.jpg[align="center"]


### PR DESCRIPTION
**What's in the PR**
- Added jump-to-target buttons for relations and also for link features
- Use a hand pointer over link features to indicate that clicking on them triggers an action
- Improved API for jumping to places
- Include the layer of the target in the role label or relation target label

**How to test manually**
* Create a relation between two spans
* Click on the relation and observer that instead of the "text" field there are now "from" and "to" fields with navigation buttons (crosshair)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
