### PR TITLE
Reset/Recreate default admin account

### DIFF
--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -101,14 +101,29 @@ public class LoginPage
         // Create admin user if there is no user yet
         if (userRepository.list().isEmpty()) {
             User admin = new User();
-            admin.setUsername(ADMIN_DEFAULT_USERNAME);
-            admin.setPassword(ADMIN_DEFAULT_PASSWORD);
+            //Checking for any env variable with the "WEBANNO_ENV_ADMIN_NAME" name, this variable is used for setting username.
+            //If the variable does not exist the default name "admin" is set.
+            if(System.getenv("WEBANNO_ENV_ADMIN_NAME")!=null){
+                admin.setUsername(System.getenv("WEBANNO_ENV_ADMIN_NAME"));
+            }
+            else {
+                admin.setUsername(ADMIN_DEFAULT_USERNAME);
+            }
+            //Checking for any env variable with the "WEBANNO_ENV_ADMIN_PASS" name, this variable is used for setting password
+            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null){
+                admin.setPassword(System.getenv("WEBANNO_ENV_ADMIN_PASS"));
+            }else{
+                admin.setPassword(ADMIN_DEFAULT_PASSWORD);
+            }
             admin.setEnabled(true);
             admin.setRoles(EnumSet.of(Role.ROLE_ADMIN, Role.ROLE_USER));
             userRepository.create(admin);
-
             String msg = "No user accounts have been found. An admin account has been created: "
                     + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
+            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null&&System.getenv("WEBANNO_ENV_ADMIN_NAME") != null){
+                msg = "No user accounts have been found. An admin account has been created: "
+                        +  System.getenv("WEBANNO_ENV_ADMIN_NAME") + "/" + System.getenv("WEBANNO_ENV_ADMIN_PASS");
+            }
             // We log this as a warning so the message sticks on the screen. Success and info
             // messages are set to auto-close after a short time.
             warn(msg);

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -119,13 +119,15 @@ public class LoginPage
             admin.setEnabled(true);
             admin.setRoles(EnumSet.of(Role.ROLE_ADMIN, Role.ROLE_USER));
             userRepository.create(admin);
+            String admn=System.getenv("WEBANNO_ENV_ADMIN_NAME");
+            String pwd=System.getenv("WEBANNO_ENV_ADMIN_PASS");
             String msg = "No user accounts have been found. An admin account has been created: "
                     + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
-            if (System.getenv("WEBANNO_ENV_ADMIN_PASS") != null &&
-                    System.getenv("WEBANNO_ENV_ADMIN_NAME") != null) {
+            if (pwd != null &&
+                    admn != null) {
                 msg = "No user accounts have been found. An admin account has been created: "
-                        +  System.getenv("WEBANNO_ENV_ADMIN_NAME") +
-                        "/" + System.getenv("WEBANNO_ENV_ADMIN_PASS");
+                        +  admn +
+                        "/" + pwd;
             }
             // We log this as a warning so the message sticks on the screen. Success and info
             // messages are set to auto-close after a short time.

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -103,16 +103,17 @@ public class LoginPage
             User admin = new User();
             //Checking for any env variable with the "WEBANNO_ENV_ADMIN_NAME" name, this variable is used for setting username.
             //If the variable does not exist the default name "admin" is set.
-            if(System.getenv("WEBANNO_ENV_ADMIN_NAME")!=null){
+            if (System.getenv("WEBANNO_ENV_ADMIN_NAME") != null) {
                 admin.setUsername(System.getenv("WEBANNO_ENV_ADMIN_NAME"));
             }
             else {
                 admin.setUsername(ADMIN_DEFAULT_USERNAME);
             }
             //Checking for any env variable with the "WEBANNO_ENV_ADMIN_PASS" name, this variable is used for setting password
-            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null){
+            if (System.getenv("WEBANNO_ENV_ADMIN_PASS") != null) {
                 admin.setPassword(System.getenv("WEBANNO_ENV_ADMIN_PASS"));
-            }else{
+            }
+            else {
                 admin.setPassword(ADMIN_DEFAULT_PASSWORD);
             }
             admin.setEnabled(true);
@@ -120,9 +121,11 @@ public class LoginPage
             userRepository.create(admin);
             String msg = "No user accounts have been found. An admin account has been created: "
                     + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
-            if(System.getenv("WEBANNO_ENV_ADMIN_PASS") != null&&System.getenv("WEBANNO_ENV_ADMIN_NAME") != null){
+            if (System.getenv("WEBANNO_ENV_ADMIN_PASS") != null &&
+                    System.getenv("WEBANNO_ENV_ADMIN_NAME") != null) {
                 msg = "No user accounts have been found. An admin account has been created: "
-                        +  System.getenv("WEBANNO_ENV_ADMIN_NAME") + "/" + System.getenv("WEBANNO_ENV_ADMIN_PASS");
+                        +  System.getenv("WEBANNO_ENV_ADMIN_NAME") +
+                        "/" + System.getenv("WEBANNO_ENV_ADMIN_PASS");
             }
             // We log this as a warning so the message sticks on the screen. Success and info
             // messages are set to auto-close after a short time.


### PR DESCRIPTION
Reset/ Recreate the default admin account.
The current version of webanno software creates a default admin account when there are no users account found. When the software runs for the first time, there will not be any user accounts, Hence to allow the user to access the software, webanno creates a default admin account with the username as admin and password as admin. We have to provide the liberty to the user to create his default admin account. 
To allow the user to create his default admin account, we provide two environment variables. One of the environment variables contains the default username and the other default password(WEBANNO_ENV_ADMIN_NAME, WEBANNO_ENV_ADMIN_PASS). If these variables are present, then these values are considered to create the default admin account. If the values are not present, the default admin account is created with username as "admin" and password as "admin".
