### PR TITLE
Unexpected duplicate selector

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/shim-kendo.scss
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/shim-kendo.scss
@@ -34,15 +34,13 @@
 	.k-dropdown-wrap {
 		border: 0px;
 	}
-}
-
 // Make sure Kendo icons show in input groups where the input groups are rendered with a 
 // z-index of 2
-.input-group {
 	.k-icon {
 		z-index: 3;
 	}
 }
+
 
 // Make Kendo components render with full width inside form groups
 /*


### PR DESCRIPTION
What's the issue?
Unexpected duplicate selector "input-group", first appeared in line 33.

Why is this issue relevant?
Duplication of code can indicate a copy-paste mistake which can make the code lengthy, increase the time of execution, decrease the quality of code. Here, input-group has already appeared in line 33 for making kendo dropdowns to fit into input groups and it is again used for Making  sure Kendo icons are shown in input groups where the input groups are rendered with a
 z-index of 2.

How can we resolve this issue?
Instead of using a duplicate selector "input-group" for kendo icons shown in input groups, we can directly put them into one selector which has been already used previously which in turn reduces the readability issues and can increase the quality of code. 


