### PR TITLE
Annotation Detail pannel placement

### DIFF
--- a/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer_ui.js
+++ b/webanno-brat/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/visualizer_ui.js
@@ -292,6 +292,19 @@ var VisualizerUI = (function($, window, undefined) {
                     if (y < 0) y = 0;
                     if (x < 0) x = 0;
         			element.css({ top: y, left: x });
+                    if (y > 210 && y < 270) {
+                        y=y-80;
+                    }
+                if (y > 270 && y < 300) {
+                     y=y-160;
+                }
+                else if ( y > 300 && y < 360) {
+                      y=y-200;
+                }
+                else if ( y > 360) {
+                       y=y-200;
+                }
+                $('.annotationpannel').css({ top: y, left: x });
                 };
 
             var commentPopup = $('#commentpopup');
@@ -324,7 +337,7 @@ var VisualizerUI = (function($, window, undefined) {
 /*
                         commentPopup.stop(true, true).fadeIn(0);
 */
-                        commentPopup.show();
+                       // commentPopup.show();
 // END WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance
                         commentDisplayed = true;
                     }, immediately ? 0 : 500);
@@ -345,7 +358,7 @@ var VisualizerUI = (function($, window, undefined) {
             var displaySpanComment = function(
                 evt, target, spanId, spanType, mods, spanText, hoverText, commentText, commentType, normalizations) {
 // WEBANNO EXTENSION END - #587 Customize mouse hover text
-
+                    $('.annotationpannel').css( 'display' ,'block' )
                     var immediately = false;
                     var comment = ('<div><span class="comment_type_id_wrapper">' + '<span class="comment_type">' + Util.escapeHTML(Util.spanDisplayForm(spanTypes, spanType)) + '</span>' + ' ' + '<span class="comment_id">' + 'ID:' + Util.escapeHTML(spanId) + '</span></span>');
                     if (mods.length) {
@@ -538,7 +551,7 @@ var VisualizerUI = (function($, window, undefined) {
                         commentPopup.stop(true, true).fadeOut(0, function() {
                             commentDisplayed = false;
                         });
-*/
+*/                      $('.annotationpannel').css( 'display', 'none' )
                         commentPopup.hide();
                         commentDisplayed = false;
 // END WEBANNO EXTENSION - #1610 - Improve brat visualization interaction performance

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.html
@@ -34,10 +34,10 @@
             </div>
           </div>
         </div>
-        <div wicket:id="rightSidebar" class="flex-sidebar flex-v-container">
-          <wicket:container wicket:id="annotationDetailEditorPanel"/>
-        </div>
       </div>
+    </div>
+    <div wicket:id="rightSidebar" class="annotationpannel" >
+      <wicket:container wicket:id="annotationDetailEditorPanel"/>
     </div>
   </wicket:extend>
 </body>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -66,19 +66,20 @@
 </head>
 <body>
   <wicket:panel>
-    <div id="annotationDetailEditorPanel" class="flex-content flex-v-container">
+    <div id="annotationDetailEditorPanel" class="editorpannel">
       <!-- 
         Style the form such that it is actionable by keyboard events but does not take up space
         on the screen.
        -->
-      <form wicket:id="forwardForm" style="width: 1px; height: 1px; overflow: hidden; opacity: 0; margin-top: -1px;">
-        <!-- 
-          The user should never tab into this field accidentally. Focus is set explicitly by the
-          forward annotation mode.
-         -->
-        <input wicket:id=forwardAnno tabindex="-1"></input>
-      </form>
       <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter">
+        <form wicket:id="forwardForm" style="width: 1px; height: 1px; overflow: hidden; opacity: 0; margin-top: -1px;">
+          <!--
+            The user should never tab into this field accidentally. Focus is set explicitly by the
+            forward annotation mode.
+           -->
+          <input wicket:id=forwardAnno tabindex="-1"></input>
+        </form>
+
         <div wicket:id=deleteAnnotationDialog/>
         <div wicket:id=replaceAnnotationDialog/>
         <div wicket:id="layerContainer" class="card"/>
@@ -100,7 +101,7 @@
               </button>
             </div>
           </div>
-          <div class="scrolling card-body flex-v-container">
+          <div class=" card-body flex-v-container">
             <div wicket:id="infoContainer"/>
             <div wicket:id="relationListContainer"/>
             <div wicket:id="featureEditorContainer"/>

--- a/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AttachedAnnotationListPanel.html
+++ b/webanno-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AttachedAnnotationListPanel.html
@@ -3,13 +3,13 @@
   Licensed to the Technische Universität Darmstadt under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
-  regarding copyright ownership.  The Technische Universität Darmstadt 
+  regarding copyright ownership.  The Technische Universität Darmstadt
   licenses this file to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.
-   
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@
           <a wicket:id="jumpToEndpoint" class="float-right"><i class="fas fa-crosshairs"></i></a>
         </label>
         <div class="feature-editor-value">
-          <div wicket:id="endpoint" class="form-control col-sm-12 scrolling"
+          <div wicket:id="endpoint" class="form-control col-sm-12 scrolling annotationtagvalue"
             style="height: unset; max-height: 4.5rem; word-wrap: break-word;" readonly></div>
         </div>
       </div>

--- a/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
+++ b/webanno-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
@@ -441,3 +441,24 @@ div.left-tabpanel div.tab-row a:hover {
   border-bottom-left-radius:  0px;
   border-left: none;
 }
+
+.annotationpannel{
+  display: none;
+  position: absolute;
+}
+.editorpannel{
+  display: flex;
+}
+.layercard{
+  width: fit-content;
+  z-index: 10;
+}
+.layercard label{
+  min-width: min-content;
+}
+.layercard .col-sm-9{
+  max-width: max-content;
+}
+.annotationcard{
+  max-width: fit-content;
+}


### PR DESCRIPTION
Changing the annotation detail placement
The annotation bar is placed in the right corner, and all annotations are present directly above the words. The annotating process would be speed up if the bar was closer to the hover. We can access the annotation easier and fast.
Remove the annotation panel from the right corner of the annotation screen and make the pannel visible whenever the mouse is moved over the annotation. The pannel can be made visible near the annotation. However, the annotation pannel updates only when a double-clicked operation is performed on the annotation. If the mouse is dragged to perform a selection for annotating, the pannel will not be visible to the user, The pannel gets visible when the new annotation is hovered. When the document is opened for the first time, the pannel is empty hence the double click operation must be performed to update the pannel.