### PR TITLE
#1822 Annotation disabled for curator

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.model;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CURATION_USER;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.wicket.event.Broadcast.BREADTH;
 
@@ -689,8 +688,7 @@ public class AnnotatorStateImpl
     @Override
     public boolean isUserViewingOthersWork(String aCurrentUserName)
     {
-        return !CURATION_USER.equals(aCurrentUserName) && 
-                !user.getUsername().equals(aCurrentUserName);
+        return !user.getUsername().equals(aCurrentUserName);
     }
 
     @SuppressWarnings("unchecked")

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.page;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.getSentenceNumber;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectSentenceCovering;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
@@ -296,7 +297,10 @@ public abstract class AnnotationPageBase
             throw new NotEditableException("No document selected");
         }
 
-        if (state.getMode().equals(CURATION)) {
+        // If curating (check mode for curation page and user for curation sidebar), 
+        // then it is editable unless the curation is finished
+        if (state.getMode().equals(CURATION) || 
+                state.getUser().getUsername().equals(CURATION_USER)) {
             if (state.getDocument().getState().equals(CURATION_FINISHED)) {
                 throw new NotEditableException("Curation is already finished. You can put it back "
                                 + "into progress via the monitoring page.");
@@ -325,8 +329,10 @@ public abstract class AnnotationPageBase
             return false;
         }
         
-        // If curating, then it is editable unless the curation is finished
-        if (state.getMode().equals(CURATION)) {
+        // If curating (check mode for curation page and user for curation sidebar), 
+        // then it is editable unless the curation is finished
+        if (state.getMode().equals(CURATION) || 
+                state.getUser().getUsername().equals(CURATION_USER)) {
             return !CURATION_FINISHED.equals(state.getDocument().getState());
         }
         

--- a/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationDocumentStateTransition.java
+++ b/webanno-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationDocumentStateTransition.java
@@ -42,7 +42,7 @@ public enum AnnotationDocumentStateTransition
      */
     NEW_TO_IGNORE,
     /**
-     * Change document state from IGNOR back to NEW
+     * Change document state from IGNORE back to NEW
      */
     IGNORE_TO_NEW;
 

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PAGE_PARAM_PROJ
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateUtils.updateDocumentTimestampAfterWrite;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorStateUtils.verifyAndUpdateDocumentTimestamp;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.FocusPosition.TOP;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition.ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition.NEW_TO_ANNOTATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 
@@ -527,6 +528,16 @@ public class AnnotationPage
                 if (AnnotationDocumentState.NEW.equals(annotationDocument.getState())) {
                     documentService.transitionAnnotationDocumentState(annotationDocument,
                             AnnotationDocumentStateTransition.NEW_TO_ANNOTATION_IN_PROGRESS);
+                }
+
+                if (state.getUser().getUsername().equals(CURATION_USER)) {
+                    SourceDocument sourceDoc = state.getDocument();
+                    SourceDocumentState sourceDocState = sourceDoc.getState();
+                    if (!sourceDocState.equals(SourceDocumentState.CURATION_IN_PROGRESS) 
+                            && !sourceDocState.equals(SourceDocumentState.CURATION_FINISHED)) {
+                        documentService.transitionSourceDocumentState(sourceDoc, 
+                                ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS);
+                    }
                 }
             }
             

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotatorWorkflowActionBarItemGroup.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotatorWorkflowActionBarItemGroup.java
@@ -32,9 +32,11 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameModifier;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ChallengeResponseDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
@@ -116,6 +118,12 @@ public class AnnotatorWorkflowActionBarItemGroup
             // manually update state change!! No idea why it is not updated in the DB
             // without calling createAnnotationDocument(...)
             documentService.createAnnotationDocument(annotationDocument);
+            
+            // curation sidebar: need to update source doc state as well to finished
+            if (state.getUser().getUsername().equals(WebAnnoConst.CURATION_USER)) {
+                documentService.transitionSourceDocumentState(state.getDocument(),
+                        SourceDocumentStateTransition.CURATION_IN_PROGRESS_TO_CURATION_FINISHED);
+            }
 
             _target.add(page);
         });


### PR DESCRIPTION
For https://github.com/inception-project/inception/pull/1872 regarding document state for curation when curating from sidebar.

**What's in the PR**
* Fixed that annotation was disabled by adding curation check to `editable`-methods
* Now tracking and transitioning curation document status in annotation mode to support curation sidebar and keep document state up to date (cf. Monitoring Page)

**How to test manually**
* Annotate, curate and finish documents and check that document state is up to date.
