### PR TITLE
#1865 - Annotation details still shown even tough selection has been cleared

### DIFF
--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ClassicKendoComboboxTextFeatureEditor.java
@@ -107,7 +107,6 @@ public class ClassicKendoComboboxTextFeatureEditor
                 Optional<AjaxRequestTarget> target = RequestCycle.get()
                         .find(AjaxRequestTarget.class);
                 if (target.isPresent()) {
-                    LOG.trace("onInitialize() requesting datasource re-reading");
                     target.get()
                             .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
                                     "var $w = %s; if ($w) { $w.dataSource.read(); }",

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.java
@@ -17,11 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
-import static com.googlecode.wicket.kendo.ui.KendoUIBehavior.widget;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -36,6 +36,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
+import com.googlecode.wicket.kendo.ui.KendoUIBehavior;
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBoxBehavior;
 
@@ -45,6 +46,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.TagEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketUtil;
 
 /**
  * String feature editor using a Kendo ComboBox field.
@@ -147,21 +149,14 @@ public class KendoComboboxTextFeatureEditor
 
                 // Trigger a re-loading of the tagset from the server as constraints may have
                 // changed the ordering
-                RequestCycle.get().find(AjaxRequestTarget.class).ifPresent(target -> {
-                    LOG.trace("onInitialize() requesting datasource re-reading");
-                    // @formatter:off
-                    target.appendJavaScript(String.join("\n",
-                            "try {",
-                            "  var $w = " + widget(this, ComboBoxBehavior.METHOD) + ";",
-                            "  if ($w) {",
-                            "    $w.dataSource.read();",
-                            "  }",
-                            "}",
-                            "catch(error) {",
-                            "  console.error(error);",
-                            "}"));
-                    // @formatter:on
-                });
+                Optional<AjaxRequestTarget> target = RequestCycle.get()
+                        .find(AjaxRequestTarget.class);
+                if (target.isPresent()) {
+                    target.get()
+                            .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
+                                    "var $w = %s; if ($w) { $w.dataSource.read(); }",
+                                    KendoUIBehavior.widget(this, ComboBoxBehavior.METHOD))));
+                }
             }
         };
     }

--- a/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/webanno-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -304,7 +304,6 @@ public class LinkFeatureEditor
                     Optional<AjaxRequestTarget> target = RequestCycle.get()
                             .find(AjaxRequestTarget.class);
                     if (target.isPresent()) {
-                        LOG.trace("onInitialize() requesting datasource re-reading");
                         target.get()
                                 .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
                                         "var $w = %s; if ($w) { $w.dataSource.read(); }",

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -547,14 +547,13 @@ public abstract class AnnotationDetailEditorPanel
     @Override
     public void actionSelect(AjaxRequestTarget aTarget) throws IOException, AnnotationException
     {
-        if (aTarget != null) {
-            aTarget.add(buttonContainer);
-        }
-
         // Edit existing annotation
         loadFeatureEditorModels(aTarget);
+
         if (aTarget != null) {
-            aTarget.add(selectedAnnotationInfoPanel, featureEditorListPanel, relationListPanel);
+            refresh(aTarget);
+            // aTarget.add(buttonContainer);
+            // aTarget.add(selectedAnnotationInfoPanel, featureEditorListPanel, relationListPanel);
         }
 
         // Ensure we re-render and update the highlight
@@ -689,11 +688,13 @@ public abstract class AnnotationDetailEditorPanel
         internalCompleteAnnotation(aTarget, aCas);
 
         if (aTarget != null) {
-            // After the annotation has been created, we need to re-render the button container e.g.
-            // to make the buttons show up if previously no annotation was selected
-            aTarget.add(buttonContainer);
-            // Also update the features and selected annotation info
-            aTarget.add(selectedAnnotationInfoPanel, featureEditorListPanel, relationListPanel);
+            refresh(aTarget);
+            // // After the annotation has been created, we need to re-render the button container
+            // e.g.
+            // // to make the buttons show up if previously no annotation was selected
+            // aTarget.add(buttonContainer);
+            // // Also update the features and selected annotation info
+            // aTarget.add(selectedAnnotationInfoPanel, featureEditorListPanel, relationListPanel);
         }
 
         state.clearArmedSlot();
@@ -1385,6 +1386,19 @@ public abstract class AnnotationDetailEditorPanel
     }
 
     /**
+     * Re-render the sidebar if the selection has changed.
+     */
+    @OnEvent
+    public void onSelectionChangedEvent(SelectionChangedEvent aEvent)
+    {
+        if (aEvent.getRequestHandler() != null) {
+            refresh(aEvent.getRequestHandler());
+            // aEvent.getRequestHandler().add(selectedAnnotationInfoPanel, featureEditorListPanel,
+            // relationListPanel);
+        }
+    }
+
+    /**
      * @deprecated Use event listeners for {@link SelectionChangedEvent}, {@link AnnotationEvent},
      *             {@link FeatureValueUpdatedEvent} and/or {@link AnnotatorViewportChangedEvent}
      *             instead.
@@ -1550,10 +1564,6 @@ public abstract class AnnotationDetailEditorPanel
         // Clear selection and feature states
         state.getFeatureStates().clear();
         state.getSelection().clear();
-        if (aTarget != null) {
-            aTarget.add(selectedAnnotationInfoPanel, buttonContainer, featureEditorListPanel,
-                    relationListPanel);
-        }
 
         // Refresh the selectable layers dropdown
         layerSelectionPanel.refreshSelectableLayers();


### PR DESCRIPTION
**What's in the PR**
- Listen to the SelectionChanged event in the AnnotationDetailEditorPanel and re-render if the selection changes
- Remove outdated logging messages
- Harmonize code to re-read Kendo datasources during rendering

**How to test manually**
* See https://github.com/inception-project/inception/issues/1791

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
