### PR TITLE
#1937 - Unable to boot WebAnno 3.6.8 with MySQL DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <mockito.version>2.28.2</mockito.version>
     <assertj.version>3.21.0</assertj.version>
     <tomcat.version>8.5.73</tomcat.version>
-    <mysql-driver.version>8.0.27</mysql-driver.version>
+    <mysql-driver.version>8.0.20</mysql-driver.version>
   </properties>
   <repositories>
     <repository>


### PR DESCRIPTION
**What's in the PR**
- Downgrade to MySQL driver 8.0.20 again due to classcast exception in liquibase

**How to test manually**
* Run with MySQL

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
