### PR TITLE
#1838 - Moving between documents shouldn't throw exceptions

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/docnav/DocumentNavigator.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/docnav/DocumentNavigator.java
@@ -24,6 +24,7 @@ import static wicket.contrib.input.events.key.KeyType.Page_up;
 import static wicket.contrib.input.events.key.KeyType.Shift;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -75,7 +76,13 @@ public class DocumentNavigator
      */
     public void actionShowPreviousDocument(AjaxRequestTarget aTarget)
     {
-        page.getModelObject().moveToPreviousDocument(page.getListOfDocs());
+        boolean documentChanged = page.getModelObject()
+                .moveToPreviousDocument(page.getListOfDocs());
+        if (!documentChanged) {
+            info("There is no previous document");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
         page.actionLoadDocument(aTarget);
     }
 
@@ -84,7 +91,12 @@ public class DocumentNavigator
      */
     public void actionShowNextDocument(AjaxRequestTarget aTarget)
     {
-        page.getModelObject().moveToNextDocument(page.getListOfDocs());
+        boolean documentChanged = page.getModelObject().moveToNextDocument(page.getListOfDocs());
+        if (!documentChanged) {
+            info("There is no next document");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
         page.actionLoadDocument(aTarget);
     }
 

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorDocumentNavigation.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorDocumentNavigation.java
@@ -37,29 +37,62 @@ public interface AnnotatorDocumentNavigation
     // ---------------------------------------------------------------------------------------------
     // Navigation within or across a document
     // ---------------------------------------------------------------------------------------------
-    default void moveToPreviousDocument(List<SourceDocument> aDocuments)
+    default boolean hasPreviousDocument(List<SourceDocument> aDocuments)
+    {
+        return aDocuments.indexOf(getDocument()) > 0;
+    }
+
+    default boolean hasNextDocument(List<SourceDocument> aDocuments)
+    {
+        int currentDocumentIndex = aDocuments.indexOf(getDocument());
+        return currentDocumentIndex >= 0 && currentDocumentIndex < aDocuments.size() - 1;
+    }
+
+    /**
+     * Moves the selection to the document preceding the current document in the given list. Has no
+     * effect if the current document is already the first document or if the current document is
+     * not actually part of the given list.
+     * 
+     * @param aDocuments
+     *            a list of documents.
+     * @return whether the current document has changed.
+     */
+    default boolean moveToPreviousDocument(List<SourceDocument> aDocuments)
     {
         // Index of the current source document in the list
         int currentDocumentIndex = aDocuments.indexOf(getDocument());
 
         // If the first the document
         if (currentDocumentIndex <= 0) {
-            throw new IllegalStateException("This is the first document!");
+            return false;
         }
 
         setDocument(aDocuments.get(currentDocumentIndex - 1), aDocuments);
+
+        return true;
     }
 
-    default void moveToNextDocument(List<SourceDocument> aDocuments)
+    /**
+     * Moves the selection to the document following the current document in the given list. Has no
+     * effect if the current document is already the last document or if the current document is not
+     * actually part of the given list.
+     * 
+     * @param aDocuments
+     *            a list of documents.
+     * @return whether the current document has changed.
+     */
+    default boolean moveToNextDocument(List<SourceDocument> aDocuments)
     {
         // Index of the current source document in the list
         int currentDocumentIndex = aDocuments.indexOf(getDocument());
 
         // If the last document
-        if (currentDocumentIndex >= aDocuments.size() - 1) {
-            throw new IllegalStateException("This is the last document!");
+        if (currentDocumentIndex < 0 || currentDocumentIndex >= aDocuments.size() - 1) {
+            return false;
         }
 
         setDocument(aDocuments.get(currentDocumentIndex + 1), aDocuments);
+
+        return true;
     }
 }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -104,25 +104,6 @@ public abstract class AnnotationPageBase
     }
 
     /**
-     * Show the previous document, if exist
-     */
-    @Deprecated
-    protected void actionShowPreviousDocument(AjaxRequestTarget aTarget)
-    {
-        getModelObject().moveToPreviousDocument(getListOfDocs());
-        actionLoadDocument(aTarget);
-    }
-
-    /**
-     * Show the next document if exist
-     */
-    protected void actionShowNextDocument(AjaxRequestTarget aTarget)
-    {
-        getModelObject().moveToNextDocument(getListOfDocs());
-        actionLoadDocument(aTarget);
-    }
-
-    /**
      * Show the specified document.
      * 
      * @return whether the document had to be switched or not.


### PR DESCRIPTION
**What's in the PR**
- Show messages that there are not next/prev documents without having to use an exception to do so.

**How to test manually**
* Try switching beyond the first/last document

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
