### PR TITLE
Non-public methods should not be "@Transactional"

### DIFF
--- a/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/webanno-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -358,7 +358,7 @@ public class DocumentServiceImpl
     }
 
     @Transactional
-    private SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
+    public SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
             SourceDocumentState aState)
     {
         Validate.notNull(aDocument, "Source document must be specified");


### PR DESCRIPTION
If we need to use @Transactional the  method must be non-public. Rather than, it will be useless and misleading due to the Spring doesn’t see non-public methods. In addition, it makes no provision for their proper invocation