### PR TITLE
#1291 - Creating tag sets with embedded db slow

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -51,14 +51,24 @@ public interface AnnotationSchemaService
     String SERVICE_NAME = "annotationService";
     
     /**
-     * creates a {@link Tag} for a given {@link TagSet}. Combination of {@code tag name} and
-     * {@code tagset name} should be unique
+     * Creates a {@link Tag}. Combination of {@code tag name} and {@code tagset name} should be
+     * unique.
      *
      * @param tag
      *            the tag.
      */
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER')")
     void createTag(Tag tag);
+
+    /**
+     * Creates multiple {@link Tag tags} at once. Combination of {@code tag name} and
+     * {@code tagset name} should be unique.
+     *
+     * @param tag
+     *            the tag.
+     */
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER')")
+    void createTags(Tag... tag);
 
     /**
      * creates a {@link TagSet} object in the database

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/JsonImportUtil.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/JsonImportUtil.java
@@ -19,6 +19,8 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 
@@ -94,33 +96,33 @@ public class JsonImportUtil
         return createTagSet(project, importedTagSet, aAnnotationService);
     }
     
-    public static TagSet createTagSet(Project project,
-            ExportedTagSet importedTagSet,
+    public static TagSet createTagSet(Project project, ExportedTagSet aExTagSet,
             AnnotationSchemaService aAnnotationService)
         throws IOException
     {
-        String importedTagSetName = importedTagSet.getName();
-        if (aAnnotationService.existsTagSet(importedTagSetName, project)) {
-            // aAnnotationService.removeTagSet(aAnnotationService.getTagSet(
-            // importedTagSet.getName(), project));
-            // Rename Imported TagSet instead of deleting the old one.
-            importedTagSetName = copyTagSetName(aAnnotationService, importedTagSetName, project);
+        String exTagSetName = aExTagSet.getName();
+        if (aAnnotationService.existsTagSet(exTagSetName, project)) {
+            exTagSetName = copyTagSetName(aAnnotationService, exTagSetName, project);
+        }
+        
+        TagSet newTagSet = new TagSet();
+        newTagSet.setDescription(aExTagSet.getDescription());
+        newTagSet.setName(exTagSetName);
+        newTagSet.setLanguage(aExTagSet.getLanguage());
+        newTagSet.setProject(project);
+        newTagSet.setCreateTag(aExTagSet.isCreateTag());
+        aAnnotationService.createTagSet(newTagSet);
+                
+        List<Tag> tags = new ArrayList<>();
+        for (ExportedTag exTag : aExTagSet.getTags()) {
+            Tag tag = new Tag();
+            tag.setDescription(exTag.getDescription());
+            tag.setTagSet(newTagSet);
+            tag.setName(exTag.getName());
+            tags.add(tag);
         }
 
-        TagSet newTagSet = new TagSet();
-        newTagSet.setDescription(importedTagSet.getDescription());
-        newTagSet.setName(importedTagSetName);
-        newTagSet.setLanguage(importedTagSet.getLanguage());
-        newTagSet.setProject(project);
-        newTagSet.setCreateTag(importedTagSet.isCreateTag());
-        aAnnotationService.createTagSet(newTagSet);
-        for (ExportedTag tag : importedTagSet.getTags()) {
-            Tag newTag = new Tag();
-            newTag.setDescription(tag.getDescription());
-            newTag.setName(tag.getName());
-            newTag.setTagSet(newTagSet);
-            aAnnotationService.createTag(newTag);
-        }
+        aAnnotationService.createTags(tags.stream().toArray(Tag[]::new));
         
         return newTagSet;
     }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -153,6 +153,15 @@ public class AnnotationSchemaServiceImpl
 
     @Override
     @Transactional
+    public void createTags(Tag... aTags)
+    {
+        for (Tag tag : aTags) {
+            createTag(tag);
+        }
+    }
+
+    @Override
+    @Transactional
     public void createTagSet(TagSet aTagSet)
     {
         if (isNull(aTagSet.getId())) {

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/TagSetExporter.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/TagSetExporter.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
 
 import org.slf4j.Logger;
@@ -87,11 +89,11 @@ public class TagSetExporter
         // this is projects prior to version 2.0
         if (aExProject.getVersion() == 0) {
             importTagSetsV0(aProject, aExProject);
+            return;
         }
-        else {
-            for (ExportedTagSet exTagSet : aExProject.getTagSets()) {
-                importTagSet(new TagSet(), exTagSet, aProject);
-            }
+        
+        for (ExportedTagSet exTagSet : aExProject.getTagSets()) {
+            importTagSet(new TagSet(), exTagSet, aProject);
         }
     }
     
@@ -163,16 +165,24 @@ public class TagSetExporter
         aTagSet.setProject(aProject);
         annotationService.createTagSet(aTagSet);
 
+        Set<String> existingTags = annotationService.listTags(aTagSet).stream() //
+                .map(Tag::getName) //
+                .collect(Collectors.toSet());
+        
+        List<Tag> tags = new ArrayList<>();
         for (ExportedTag exTag : aExTagSet.getTags()) {
             // do not duplicate tag
-            if (annotationService.existsTag(exTag.getName(), aTagSet)) {
+            if (existingTags.contains(exTag.getName())) {
                 continue;
             }
+            
             Tag tag = new Tag();
             tag.setDescription(exTag.getDescription());
             tag.setTagSet(aTagSet);
             tag.setName(exTag.getName());
-            annotationService.createTag(tag);
+            tags.add(tag);
         }
+
+        annotationService.createTags(tags.stream().toArray(Tag[]::new));
     }
 }

--- a/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
+++ b/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
@@ -103,7 +103,7 @@ public class TagSetEditorPanel
                 .setRequired(true));
         form.add(new TextField<String>("language"));
         form.add(new TextArea<String>("description"));
-        form.add(new CheckBox("createTag"));
+        form.add(new CheckBox("createTag").setOutputMarkupId(true));
         
         form.add(new LambdaAjaxButton<>("save", this::actionSave));
         form.add(new LambdaAjaxLink("delete", this::actionDelete)

--- a/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
+++ b/webanno-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
@@ -89,7 +89,7 @@ public class TagSetImportPanel
         format.setModelObject(JSON_FORMAT); // Set after adding to form to have access to for model
         format.setRequired(true);
         
-        form.add(new CheckBox("overwrite"));
+        form.add(new CheckBox("overwrite").setOutputMarkupId(true));
         
         form.add(fileUpload = new BootstrapFileInputField("content", new ListModel<>()));
         fileUpload.getConfig().showPreview(false);


### PR DESCRIPTION
**What's in the PR**
- Batch importing tags into one transaction
- Improve synchronization on event log to avoid empirically observed deadlock with huge tagsets on HSQLDB
- Fix warnings about missing markup IDs on the tagset management panel

**How to test manually**
* Create a project using the embedded DB
* Import a project with a very large tagset

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
