### PR TITLE
#1887 - Race condition for shared-read-only access can cause re-initialization of CAS

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -753,6 +753,16 @@ public class DocumentServiceImpl
 
     @Override
     @Transactional
+    public void writeAnnotationCas(CAS aCas, SourceDocument aDocument, String aUser,
+            boolean aUpdateTimestamp)
+        throws IOException
+    {
+        AnnotationDocument annotationDocument = getAnnotationDocument(aDocument, aUser);
+        writeAnnotationCas(aCas, annotationDocument, aUpdateTimestamp);
+    }
+
+    @Override
+    @Transactional
     public void writeAnnotationCas(CAS aCas, SourceDocument aDocument, User aUser,
             boolean aUpdateTimestamp)
         throws IOException

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -745,6 +745,13 @@ public class DocumentServiceImpl
     }
 
     @Override
+    public void deleteAnnotationCas(SourceDocument aSourceDocument, String aUsername)
+        throws IOException
+    {
+        casStorageService.deleteCas(aSourceDocument, aUsername);
+    }
+
+    @Override
     public void deleteAnnotationCas(AnnotationDocument aAnnotationDocument) throws IOException
     {
         casStorageService.deleteCas(aAnnotationDocument.getDocument(),

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasHolder.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasHolder.java
@@ -17,9 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
+
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.uima.cas.CAS;
 
 /**
@@ -139,7 +140,7 @@ public class CasHolder
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).append("key", key)
+        return new ToStringBuilder(this, SHORT_PREFIX_STYLE).append("key", key)
                 .append("deleted", deleted).append("typeSystemOutdated", typeSystemOutdated)
                 .toString();
     }

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasStorageSession.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/CasStorageSession.java
@@ -165,8 +165,10 @@ public class CasStorageSession
         LOGGER.trace("CAS storage session [{}]: closing...", hashCode());
 
         managedCases.values().forEach(casByUser -> casByUser.values().forEach(managedCas -> {
-            LOGGER.trace("CAS storage session [{}]: releasing {}", hashCode(), managedCas);
-            managedCas.getCas().release();
+            if (managedCas.isReleaseOnClose()) {
+                LOGGER.trace("CAS storage session [{}]: releasing {}", hashCode(), managedCas);
+                managedCas.getCas().release();
+            }
         }));
 
         LOGGER.trace("CAS storage session [{}]: closed", hashCode());

--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/SessionManagedCas.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/casstorage/SessionManagedCas.java
@@ -36,6 +36,7 @@ public class SessionManagedCas
     private final CAS cas;
     private final CasHolder casHolder;
 
+    private boolean shouldReleaseOnClose = true;
     private int readCount;
     private int writeCount;
 
@@ -50,6 +51,7 @@ public class SessionManagedCas
         mode = aMode;
         cas = aCas;
         casHolder = null;
+        shouldReleaseOnClose = true;
     }
 
     public SessionManagedCas(long aSourceDocumentId, String aUserId, CasAccessMode aMode,
@@ -84,6 +86,16 @@ public class SessionManagedCas
     public CasAccessMode getMode()
     {
         return mode;
+    }
+
+    public void setReleaseOnClose(boolean aReleaseOnClose)
+    {
+        shouldReleaseOnClose = aReleaseOnClose;
+    }
+
+    public boolean isReleaseOnClose()
+    {
+        return shouldReleaseOnClose;
     }
 
     public boolean isCasSet()
@@ -169,8 +181,7 @@ public class SessionManagedCas
             builder.append("purpose", userId);
         }
 
-        return builder.append("cas", cas.hashCode()).append("m", mode).append("r", readCount)
-                .append("w", writeCount).toString();
-
+        return builder.append("cas", cas != null ? cas.hashCode() : "[NULL]").append("m", mode)
+                .append("r", readCount).append("w", writeCount).toString();
     }
 }

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/CasStorageServiceImplTest.java
@@ -17,44 +17,51 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.NO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils.getInternalTypeSystem;
 import static de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession.openNested;
+import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.apache.uima.fit.factory.CasFactory.createCas;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.CASException;
-import org.apache.uima.cas.SerialFormat;
 import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.util.CasCreationUtils;
-import org.apache.uima.util.CasIOUtils;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSessionException;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
@@ -65,10 +72,20 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public class CasStorageServiceImplTest
 {
+    private Logger log = LoggerFactory.getLogger(getClass());
+
+    private AtomicBoolean exception = new AtomicBoolean(false);
+    private AtomicBoolean rwTasksCompleted = new AtomicBoolean(false);
+    private AtomicInteger managedReadCounter = new AtomicInteger(0);
+    private AtomicInteger unmanagedReadCounter = new AtomicInteger(0);
+    private AtomicInteger unmanagedNonInitializingReadCounter = new AtomicInteger(0);
+    private AtomicInteger deleteCounter = new AtomicInteger(0);
+    private AtomicInteger deleteInitialCounter = new AtomicInteger(0);
+    private AtomicInteger writeCounter = new AtomicInteger(0);
+
     private CasStorageServiceImpl sut;
     private BackupProperties backupProperties;
     private RepositoryProperties repositoryProperties;
-    private CasStorageSession casStorageSession;
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
@@ -76,7 +93,14 @@ public class CasStorageServiceImplTest
     @Before
     public void setup() throws Exception
     {
-        casStorageSession = CasStorageSession.open();
+        exception.set(false);
+        rwTasksCompleted.set(false);
+        managedReadCounter.set(0);
+        unmanagedReadCounter.set(0);
+        unmanagedNonInitializingReadCounter.set(0);
+        writeCounter.set(0);
+        deleteCounter.set(0);
+        deleteInitialCounter.set(0);
 
         backupProperties = new BackupProperties();
 
@@ -86,83 +110,83 @@ public class CasStorageServiceImplTest
         sut = new CasStorageServiceImpl(null, null, repositoryProperties, backupProperties);
     }
 
-    @After
-    public void tearDown()
-    {
-        CasStorageSession.get().close();
-    }
-
     @Test
     public void testWriteReadExistsDeleteCas() throws Exception
     {
-        // Setup fixture
-        SourceDocument doc = makeSourceDocument(1l, 1l);
-        JCas templateCas = JCasFactory.createText("This is a test");
-        casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, templateCas.getCas());
-        String user = "test";
+        try (CasStorageSession casStorageSession = openNested(true)) {
+            // Setup fixture
+            SourceDocument doc = makeSourceDocument(1l, 1l, "test");
+            JCas templateCas = JCasFactory.createText("This is a test");
+            casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, templateCas.getCas());
+            String user = "test";
 
-        sut.writeCas(doc, templateCas.getCas(), user);
-        assertThat(sut.getCasFile(doc, user)).exists();
-        assertThat(sut.existsCas(doc, user)).isTrue();
+            sut.writeCas(doc, templateCas.getCas(), user);
+            assertThat(sut.getCasFile(doc, user)).exists();
+            assertThat(sut.existsCas(doc, user)).isTrue();
 
-        // Actual test
-        CAS cas = sut.readCas(doc, user);
-        assertThat(cas.getDocumentText()).isEqualTo(templateCas.getDocumentText());
+            // Actual test
+            CAS cas = sut.readCas(doc, user);
+            assertThat(cas.getDocumentText()).isEqualTo(templateCas.getDocumentText());
 
-        sut.deleteCas(doc, user);
-        assertThat(sut.getCasFile(doc, user)).doesNotExist();
-        assertThat(sut.existsCas(doc, user)).isFalse();
-        assertThat(casStorageSession.contains(cas)).isFalse();
+            sut.deleteCas(doc, user);
+            assertThat(sut.getCasFile(doc, user)).doesNotExist();
+            assertThat(sut.existsCas(doc, user)).isFalse();
+            assertThat(casStorageSession.contains(cas)).isFalse();
+        }
     }
 
     @Test
     public void testCasMetadataGetsCreated() throws Exception
     {
-        List<TypeSystemDescription> typeSystems = new ArrayList<>();
-        typeSystems.add(createTypeSystemDescription());
-        typeSystems.add(CasMetadataUtils.getInternalTypeSystem());
+        try (CasStorageSession casStorageSession = openNested(true)) {
+            List<TypeSystemDescription> typeSystems = new ArrayList<>();
+            typeSystems.add(createTypeSystemDescription());
+            typeSystems.add(CasMetadataUtils.getInternalTypeSystem());
 
-        JCas cas = JCasFactory.createJCas(mergeTypeSystems(typeSystems));
-        casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, cas.getCas());
+            JCas cas = JCasFactory.createJCas(mergeTypeSystems(typeSystems));
+            casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, cas.getCas());
 
-        SourceDocument doc = makeSourceDocument(1l, 1l);
-        String user = "test";
+            SourceDocument doc = makeSourceDocument(2l, 2l, "test");
+            String user = "test";
 
-        sut.writeCas(doc, cas.getCas(), user);
+            sut.writeCas(doc, cas.getCas(), user);
 
-        JCas cas2 = sut.readCas(doc, user).getJCas();
+            JCas cas2 = sut.readCas(doc, user).getJCas();
 
-        List<CASMetadata> cmds = new ArrayList<>(select(cas2, CASMetadata.class));
-        assertThat(cmds).hasSize(1);
-        assertThat(cmds.get(0).getProjectId()).isEqualTo(doc.getProject().getId());
-        assertThat(cmds.get(0).getSourceDocumentId()).isEqualTo(doc.getId());
-        assertThat(cmds.get(0).getLastChangedOnDisk())
-                .isEqualTo(sut.getCasTimestamp(doc, user).get());
+            List<CASMetadata> cmds = new ArrayList<>(select(cas2, CASMetadata.class));
+            assertThat(cmds).hasSize(1);
+            assertThat(cmds.get(0).getProjectId()).isEqualTo(doc.getProject().getId());
+            assertThat(cmds.get(0).getSourceDocumentId()).isEqualTo(doc.getId());
+            assertThat(cmds.get(0).getLastChangedOnDisk())
+                    .isEqualTo(sut.getCasTimestamp(doc, user).get());
+        }
     }
 
     @Test
     public void testReadOrCreateCas() throws Exception
     {
-        // Setup fixture
-        SourceDocument doc = makeSourceDocument(2l, 2l);
-        String user = "test";
-        String text = "This is a test";
-        createCasFile(doc, user, text);
+        try (CasStorageSession casStorageSession = openNested(true)) {
+            // Setup fixture
+            SourceDocument doc = makeSourceDocument(3l, 3l, "test");
+            String user = "test";
+            String text = "This is a test";
+            createCasFile(doc, user, text);
 
-        // Actual test
-        JCas cas = sut.readCas(doc, user).getJCas();
-        assertThat(cas.getDocumentText()).isEqualTo(text);
+            // Actual test
+            JCas cas = sut.readCas(doc, user).getJCas();
+            assertThat(cas.getDocumentText()).isEqualTo(text);
 
-        sut.deleteCas(doc, user);
-        assertThat(sut.getCasFile(doc, user)).doesNotExist();
-        assertThat(sut.existsCas(doc, user)).isFalse();
+            sut.deleteCas(doc, user);
+            assertThat(sut.getCasFile(doc, user)).doesNotExist();
+            assertThat(sut.existsCas(doc, user)).isFalse();
+        }
     }
 
     @Test
     public void testThatLayerChangeEventInvalidatesCachedCas() throws Exception
     {
         // Setup fixture
-        SourceDocument doc = makeSourceDocument(2l, 2l);
+        SourceDocument doc = makeSourceDocument(4l, 4l, "test");
         String user = "test";
         try (CasStorageSession session = openNested(true)) {
             String text = "This is a test";
@@ -203,7 +227,7 @@ public class CasStorageServiceImplTest
     public void testConcurrentAccess() throws Exception
     {
         // Setup fixture
-        SourceDocument doc = makeSourceDocument(2l, 2l);
+        SourceDocument doc = makeSourceDocument(5l, 5l, "test");
         String user = "test";
         File casFile = sut.getCasFile(doc, user);
 
@@ -212,74 +236,415 @@ public class CasStorageServiceImplTest
             assertThat(casFile).exists();
         }
 
-        CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
+        try (CasStorageSession casStorageSession = openNested(true)) {
+            CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
 
-        casFile.setLastModified(casFile.lastModified() + 10_000);
-        long timestamp = casFile.lastModified();
+            casFile.setLastModified(casFile.lastModified() + 10_000);
+            long timestamp = casFile.lastModified();
 
-        assertThatExceptionOfType(IOException.class)
-                .isThrownBy(() -> sut.writeCas(doc, mainCas, user))
-                .withMessageContaining("concurrent modification");
+            assertThatExceptionOfType(IOException.class)
+                    .isThrownBy(() -> sut.writeCas(doc, mainCas, user))
+                    .withMessageContaining("concurrent modification");
 
-        assertThat(casFile).exists();
-        assertThat(casFile.lastModified()).isEqualTo(timestamp);
+            assertThat(casFile).exists();
+            assertThat(casFile.lastModified()).isEqualTo(timestamp);
+        }
     }
 
     @Test
     public void testRestorationOfCasWhenSaveFails() throws Exception
     {
-        // Setup fixture
-        SourceDocument doc = makeSourceDocument(2l, 2l);
-        String user = "test";
-        File casFile = sut.getCasFile(doc, user);
+        try (CasStorageSession casStorageSession = openNested(true)) {
+            // Setup fixture
+            SourceDocument doc = makeSourceDocument(6l, 6l, "test");
+            String user = "test";
+            File casFile = sut.getCasFile(doc, user);
 
-        long casFileSize;
-        long casFileLastModified;
+            long casFileSize;
+            long casFileLastModified;
 
-        try (CasStorageSession session = openNested(true)) {
-            createCasFile(doc, user, "This is a test");
-            assertThat(casFile).exists();
-            casFileSize = casFile.length();
-            casFileLastModified = casFile.lastModified();
+            try (CasStorageSession session = openNested(true)) {
+                createCasFile(doc, user, "This is a test");
+                assertThat(casFile).exists();
+                casFileSize = casFile.length();
+                casFileLastModified = casFile.lastModified();
+            }
+
+            CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
+
+            // Wrap the CAS in a proxy so that UIMA cannot serialize it
+            CAS guardedCas = (CAS) Proxy.newProxyInstance(getClass().getClassLoader(),
+                    new Class[] { CAS.class },
+                    (proxy, method, args) -> method.invoke(mainCas, args));
+
+            assertThatExceptionOfType(IOException.class).as(
+                    "Saving fails because UIMA cannot cast the proxied CAS to something serializable")
+                    .isThrownBy(() -> sut.writeCas(doc, guardedCas, user))
+                    .withRootCauseInstanceOf(ClassCastException.class);
+
+            assertThat(casFile).exists().hasSize(casFileSize);
+            assertThat(casFile.lastModified()).isEqualTo(casFileLastModified);
+            assertThat(new File(casFile.getParentFile(), user + ".ser.old")).doesNotExist();
+        }
+    }
+
+    @Test
+    public void testHighConcurrencyIncludingDeletion() throws Exception
+    {
+        CasProvider initializer = () -> {
+            try {
+                CAS cas = createCas(mergeTypeSystems(
+                        asList(createTypeSystemDescription(), getInternalTypeSystem())));
+                cas.setDocumentText(repeat("This is a test.\n", 100_000));
+                return cas;
+            }
+            catch (ResourceInitializationException e) {
+                throw new IOException(e);
+            }
+        };
+
+        SourceDocument doc = makeSourceDocument(7l, 7l, "doc");
+        String user = "annotator";
+
+        // We interleave all the primary and secondary tasks into the main tasks list
+        // Primary tasks run for a certain number of iterations
+        // Secondary tasks run as long as any primary task is still running
+        List<Thread> tasks = new ArrayList<>();
+        List<Thread> primaryTasks = new ArrayList<>();
+        List<Thread> secondaryTasks = new ArrayList<>();
+
+        int threadGroupCount = 4;
+        int iterations = 50;
+        for (int n = 0; n < threadGroupCount; n++) {
+            Thread rw = new ExclusiveReadWriteTask(n, doc, user, initializer, iterations);
+            primaryTasks.add(rw);
+            tasks.add(rw);
+
+            Thread ro = new SharedReadOnlyTask(n, doc, user, initializer);
+            secondaryTasks.add(ro);
+            tasks.add(ro);
+
+            Thread un = new UnmanagedTask(n, doc, user, initializer);
+            secondaryTasks.add(un);
+            tasks.add(un);
+
+            Thread uni = new UnmanagedNonInitializingTask(n, doc, user);
+            secondaryTasks.add(uni);
+            tasks.add(uni);
+
+            DeleterTask xx = new DeleterTask(n, doc, user);
+            secondaryTasks.add(xx);
+            tasks.add(xx);
         }
 
-        CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
+        log.info("---- Starting all threads ----");
+        tasks.forEach(Thread::start);
 
-        // Wrap the CAS in a proxy so that UIMA cannot serialize it
-        CAS guardedCas = (CAS) Proxy.newProxyInstance(getClass().getClassLoader(),
-                new Class[] { CAS.class }, (proxy, method, args) -> method.invoke(mainCas, args));
+        log.info("---- Wait for primary threads to complete ----");
+        boolean done = false;
+        while (!done) {
+            long running = primaryTasks.stream().filter(Thread::isAlive).count();
+            done = running == 0l;
+            sleep(1000);
+            log.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}  xx {} XX {}", running,
+                    (writeCounter.get() * 100) / (threadGroupCount * iterations), writeCounter,
+                    managedReadCounter, unmanagedReadCounter, unmanagedNonInitializingReadCounter,
+                    deleteCounter, deleteInitialCounter);
+        }
 
-        assertThatExceptionOfType(IOException.class).as(
-                "Saving fails because UIMA cannot cast the proxied CAS to something serializable")
-                .isThrownBy(() -> sut.writeCas(doc, guardedCas, user))
-                .withRootCauseInstanceOf(ClassCastException.class);
+        log.info("---- Wait for threads secondary threads to wrap up ----");
+        rwTasksCompleted.set(true);
+        for (Thread thread : secondaryTasks) {
+            thread.join();
+        }
 
-        assertThat(casFile).exists().hasSize(casFileSize);
-        assertThat(casFile.lastModified()).isEqualTo(casFileLastModified);
-        assertThat(new File(casFile.getParentFile(), user + ".ser.old")).doesNotExist();
+        log.info("---- Test is done ----");
+
+        assertThat(exception).isFalse();
+    }
+
+    @Test
+    public void testHighConcurrencyWithoutDeletion() throws Exception
+    {
+        CasProvider initializer = () -> {
+            try {
+                CAS cas = createCas(mergeTypeSystems(
+                        asList(createTypeSystemDescription(), getInternalTypeSystem())));
+                cas.setDocumentText(repeat("This is a test.\n", 100_000));
+                return cas;
+            }
+            catch (ResourceInitializationException e) {
+                throw new IOException(e);
+            }
+        };
+
+        CasProvider badSeed = () -> {
+            throw new IOException("This initializer should never be called!");
+        };
+
+        SourceDocument doc = makeSourceDocument(8l, 8l, "doc");
+        String user = "annotator";
+        try (CasStorageSession session = openNested()) {
+            // Make sure the CAS exists so that the threads should never be forced to call the
+            // the initializer
+            sut.readOrCreateCas(doc, user, FORCE_CAS_UPGRADE, initializer, EXCLUSIVE_WRITE_ACCESS);
+        }
+
+        // We interleave all the primary and secondary tasks into the main tasks list
+        // Primary tasks run for a certain number of iterations
+        // Secondary tasks run as long as any primary task is still running
+        List<Thread> tasks = new ArrayList<>();
+        List<Thread> primaryTasks = new ArrayList<>();
+        List<Thread> secondaryTasks = new ArrayList<>();
+
+        int threadGroupCount = 4;
+        int iterations = 50;
+        for (int n = 0; n < threadGroupCount; n++) {
+            ExclusiveReadWriteTask rw = new ExclusiveReadWriteTask(n, doc, user, badSeed,
+                    iterations);
+            primaryTasks.add(rw);
+            tasks.add(rw);
+
+            Thread ro = new SharedReadOnlyTask(n, doc, user, badSeed);
+            secondaryTasks.add(ro);
+            tasks.add(ro);
+
+            Thread un = new UnmanagedTask(n, doc, user, badSeed);
+            secondaryTasks.add(un);
+            tasks.add(un);
+
+            Thread uni = new UnmanagedNonInitializingTask(n, doc, user);
+            secondaryTasks.add(uni);
+            tasks.add(uni);
+        }
+
+        log.info("---- Starting all threads ----");
+        tasks.forEach(Thread::start);
+
+        log.info("---- Wait for primary threads to complete ----");
+        boolean done = false;
+        while (!done) {
+            long running = primaryTasks.stream().filter(Thread::isAlive).count();
+            done = running == 0l;
+            sleep(1000);
+            log.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}", running,
+                    (writeCounter.get() * 100) / (threadGroupCount * iterations), writeCounter,
+                    managedReadCounter, unmanagedReadCounter, unmanagedNonInitializingReadCounter);
+        }
+
+        log.info("---- Wait for threads secondary threads to wrap up ----");
+        rwTasksCompleted.set(true);
+        for (Thread thread : secondaryTasks) {
+            thread.join();
+        }
+
+        log.info("---- Test is done ----");
+
+        assertThat(exception).isFalse();
+    }
+
+    private class ExclusiveReadWriteTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+        private int repeat;
+        private CasProvider initializer;
+
+        public ExclusiveReadWriteTask(int n, SourceDocument aDoc, String aUser,
+                CasProvider aInitializer, int aRepeat)
+        {
+            super("RW" + n);
+            doc = aDoc;
+            user = aUser;
+            repeat = aRepeat;
+            initializer = aInitializer;
+        }
+
+        @Override
+        public void run()
+        {
+            for (int n = 0; n < repeat; n++) {
+                if (exception.get()) {
+                    return;
+                }
+
+                try (CasStorageSession session = openNested()) {
+                    CAS cas = sut.readOrCreateCas(doc, user, FORCE_CAS_UPGRADE, initializer,
+                            EXCLUSIVE_WRITE_ACCESS);
+                    Thread.sleep(50);
+                    sut.writeCas(doc, cas, user);
+                    writeCounter.incrementAndGet();
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private class SharedReadOnlyTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+        private CasProvider initializer;
+
+        public SharedReadOnlyTask(int n, SourceDocument aDoc, String aUser,
+                CasProvider aInitializer)
+        {
+            super("RO" + n);
+            doc = aDoc;
+            user = aUser;
+            initializer = aInitializer;
+        }
+
+        @Override
+        public void run()
+        {
+            while (!(exception.get() || rwTasksCompleted.get())) {
+                try (CasStorageSession session = openNested()) {
+                    sut.readOrCreateCas(doc, user, AUTO_CAS_UPGRADE, initializer,
+                            SHARED_READ_ONLY_ACCESS);
+                    managedReadCounter.incrementAndGet();
+                    Thread.sleep(50);
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private class DeleterTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+        private Random rnd;
+
+        public DeleterTask(int n, SourceDocument aDoc, String aUser)
+        {
+            super("XX" + n);
+            doc = aDoc;
+            user = aUser;
+            rnd = new Random();
+        }
+
+        @Override
+        public void run()
+        {
+            while (!(exception.get() || rwTasksCompleted.get())) {
+                try (CasStorageSession session = openNested()) {
+                    Thread.sleep(2500 + rnd.nextInt(2500));
+                    if (rnd.nextInt(100) >= 75) {
+                        sut.deleteCas(doc, INITIAL_CAS_PSEUDO_USER);
+                        deleteInitialCounter.incrementAndGet();
+                    }
+                    sut.deleteCas(doc, user);
+                    deleteCounter.incrementAndGet();
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private class UnmanagedTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+        private CasProvider initializer;
+
+        public UnmanagedTask(int n, SourceDocument aDoc, String aUser, CasProvider aInitializer)
+        {
+            super("UN" + n);
+            doc = aDoc;
+            user = aUser;
+            initializer = aInitializer;
+        }
+
+        @Override
+        public void run()
+        {
+            while (!(exception.get() || rwTasksCompleted.get())) {
+                try (CasStorageSession session = openNested()) {
+                    sut.readOrCreateCas(doc, user, AUTO_CAS_UPGRADE, initializer, UNMANAGED_ACCESS);
+                    unmanagedReadCounter.incrementAndGet();
+                    Thread.sleep(50);
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private class UnmanagedNonInitializingTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+
+        public UnmanagedNonInitializingTask(int n, SourceDocument aDoc, String aUser)
+        {
+            super("U_" + n);
+            doc = aDoc;
+            user = aUser;
+        }
+
+        @Override
+        public void run()
+        {
+            while (!(exception.get() || rwTasksCompleted.get())) {
+                try (CasStorageSession session = openNested()) {
+                    sut.readCas(doc, user, UNMANAGED_NON_INITIALIZING_ACCESS);
+                    unmanagedNonInitializingReadCounter.incrementAndGet();
+                    Thread.sleep(50);
+                }
+                catch (FileNotFoundException e) {
+                    // We ignore the FileNotFoundException, this could be hapening if the deleter
+                    // has just kicked in and would be perfectly normal
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private CAS makeCas(String aText) throws IOException
+    {
+        try {
+            CAS cas = CasFactory.createCas(mergeTypeSystems(
+                    asList(createTypeSystemDescription(), getInternalTypeSystem())));
+            cas.setDocumentText(aText);
+            return cas;
+        }
+        catch (Exception e) {
+            throw new IOException(e);
+        }
     }
 
     private JCas createCasFile(SourceDocument doc, String user, String text)
         throws CASException, CasSessionException, IOException
     {
-        JCas casTemplate = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> {
-            try {
-                CAS cas = CasFactory.createCas(mergeTypeSystems(
-                        asList(createTypeSystemDescription(), getInternalTypeSystem())));
-                cas.setDocumentText(text);
-                return cas;
-            }
-            catch (UIMAException e) {
-                throw new IOException(e);
-            }
-        }, EXCLUSIVE_WRITE_ACCESS).getJCas();
+        JCas casTemplate = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> makeCas(text),
+                EXCLUSIVE_WRITE_ACCESS).getJCas();
         assertThat(sut.getCasFile(doc, user)).exists();
         assertThat(sut.existsCas(doc, user)).isTrue();
 
         return casTemplate;
     }
 
-    private SourceDocument makeSourceDocument(long aProjectId, long aDocumentId)
+    private SourceDocument makeSourceDocument(long aProjectId, long aDocumentId, String aDocName)
     {
         Project project = new Project();
         project.setId(aProjectId);
@@ -287,40 +652,8 @@ public class CasStorageServiceImplTest
         SourceDocument doc = new SourceDocument();
         doc.setProject(project);
         doc.setId(aDocumentId);
+        doc.setName(aDocName);
 
         return doc;
-    }
-
-    private CAS cloneCas(CAS aCas) throws ResourceInitializationException, IOException
-    {
-        byte[] buffer;
-        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            CasIOUtils.save(aCas, os, SerialFormat.SERIALIZED_TSI);
-            buffer = os.toByteArray();
-        }
-
-        CAS clonedCas = CasCreationUtils.createCas((TypeSystemDescription) null, null, null, null);
-        try (ByteArrayInputStream is = new ByteArrayInputStream(buffer)) {
-            CasIOUtils.load(is, clonedCas);
-        }
-
-        return clonedCas;
-    }
-
-    private static class ThreadLockingInvocationHandler
-        implements InvocationHandler
-    {
-        private Object target;
-
-        public ThreadLockingInvocationHandler(Object aTarget)
-        {
-            target = aTarget;
-        }
-
-        @Override
-        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
-        {
-            return method.invoke(target, args);
-        }
     }
 }

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -31,7 +31,6 @@ import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTyp
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -44,7 +43,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.CasFactory;
@@ -55,7 +53,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,8 +98,6 @@ public class DocumentServiceImplTest
     @Before
     public void setup() throws Exception
     {
-        Mockito.lenient();
-
         exception.set(false);
         rwTasksCompleted.set(false);
         managedReadCounter.set(0);
@@ -152,7 +147,6 @@ public class DocumentServiceImplTest
         try (CasStorageSession session = CasStorageSession.open()) {
             SourceDocument sourceDocument = makeSourceDocument(1l, 1l, "test");
             User user = makeUser();
-            when(entityManager.createQuery(anyString(), any())).thenThrow(NoResultException.class);
 
             JCas cas = sut.readAnnotationCas(sourceDocument, user.getUsername()).getJCas();
 

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -17,25 +17,42 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.dao;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils.getInternalTypeSystem;
+import static de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession.openNested;
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 
-import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.jcas.JCas;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
@@ -43,34 +60,38 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
+@RunWith(MockitoJUnitRunner.class)
 public class DocumentServiceImplTest
 {
-    private DocumentService sut;
+    private Logger log = LoggerFactory.getLogger(getClass());
 
     private @Mock ImportExportService importExportService;
     private @Mock ProjectService projectService;
     private @Mock ApplicationEventPublisher applicationEventPublisher;
     private @Mock EntityManager entityManager;
 
+    public @Rule TemporaryFolder testFolder = new TemporaryFolder();
+
+    private AtomicBoolean exception = new AtomicBoolean(false);
+    private AtomicBoolean rwTasksCompleted = new AtomicBoolean(false);
+
+    private DocumentService sut;
+
     private BackupProperties backupProperties;
     private RepositoryProperties repositoryProperties;
     private CasStorageService storageService;
 
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
-
     @Before
     public void setup() throws Exception
     {
-        initMocks(this);
-
-        CasStorageSession.open();
+        exception.set(false);
+        rwTasksCompleted.set(false);
 
         backupProperties = new BackupProperties();
 
@@ -80,45 +101,151 @@ public class DocumentServiceImplTest
         storageService = new CasStorageServiceImpl(null, null, repositoryProperties,
                 backupProperties);
 
-        sut = new DocumentServiceImpl(repositoryProperties, storageService, importExportService,
-                projectService, applicationEventPublisher, entityManager);
+        sut = spy(new DocumentServiceImpl(repositoryProperties, storageService, importExportService,
+                projectService, applicationEventPublisher, entityManager));
+
+        doAnswer(_invocation -> {
+            SourceDocument doc = _invocation.getArgument(0, SourceDocument.class);
+            String user = _invocation.getArgument(1, String.class);
+            return new AnnotationDocument(doc.getName(), doc.getProject(), user, doc);
+        }).when(sut).getAnnotationDocument(any(), any(String.class));
 
         when(importExportService.importCasFromFile(any(File.class), any(Project.class), any(),
-                any())).thenReturn(JCasFactory.createText("Test").getCas());
-    }
-
-    @After
-    public void tearDown()
-    {
-        CasStorageSession.get().close();
+                any())).then(_invocation -> {
+                    CAS cas = CasFactory.createCas(mergeTypeSystems(
+                            asList(createTypeSystemDescription(), getInternalTypeSystem())));
+                    cas.setDocumentText(StringUtils.repeat("This is a test.\n", 100_000));
+                    return cas;
+                });
     }
 
     @Test
     public void thatCreatingOrReadingInitialCasForNewDocumentCreatesNewCas() throws Exception
     {
+        try (CasStorageSession session = CasStorageSession.open()) {
+            SourceDocument doc = makeSourceDocument(1l, 1l, "test");
 
-        SourceDocument doc = makeSourceDocument(1l, 1l, "test");
+            JCas cas = sut.createOrReadInitialCas(doc).getJCas();
 
-        JCas cas = sut.createOrReadInitialCas(doc).getJCas();
-
-        assertThat(cas).isNotNull();
-        assertThat(cas.getDocumentText()).isEqualTo("Test");
-        assertThat(storageService.getCasFile(doc, WebAnnoConst.INITIAL_CAS_PSEUDO_USER)).exists();
+            assertThat(cas).isNotNull();
+            assertThat(cas.getDocumentText()).isEqualTo("Test");
+            assertThat(storageService.getCasFile(doc, INITIAL_CAS_PSEUDO_USER)).exists();
+        }
     }
 
     @Test
     public void thatReadingNonExistentAnnotationCasCreatesNewCas() throws Exception
     {
-        SourceDocument sourceDocument = makeSourceDocument(1l, 1l, "test");
-        User user = makeUser();
-        when(entityManager.createQuery(anyString(), any())).thenThrow(NoResultException.class);
+        try (CasStorageSession session = CasStorageSession.open()) {
+            SourceDocument sourceDocument = makeSourceDocument(1l, 1l, "test");
+            User user = makeUser();
+            when(entityManager.createQuery(anyString(), any())).thenThrow(NoResultException.class);
 
-        JCas cas = sut.readAnnotationCas(sourceDocument, user.getUsername()).getJCas();
+            JCas cas = sut.readAnnotationCas(sourceDocument, user.getUsername()).getJCas();
 
-        assertThat(cas).isNotNull();
-        assertThat(cas.getDocumentText()).isEqualTo("Test");
-        assertThat(storageService.getCasFile(sourceDocument, user.getUsername())).exists();
+            assertThat(cas).isNotNull();
+            assertThat(cas.getDocumentText()).isEqualTo("Test");
+            assertThat(storageService.getCasFile(sourceDocument, user.getUsername())).exists();
+        }
     }
+
+    @Test
+    public void testHighConcurrency() throws Exception
+    {
+        SourceDocument doc = makeSourceDocument(2l, 2l, "doc");
+        String user = "annotator";
+
+        List<Thread> tasks = new ArrayList<>();
+        List<Thread> rwTasks = new ArrayList<>();
+        List<Thread> roTasks = new ArrayList<>();
+        for (int n = 0; n < 10; n++) {
+            Thread rw = new ReadWriteTask(n, doc, user);
+            rwTasks.add(rw);
+            tasks.add(rw);
+
+            Thread ro = new ReadOnlyTask(n, doc, user);
+            roTasks.add(ro);
+            tasks.add(ro);
+        }
+
+        log.info("---- Start threads ----");
+        tasks.forEach(Thread::start);
+
+        log.info("---- Wait for threads to complete ----");
+        for (Thread thread : rwTasks) {
+            thread.join();
+        }
+
+        rwTasksCompleted.set(true);
+        for (Thread thread : roTasks) {
+            thread.join();
+        }
+
+        assertThat(exception).isFalse();
+    }
+
+    private class ReadWriteTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+
+        public ReadWriteTask(int n, SourceDocument aDoc, String aUser)
+        {
+            super("RW" + n);
+            doc = aDoc;
+            user = aUser;
+        }
+
+        @Override
+        public void run()
+        {
+            for (int n = 0; n < 1000; n++) {
+                if (exception.get()) {
+                    return;
+                }
+
+                try (CasStorageSession session = openNested()) {
+                    CAS cas = sut.readAnnotationCas(doc, user);
+                    Thread.sleep(50);
+                    sut.writeAnnotationCas(cas, doc, user, false);
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
+
+    private class ReadOnlyTask
+        extends Thread
+    {
+        private SourceDocument doc;
+        private String user;
+
+        public ReadOnlyTask(int n, SourceDocument aDoc, String aUser)
+        {
+            super("RO" + n);
+            doc = aDoc;
+            user = aUser;
+        }
+
+        @Override
+        public void run()
+        {
+            while (!(exception.get() || rwTasksCompleted.get())) {
+                try (CasStorageSession session = openNested()) {
+                    sut.readAnnotationCas(doc, user, AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
+                    Thread.sleep(50);
+                }
+                catch (Exception e) {
+                    exception.set(true);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    };
 
     private SourceDocument makeSourceDocument(long aProjectId, long aDocumentId, String aDocName)
     {

--- a/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/webanno-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +101,8 @@ public class DocumentServiceImplTest
     @Before
     public void setup() throws Exception
     {
+        Mockito.lenient();
+
         exception.set(false);
         rwTasksCompleted.set(false);
         managedReadCounter.set(0);

--- a/webanno-api-dao/src/test/resources/log4j2.xml
+++ b/webanno-api-dao/src/test/resources/log4j2.xml
@@ -2,13 +2,16 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="ConsoleAppender" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%thread] %level{length=5} %logger{1} - %msg%n" />
+      <PatternLayout pattern="%d{HH:mm:ss} %level{length=5} %25logger{1}:%-4L - [%thread] %msg%n" />
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="DEBUG"/>
+    <Logger name="de.tudarmstadt" level="INFO"/>
+    <!--
+    <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/>
 		<logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/>
 		<Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/>
+		-->
     <Root level="warn">
       <AppenderRef ref="ConsoleAppender" />
     </Root>

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -369,6 +369,8 @@ public interface DocumentService
 
     void deleteAnnotationCas(AnnotationDocument annotationDocument) throws IOException;
 
+    void deleteAnnotationCas(SourceDocument aSourceDocument, String aUsername) throws IOException;
+
     /**
      * Gets the CAS for the given source document. Converts it form the source document if
      * necessary. The state of the source document is not changed.

--- a/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/webanno-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -238,6 +238,10 @@ public interface DocumentService
     void writeAnnotationCas(CAS aCas, SourceDocument document, User user, boolean aUpdateTimestamp)
         throws IOException;
 
+    void writeAnnotationCas(CAS aCas, SourceDocument document, String user,
+            boolean aUpdateTimestamp)
+        throws IOException;
+
     /**
      * Resets the annotation document to its initial state by overwriting it with the initial CAS.
      *


### PR DESCRIPTION
**What's in the PR**
* Ensure exclusive access even for read-only and unmanaged accesses for the moment that the access and potentially an entailing initialization of the CAS from the initial CAS is perfomed.

**How to test manually**
* No specific manual test procedure. Automatic test included.

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
